### PR TITLE
feat: add Cursor agent tool integration

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		269DD148F3D616460B3E5DE2 /* ScrollSwitchGestureHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905DD9FD69FFEA7991390EA4 /* ScrollSwitchGestureHandler.swift */; };
 		26D68604F3403C3BC9299DEC /* SidebarVisibilityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A34A831CA0E3FE65355578 /* SidebarVisibilityControllerTests.swift */; };
 		28E673F10881B25E277F61A6 /* AgentResumeCommandBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44EC40C277824843955668D /* AgentResumeCommandBuilderTests.swift */; };
+		2BC7421FF9D00CF7851A5E32 /* JSONCRelaxedParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */; };
 		2F54A7D7AD63E93CC841317F /* GlobalSearchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4483B8E7BA05745883A993C0 /* GlobalSearchCoordinatorTests.swift */; };
 		2F66DA8093CA1E0590D3DD0F /* SidebarTextMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880AC8A873636B3675457AAD /* SidebarTextMetrics.swift */; };
 		30B9ACBE47351D6E5EF639C5 /* CommandPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA45568C0DF115CFA41141 /* CommandPalettePanel.swift */; };
@@ -158,6 +159,7 @@
 		96C8DAEB457704BB7D4DEC7D /* PaneAgentReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB869749410CBF86B97FA142 /* PaneAgentReducer.swift */; };
 		979D0127696D756BDA955A55 /* LibghosttyRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F2B610CEE3EE12203D913C /* LibghosttyRuntimeTests.swift */; };
 		98F978A3B1153B5779E303B4 /* AgentStatusShellIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BA6CB9ADE94B1F271FFDE7 /* AgentStatusShellIntegrationTests.swift */; };
+		99451BC2B09FAA072A3B3A88 /* JSONCRelaxedParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */; };
 		996B3F52A55E43059D1727A6 /* SidebarRowDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B308B03F54BFA5F3812B101D /* SidebarRowDiffTests.swift */; };
 		9977740E789BA5C77113EBE4 /* CommandPaletteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A52BCC7DF27C885882E1630 /* CommandPaletteItem.swift */; };
 		9AEA030AF6FDAF94B9D2C2F7 /* ShortcutPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F75411847A448AECDBD466 /* ShortcutPreset.swift */; };
@@ -192,6 +194,7 @@
 		BA9D0265E08E22F14A7E1C8A /* AgentWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5C60D4800BDD040F2D5B12 /* AgentWrapperTests.swift */; };
 		BB5B3519D7A006621A08A991 /* AppUpdateStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BF48FCF3548F4ABF45950F /* AppUpdateStateStore.swift */; };
 		BE30B813EC32158B648F52B1 /* SidebarShimmerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE256725D568E7583890592B /* SidebarShimmerCoordinatorTests.swift */; };
+		BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C01A739643B858C0F3A69C88 /* PaneStripMotionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6261C82AADF1EDAAA09BC9 /* PaneStripMotionController.swift */; };
 		C038C6FB8A7F9335CC3AFB1A /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C5CDA1B0A63C72FE9048F9 /* AboutViewController.swift */; };
 		C1E6E40E7FEAE93149414E37 /* PaneStripStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */; };
@@ -200,6 +203,7 @@
 		C41A9DA1C5F846F4F63F7D95 /* SidebarWorklaneRowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916D215502518D8BAF3C3921 /* SidebarWorklaneRowLayout.swift */; };
 		C4F35E741F4A20FEA6E0B5C4 /* ZenttyCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F4075E849631130D781E1 /* ZenttyCLI.swift */; };
 		C57C067DB3163F1B09E7E72F /* PresentationReducerContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058230B7588E412C374895C9 /* PresentationReducerContext.swift */; };
+		C6FC32D748BD8642629B7321 /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C749B84F3DFA56E1241551D1 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A00B46795D7A242D2C9107 /* SettingsWindowController.swift */; };
 		C7E03A7F4908AC8B2713A19B /* SidebarVisibilityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163D5C0FE862CC71E8B354E2 /* SidebarVisibilityController.swift */; };
 		C81F06F705D6F4A67A3DAE8F /* WorklaneSidebarSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A594231C8131296490BB8E76 /* WorklaneSidebarSummaryBuilder.swift */; };
@@ -327,6 +331,7 @@
 		20951EA69B03694C17C61738 /* LibghosttySurfaceActionCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySurfaceActionCoalescerTests.swift; sourceTree = "<group>"; };
 		233D493A53D80ADC3053E6D3 /* LicensesWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesWindowControllerTests.swift; sourceTree = "<group>"; };
 		239D19C1C465BA5197EBC394 /* WorklaneHeaderSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneHeaderSummaryBuilder.swift; sourceTree = "<group>"; };
+		24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCRelaxedParse.swift; sourceTree = "<group>"; };
 		24F2B610CEE3EE12203D913C /* LibghosttyRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyRuntimeTests.swift; sourceTree = "<group>"; };
 		25A34A831CA0E3FE65355578 /* SidebarVisibilityControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityControllerTests.swift; sourceTree = "<group>"; };
 		25C38CE6BD2D5F5D24B1B7FE /* AppConfigTOML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTOML.swift; sourceTree = "<group>"; };
@@ -516,6 +521,7 @@
 		D25EF5AC625776DA85911237 /* TrackpadPanGestureDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadPanGestureDriver.swift; sourceTree = "<group>"; };
 		D28121A25243C98C3BFB947A /* CommandAvailabilityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAvailabilityResolverTests.swift; sourceTree = "<group>"; };
 		D2D282138FCDC94B5D876B4D /* WorklaneGitContextResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneGitContextResolverTests.swift; sourceTree = "<group>"; };
+		D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorHooksInstaller.swift; sourceTree = "<group>"; };
 		D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeThemeSync.swift; sourceTree = "<group>"; };
 		D649A4BADA61361091434B5E /* GhosttyThemeLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyThemeLibraryTests.swift; sourceTree = "<group>"; };
 		D9B72357CA80C59A161F7BE2 /* WorklaneAttentionChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionChipView.swift; sourceTree = "<group>"; };
@@ -793,6 +799,8 @@
 				10C70E68528914C7BDC3B755 /* AgentStatusHelper.swift */,
 				B79972CCAB3361277D4E949C /* AgentStatusPayload.swift */,
 				C344F4EE24498B605D2794B3 /* ClaudeHookSessionStore.swift */,
+				D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */,
+				24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */,
 				898B152AC508F23715DB2518 /* OpenCodeLiveThemeSync.swift */,
 				14B5D7C3DB0445971F90C314 /* OpenCodeOverlayLayout.swift */,
 				D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */,
@@ -1315,7 +1323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/gemini/gemini\" -o -path \"*/opencode/opencode\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
+			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/gemini/gemini\" -o -path \"*/opencode/opencode\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
 		};
 		C7055FCE2E5119172F74E931 /* Verify GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1462,6 +1470,7 @@
 				F41BF0F2213D63594DF10864 /* CommandPaletteView.swift in Sources */,
 				FA751D5D7BCE3C7048198953 /* CopilotOSCProgressReducer.swift in Sources */,
 				4CCDF0D69B99D52B07074B08 /* CopilotTitleNeedsInputReducer.swift in Sources */,
+				C6FC32D748BD8642629B7321 /* CursorHooksInstaller.swift in Sources */,
 				DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */,
 				257E380BBDC29CDFE3389A48 /* ExplicitAgentStateReducer.swift in Sources */,
 				260AB2147508C0997EDC89BC /* FallbackTitleHeuristicReducer.swift in Sources */,
@@ -1473,6 +1482,7 @@
 				E35D333286219155A79F8E92 /* GhosttyThemeResolver.swift in Sources */,
 				A92728F291D5458A677DDD7B /* GlassSurfaceView.swift in Sources */,
 				A6A1F413A649AAE4E833DE30 /* GlobalSearchCoordinator.swift in Sources */,
+				2BC7421FF9D00CF7851A5E32 /* JSONCRelaxedParse.swift in Sources */,
 				F33474EA4FEC1975F4FB4754 /* KeyboardShortcut.swift in Sources */,
 				DE22542885A2BE164FE9090E /* KeyboardShortcutPreview.swift in Sources */,
 				066389EC522A58949B0D4A67 /* KeyboardShortcutPreviewView.swift in Sources */,
@@ -1621,6 +1631,8 @@
 				2646F473E8AB7B0F855F6857 /* AgentIPCClient.swift in Sources */,
 				880EF4CC0E61299FC43869BC /* AgentIPCProtocol.swift in Sources */,
 				F5A26C1A6A89ED60FFF6F341 /* AgentToolLauncher.swift in Sources */,
+				BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */,
+				99451BC2B09FAA072A3B3A88 /* JSONCRelaxedParse.swift in Sources */,
 				C4F35E741F4A20FEA6E0B5C4 /* ZenttyCLI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Zentty/AppState/Agent/AgentEventAdapters.swift
+++ b/Zentty/AppState/Agent/AgentEventAdapters.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let cursorAdapterLogger = Logger(subsystem: "be.zenjoy.zentty", category: "CursorAdapter")
 
 // MARK: - Gemini Adapter
 
@@ -123,6 +126,144 @@ extension AgentEventBridge {
         case (nil, nil):
             return nil
         }
+    }
+}
+
+// MARK: - Cursor Adapter
+
+extension AgentEventBridge {
+    static func cursorAdapter(
+        data: Data,
+        environment: [String: String]
+    ) throws -> [AgentStatusPayload] {
+        let jsonObject = data.isEmpty ? [:] : (try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:])
+        guard let hookEventName = firstString(in: jsonObject, keys: ["hook_event_name", "hookEventName"]) else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+
+        guard currentTargetIfAvailable(from: environment) != nil else {
+            return []
+        }
+
+        let target = try currentTarget(from: environment)
+        let toolName = AgentTool.cursor.displayName
+        let sessionID = firstString(in: jsonObject, keys: ["conversation_id", "conversationId"])
+        let cwd = cursorWorkspaceRoot(from: jsonObject)
+        let pid = parseAgentPID(from: environment, key: "ZENTTY_CURSOR_PID")
+
+        let normalized = hookEventName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        switch normalized {
+        case "sessionstart":
+            var payloads: [AgentStatusPayload] = []
+            if let pid {
+                payloads.append(pidPayload(target: target, toolName: toolName, pid: pid, event: .attach, sessionID: sessionID))
+            }
+            payloads.append(lifecyclePayload(
+                target: target,
+                toolName: toolName,
+                state: .starting,
+                sessionID: sessionID,
+                cwd: cwd
+            ))
+            return payloads
+
+        case "beforesubmitprompt":
+            return [lifecyclePayload(
+                target: target,
+                toolName: toolName,
+                state: .running,
+                sessionID: sessionID,
+                cwd: cwd
+            )]
+
+        case "sessionend":
+            return [
+                AgentStatusPayload(
+                    windowID: target.windowID,
+                    worklaneID: target.worklaneID,
+                    paneID: target.paneID,
+                    signalKind: .lifecycle,
+                    state: nil,
+                    origin: .explicitHook,
+                    toolName: toolName,
+                    text: nil,
+                    sessionID: sessionID,
+                    artifactKind: nil,
+                    artifactLabel: nil,
+                    artifactURL: nil
+                ),
+                pidPayload(target: target, toolName: toolName, pid: nil, event: .clear, sessionID: sessionID),
+            ]
+
+        case "stop":
+            let status = firstString(in: jsonObject, keys: ["status"])?.lowercased()
+            switch status {
+            case "error":
+                return [lifecyclePayload(
+                    target: target,
+                    toolName: toolName,
+                    state: .unresolvedStop,
+                    lifecycleEvent: .update,
+                    sessionID: sessionID,
+                    cwd: cwd
+                )]
+            case "aborted":
+                return [lifecyclePayload(
+                    target: target,
+                    toolName: toolName,
+                    state: .idle,
+                    lifecycleEvent: .stopCandidate,
+                    sessionID: sessionID,
+                    cwd: cwd
+                )]
+            case "completed", nil:
+                return [lifecyclePayload(
+                    target: target,
+                    toolName: toolName,
+                    state: .idle,
+                    lifecycleEvent: .update,
+                    sessionID: sessionID,
+                    cwd: cwd
+                )]
+            default:
+                return [lifecyclePayload(
+                    target: target,
+                    toolName: toolName,
+                    state: .idle,
+                    lifecycleEvent: .update,
+                    sessionID: sessionID,
+                    cwd: cwd
+                )]
+            }
+
+        case "subagentstart", "subagentstop":
+            return []
+
+        case "pretooluse", "posttooluse", "posttoolusefailure":
+            guard environment["ZENTTY_CURSOR_VERBOSE_HOOKS"] == "1" else {
+                return []
+            }
+            return [lifecyclePayload(
+                target: target,
+                toolName: toolName,
+                state: .running,
+                sessionID: sessionID,
+                cwd: cwd
+            )]
+
+        default:
+            cursorAdapterLogger.debug("Unhandled cursor hook event: \(normalized, privacy: .public)")
+            return []
+        }
+    }
+
+    private static func cursorWorkspaceRoot(from jsonObject: [String: Any]) -> String? {
+        let roots = (jsonObject["workspace_roots"] as? [String]) ?? (jsonObject["workspaceRoots"] as? [String])
+        guard let first = roots?.first?.trimmingCharacters(in: .whitespacesAndNewlines), !first.isEmpty else {
+            return nil
+        }
+        return first
     }
 }
 

--- a/Zentty/AppState/Agent/AgentEventBridge.swift
+++ b/Zentty/AppState/Agent/AgentEventBridge.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let agentEventBridgeLogger = Logger(subsystem: "be.zenjoy.zentty", category: "AgentEventBridge")
 
 struct AgentEventInput {
     let event: String
@@ -45,6 +48,8 @@ enum AgentEventBridge {
         let remaining = Array(arguments.dropFirst(2))
         let adapter = parseAdapterFlag(remaining)
         let positionalArgs = remaining.filter { !$0.hasPrefix("--adapter=") }
+        let adapterLabel = adapter ?? "(default)"
+        agentEventBridgeLogger.debug("run adapter=\(adapterLabel, privacy: .public) bytes=\(inputData.count)")
         do {
             let payloads: [AgentStatusPayload]
             switch adapter {
@@ -60,17 +65,21 @@ enum AgentEventBridge {
                 payloads = try codexNotifyAdapter(data: inputData, environment: environment)
             case "gemini":
                 payloads = try geminiAdapter(data: inputData, environment: environment)
+            case "cursor":
+                payloads = try cursorAdapter(data: inputData, environment: environment)
             case .none:
                 let input = try parseInput(inputData)
                 payloads = try makePayloads(from: input, environment: environment)
             case let name?:
                 throw AgentStatusPayloadError.invalidArguments("Unknown adapter: \(name)")
             }
+            agentEventBridgeLogger.debug("run adapter=\(adapterLabel, privacy: .public) produced \(payloads.count) payload(s)")
             for payload in payloads {
                 post(payload)
             }
             return EXIT_SUCCESS
         } catch {
+            agentEventBridgeLogger.error("run adapter=\(adapterLabel, privacy: .public) threw: \(error.localizedDescription, privacy: .public)")
             if adapter == "claude" {
                 return EXIT_SUCCESS
             }

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -15,8 +15,21 @@ enum AgentBootstrapTool: String, Codable, Equatable {
     case claude
     case codex
     case copilot
+    case cursor
     case gemini
     case opencode
+
+    /// Names of the real CLI binary (or binaries) this wrapped tool resolves to on PATH.
+    /// For most tools this matches `rawValue`, but cursor's CLI is shipped as `cursor-agent`
+    /// (with `agent` as a user-facing alias) while `cursor` itself is the IDE launcher.
+    var realBinaryNames: [String] {
+        switch self {
+        case .cursor:
+            return ["cursor-agent"]
+        case .claude, .codex, .copilot, .gemini, .opencode:
+            return [rawValue]
+        }
+    }
 }
 
 struct AgentIPCRequest: Codable, Equatable {

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -47,6 +47,13 @@ enum AgentLaunchBootstrap {
                 runtimeDirectoryURL: runtimeDirectoryURL,
                 fileManager: fileManager
             )
+        case .cursor:
+            return try cursorPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                environment: environment,
+                fileManager: fileManager
+            )
         case .gemini:
             return try geminiPlan(
                 executablePath: executablePath,
@@ -71,6 +78,29 @@ enum AgentLaunchBootstrap {
                 appConfigProvider: appConfigProvider
             )
         }
+    }
+
+    private static func cursorPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        fileManager: FileManager
+    ) throws -> AgentLaunchPlan {
+        if environment["ZENTTY_CURSOR_HOOKS_DISABLED"] == "1" {
+            return directPlan(executablePath: executablePath, arguments: arguments)
+        }
+
+        CursorHooksInstaller.installIfPossible(environment: environment, fileManager: fileManager)
+
+        return AgentLaunchPlan(
+            executablePath: executablePath,
+            arguments: arguments,
+            setEnvironment: [
+                "ZENTTY_AGENT_TOOL": "cursor",
+            ],
+            unsetEnvironment: [],
+            preLaunchActions: []
+        )
     }
 
     private static func claudePlan(
@@ -617,8 +647,8 @@ enum AgentLaunchBootstrap {
     }
 
     private static func copilotMergedConfigJSON(existingData: Data, cliPath: String) throws -> Data? {
-        guard let uncommentedData = stripJSONCComments(in: existingData),
-              let cleanedData = stripTrailingCommas(in: uncommentedData),
+        guard let uncommentedData = JSONCRelaxedParse.stripComments(in: existingData),
+              let cleanedData = JSONCRelaxedParse.stripTrailingCommas(in: uncommentedData),
               var jsonObject = try JSONSerialization.jsonObject(with: cleanedData) as? [String: Any] else {
             return nil
         }
@@ -916,129 +946,6 @@ enum AgentLaunchBootstrap {
     ) throws {
         try? fileManager.removeItem(at: destinationURL)
         try fileManager.copyItem(at: sourceURL, to: destinationURL)
-    }
-
-    private static func stripJSONCComments(in data: Data) -> Data? {
-        guard let text = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        var output = ""
-        var iterator = text.makeIterator()
-        var pending = iterator.next()
-        var inString = false
-        var escaping = false
-        var lookahead: Character?
-
-        func advance() {
-            pending = lookahead ?? iterator.next()
-            lookahead = nil
-        }
-
-        while let character = pending {
-            if inString {
-                output.append(character)
-                if escaping {
-                    escaping = false
-                } else if character == "\\" {
-                    escaping = true
-                } else if character == "\"" {
-                    inString = false
-                }
-                advance()
-                continue
-            }
-
-            if character == "\"" {
-                inString = true
-                output.append(character)
-                advance()
-                continue
-            }
-
-            if character == "/" {
-                lookahead = iterator.next()
-                if lookahead == "/" {
-                    advance()
-                    while let next = pending, next != "\n", next != "\r" {
-                        advance()
-                    }
-                    continue
-                }
-                if lookahead == "*" {
-                    advance()
-                    while let next = pending {
-                        if next == "*" {
-                            lookahead = iterator.next()
-                            if lookahead == "/" {
-                                advance()
-                                advance()
-                                break
-                            }
-                        }
-                        advance()
-                    }
-                    continue
-                }
-                output.append(character)
-                advance()
-                continue
-            }
-
-            output.append(character)
-            advance()
-        }
-
-        return output.data(using: .utf8)
-    }
-
-    private static func stripTrailingCommas(in data: Data) -> Data? {
-        guard let text = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        let characters = Array(text)
-        var output = ""
-        var inString = false
-        var escaping = false
-        var index = 0
-
-        while index < characters.count {
-            let character = characters[index]
-            if inString {
-                output.append(character)
-                if escaping {
-                    escaping = false
-                } else if character == "\\" {
-                    escaping = true
-                } else if character == "\"" {
-                    inString = false
-                }
-                index += 1
-                continue
-            }
-
-            if character == "\"" {
-                inString = true
-                output.append(character)
-                index += 1
-                continue
-            }
-
-            if character == "," {
-                var lookahead = index + 1
-                while lookahead < characters.count, characters[lookahead].isWhitespace {
-                    lookahead += 1
-                }
-                if lookahead < characters.count, characters[lookahead] == "}" || characters[lookahead] == "]" {
-                    index += 1
-                    continue
-                }
-            }
-
-            output.append(character)
-            index += 1
-        }
-
-        return output.data(using: .utf8)
     }
 
     private static func loadAppConfig() -> AppConfig {

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -4,6 +4,7 @@ enum AgentTool: Equatable, Sendable {
     case claudeCode
     case codex
     case copilot
+    case cursor
     case gemini
     case openCode
     case custom(String)
@@ -16,6 +17,8 @@ enum AgentTool: Equatable, Sendable {
             return "Codex"
         case .copilot:
             return "Copilot"
+        case .cursor:
+            return "Cursor"
         case .gemini:
             return "Gemini"
         case .openCode:
@@ -38,6 +41,9 @@ enum AgentTool: Equatable, Sendable {
         }
         if normalized.contains("copilot") {
             return .copilot
+        }
+        if normalized.contains("cursor") {
+            return .cursor
         }
         if normalized.contains("gemini") {
             return .gemini

--- a/Zentty/AppState/Agent/AgentStatusHelper.swift
+++ b/Zentty/AppState/Agent/AgentStatusHelper.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 enum AgentStatusHelper {
-    private static let wrappedToolNames = ["claude", "codex", "copilot", "gemini", "opencode"]
+    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "gemini", "opencode"]
     private static let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
     static func runIfNeeded(arguments: [String], environment: [String: String]) -> Int32? {
@@ -54,6 +54,7 @@ enum AgentStatusHelper {
                     "claude/claude",
                     "codex/codex",
                     "copilot/copilot",
+                    "cursor/cursor-agent",
                     "gemini/gemini",
                     "opencode/opencode",
                     "shared/zentty-agent-wrapper",
@@ -62,6 +63,7 @@ enum AgentStatusHelper {
                     "claude/claude",
                     "codex/codex",
                     "copilot/copilot",
+                    "cursor/cursor-agent",
                     "gemini/gemini",
                     "opencode/opencode",
                     "shared/zentty-agent-wrapper",
@@ -119,15 +121,17 @@ enum AgentStatusHelper {
 
         return wrapperDirectories.filter { wrapperDirectory in
             let toolName = URL(fileURLWithPath: wrapperDirectory, isDirectory: true).lastPathComponent
+            let candidateBinaryNames = AgentBootstrapTool(rawValue: toolName)?.realBinaryNames ?? [toolName]
             return pathEntries.contains { entry in
                 guard !excludedDirectories.contains(entry) else {
                     return false
                 }
-
-                let candidatePath = URL(fileURLWithPath: entry, isDirectory: true)
-                    .appendingPathComponent(toolName, isDirectory: false)
-                    .path
-                return FileManager.default.isExecutableFile(atPath: candidatePath)
+                return candidateBinaryNames.contains { binaryName in
+                    let candidatePath = URL(fileURLWithPath: entry, isDirectory: true)
+                        .appendingPathComponent(binaryName, isDirectory: false)
+                        .path
+                    return FileManager.default.isExecutableFile(atPath: candidatePath)
+                }
             }
         }
     }

--- a/Zentty/AppState/Agent/CursorHooksInstaller.swift
+++ b/Zentty/AppState/Agent/CursorHooksInstaller.swift
@@ -1,0 +1,223 @@
+import Foundation
+import os
+
+private let installerLogger = Logger(subsystem: "be.zenjoy.zentty", category: "CursorHookInstall")
+
+/// Installs and removes Zentty hook entries in Cursor's user-level hooks file.
+///
+/// Cursor (the Cursor CLI agent, `cursor-agent`) loads hooks from
+/// `~/.cursor/hooks.json`; there is no environment variable or CLI flag that
+/// redirects this path. The installer mutates that file in place: Zentty's
+/// managed entries are marked by the presence of `hookMarker` in the command
+/// string, so uninstall (and re-install) can find and rewrite them without
+/// touching entries owned by the user or other tools.
+enum CursorHooksInstaller {
+    static let managedEvents: [String] = [
+        "sessionStart",
+        "sessionEnd",
+        "beforeSubmitPrompt",
+        "stop",
+    ]
+
+    /// Substring present in every Zentty-managed hook command. Used to locate
+    /// and remove our entries without affecting entries the user added by hand
+    /// or via another tool.
+    static let hookMarker: String = "ipc agent-event --adapter=cursor"
+
+    static func defaultUserHooksURL(
+        home: String = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+    ) -> URL {
+        URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".cursor", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+    }
+
+    /// Write (or refresh) Zentty's hook entries in the given file. Safe to call
+    /// repeatedly; stale entries are replaced in place.
+    ///
+    /// Throws only on unrecoverable I/O failures. A malformed existing file is
+    /// surfaced as a thrown error so the caller can log an actionable message
+    /// rather than destroying user data.
+    static func install(
+        at hooksURL: URL,
+        cliPath: String,
+        fileManager: FileManager = .default
+    ) throws {
+        let command = hookCommand(cliPath: cliPath)
+        try fileManager.createDirectory(
+            at: hooksURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        var jsonObject: [String: Any] = [:]
+        if fileManager.isReadableFile(atPath: hooksURL.path) {
+            let data = try Data(contentsOf: hooksURL)
+            if !data.isEmpty {
+                guard let parsed = parsePermissive(data) else {
+                    throw CocoaError(
+                        .propertyListReadCorrupt,
+                        userInfo: [NSLocalizedDescriptionKey:
+                            "\(hooksURL.path) is not valid JSON; move it aside or fix it and relaunch"]
+                    )
+                }
+                jsonObject = parsed
+            }
+        }
+        jsonObject["version"] = 1
+
+        var hooks = jsonObject["hooks"] as? [String: Any] ?? [:]
+        for event in managedEvents {
+            var entries = hooks[event] as? [[String: Any]] ?? []
+            entries.removeAll { entry in
+                guard let existing = entry["command"] as? String else { return false }
+                return existing.contains(hookMarker)
+            }
+            entries.append(["command": command])
+            hooks[event] = entries
+        }
+        jsonObject["hooks"] = hooks
+
+        let newData = try JSONSerialization.data(
+            withJSONObject: jsonObject,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+
+        if fileManager.isReadableFile(atPath: hooksURL.path),
+           let existing = try? Data(contentsOf: hooksURL),
+           existing == newData {
+            return
+        }
+
+        try newData.write(to: hooksURL, options: .atomic)
+    }
+
+    /// Remove any Zentty-managed entries from the given file. If removal
+    /// leaves the file with no hooks and no other top-level keys, the file is
+    /// deleted entirely. Files that never contained a Zentty entry are left
+    /// exactly as-is (including any JSON-with-Comments formatting the user may
+    /// have).
+    static func uninstall(
+        at hooksURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.isReadableFile(atPath: hooksURL.path) else {
+            return
+        }
+        let data = try Data(contentsOf: hooksURL)
+        guard !data.isEmpty, var jsonObject = parsePermissive(data) else {
+            return
+        }
+
+        guard var hooks = jsonObject["hooks"] as? [String: Any] else {
+            return
+        }
+
+        var didRemoveAny = false
+        for event in managedEvents {
+            guard var entries = hooks[event] as? [[String: Any]] else { continue }
+            let before = entries.count
+            entries.removeAll { entry in
+                guard let existing = entry["command"] as? String else { return false }
+                return existing.contains(hookMarker)
+            }
+            if entries.count != before {
+                didRemoveAny = true
+            }
+            if entries.isEmpty {
+                if hooks[event] != nil {
+                    hooks.removeValue(forKey: event)
+                }
+            } else {
+                hooks[event] = entries
+            }
+        }
+
+        guard didRemoveAny else {
+            return
+        }
+
+        if hooks.isEmpty {
+            jsonObject.removeValue(forKey: "hooks")
+        } else {
+            jsonObject["hooks"] = hooks
+        }
+
+        let hasOnlyVersion = jsonObject.keys.allSatisfy { $0 == "version" }
+        if hasOnlyVersion {
+            try fileManager.removeItem(at: hooksURL)
+            return
+        }
+
+        let newData = try JSONSerialization.data(
+            withJSONObject: jsonObject,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        if data == newData {
+            return
+        }
+        try newData.write(to: hooksURL, options: .atomic)
+    }
+
+    /// Run `install` with environment-derived paths, logging the outcome.
+    /// Used by the auto-install path during `zentty launch cursor`.
+    static func installIfPossible(
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) {
+        guard let cliPath = environment["ZENTTY_CLI_BIN"]?.nonBlank else {
+            installerLogger.debug("Skipping cursor hook install: ZENTTY_CLI_BIN is not set")
+            return
+        }
+        guard let home = environment["HOME"]?.nonBlank else {
+            installerLogger.debug("Skipping cursor hook install: HOME is not set")
+            return
+        }
+        let hooksURL = defaultUserHooksURL(home: home)
+        do {
+            try install(at: hooksURL, cliPath: cliPath, fileManager: fileManager)
+            installerLogger.info("Installed Zentty hook entries in \(hooksURL.path, privacy: .public)")
+        } catch {
+            installerLogger.error(
+                "Failed to install cursor hooks at \(hooksURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Internals
+
+    static func hookCommand(cliPath: String) -> String {
+        "\"\(shellEscapeDoubleQuoted(cliPath))\" ipc agent-event --adapter=cursor"
+    }
+
+    /// Try strict JSON first; on failure, retry after stripping `//` / `/* */`
+    /// comments and trailing commas (JSON-with-Comments forms some users edit
+    /// by hand). Returns `nil` only when the content can't be recovered.
+    private static func parsePermissive(_ data: Data) -> [String: Any]? {
+        if let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return parsed
+        }
+        guard let stripped = JSONCRelaxedParse.stripComments(in: data),
+              let cleaned = JSONCRelaxedParse.stripTrailingCommas(in: stripped),
+              let parsed = try? JSONSerialization.jsonObject(with: cleaned) as? [String: Any] else {
+            return nil
+        }
+        return parsed
+    }
+
+    private static func shellEscapeDoubleQuoted(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
+    }
+}
+
+private extension String {
+    /// Returns `self` when it has at least one non-whitespace character; `nil`
+    /// otherwise. Mirrors the trimming behaviour the pre-extraction helpers
+    /// relied on to filter out env vars set to whitespace-only strings.
+    var nonBlank: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
+}

--- a/Zentty/AppState/Agent/JSONCRelaxedParse.swift
+++ b/Zentty/AppState/Agent/JSONCRelaxedParse.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Tiny helpers that relax a JSON document enough for parsers that normally
+/// insist on strict JSON. They accept JSON-with-comments (`//` and `/* */`)
+/// and trailing commas — both common when users hand-edit agent config files.
+///
+/// Callers should still try strict parsing first and fall back to these only
+/// when that fails, so genuine syntax errors surface clearly.
+enum JSONCRelaxedParse {
+    /// Strip `//` and `/* */` comments, preserving content inside string
+    /// literals. Returns `nil` if the input isn't valid UTF-8.
+    static func stripComments(in data: Data) -> Data? {
+        guard let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        var output = ""
+        var iterator = text.makeIterator()
+        var pending = iterator.next()
+        var inString = false
+        var escaping = false
+        var lookahead: Character?
+
+        func advance() {
+            pending = lookahead ?? iterator.next()
+            lookahead = nil
+        }
+
+        while let character = pending {
+            if inString {
+                output.append(character)
+                if escaping {
+                    escaping = false
+                } else if character == "\\" {
+                    escaping = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                advance()
+                continue
+            }
+
+            if character == "\"" {
+                inString = true
+                output.append(character)
+                advance()
+                continue
+            }
+
+            if character == "/" {
+                lookahead = iterator.next()
+                if lookahead == "/" {
+                    advance()
+                    while let next = pending, next != "\n", next != "\r" {
+                        advance()
+                    }
+                    continue
+                }
+                if lookahead == "*" {
+                    advance()
+                    while let next = pending {
+                        if next == "*" {
+                            lookahead = iterator.next()
+                            if lookahead == "/" {
+                                advance()
+                                advance()
+                                break
+                            }
+                        }
+                        advance()
+                    }
+                    continue
+                }
+                output.append(character)
+                advance()
+                continue
+            }
+
+            output.append(character)
+            advance()
+        }
+
+        return output.data(using: .utf8)
+    }
+
+    /// Remove commas that appear immediately before `}` or `]`, which strict
+    /// JSON rejects.
+    static func stripTrailingCommas(in data: Data) -> Data? {
+        guard let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let characters = Array(text)
+        var output = ""
+        var inString = false
+        var escaping = false
+        var index = 0
+
+        while index < characters.count {
+            let character = characters[index]
+            if inString {
+                output.append(character)
+                if escaping {
+                    escaping = false
+                } else if character == "\\" {
+                    escaping = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                index += 1
+                continue
+            }
+
+            if character == "\"" {
+                inString = true
+                output.append(character)
+                index += 1
+                continue
+            }
+
+            if character == "," {
+                var lookahead = index + 1
+                while lookahead < characters.count, characters[lookahead].isWhitespace {
+                    lookahead += 1
+                }
+                if lookahead < characters.count, characters[lookahead] == "}" || characters[lookahead] == "]" {
+                    index += 1
+                    continue
+                }
+            }
+
+            output.append(character)
+            index += 1
+        }
+
+        return output.data(using: .utf8)
+    }
+}

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -752,6 +752,8 @@ enum PanePresentationNormalizer {
             return ["codex"].contains(normalized)
         case .copilot:
             return ["copilot"].contains(normalized)
+        case .cursor:
+            return ["cursor"].contains(normalized)
         case .gemini:
             return ["gemini", "gemini cli"].contains(normalized)
         case .openCode:

--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -578,6 +578,7 @@ extension WorklaneStore {
             case .claudeCode: return "claude"
             case .codex: return "codex"
             case .copilot: return "gh copilot"
+            case .cursor: return "cursor"
             case .gemini: return "gemini"
             case .openCode: return "opencode"
             case .custom(let name): return name

--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -369,6 +369,8 @@ enum AgentResumeCommandBuilder {
             return "copilot --resume=\(sessionID)"
         case .gemini:
             return "gemini --resume"
+        case .cursor:
+            return nil
         default:
             return nil
         }

--- a/Zentty/Terminal/TerminalMetadata.swift
+++ b/Zentty/Terminal/TerminalMetadata.swift
@@ -937,6 +937,8 @@ final class TerminalDiagnostics: @unchecked Sendable {
             return "codex"
         case .copilot:
             return "copilot"
+        case .cursor:
+            return "cursor"
         case .gemini:
             return "gemini"
         case .openCode:

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -51,13 +51,15 @@ struct AgentToolLauncher {
             return !passthroughSubcommands.contains(arguments.first ?? "")
         case .copilot:
             return environment["ZENTTY_COPILOT_HOOKS_DISABLED"] != "1"
+        case .cursor:
+            return environment["ZENTTY_CURSOR_HOOKS_DISABLED"] != "1"
         case .codex, .gemini, .opencode:
             return true
         }
     }
 
     private func findRealBinary() throws -> String {
-        let wrappedToolName = tool.rawValue
+        let wrappedToolNames = tool.realBinaryNames
         let wrapperDirectories = environmentPathEntries(forKeys: [
             "ZENTTY_ALL_WRAPPER_BIN_DIRS",
             "ZENTTY_WRAPPER_BIN_DIRS",
@@ -72,11 +74,13 @@ struct AgentToolLauncher {
             guard !excludedDirectories.contains(entry) else {
                 continue
             }
-            let candidate = URL(fileURLWithPath: entry, isDirectory: true)
-                .appendingPathComponent(wrappedToolName, isDirectory: false)
-                .path
-            if FileManager.default.isExecutableFile(atPath: candidate) {
-                return candidate
+            for wrappedToolName in wrappedToolNames {
+                let candidate = URL(fileURLWithPath: entry, isDirectory: true)
+                    .appendingPathComponent(wrappedToolName, isDirectory: false)
+                    .path
+                if FileManager.default.isExecutableFile(atPath: candidate) {
+                    return candidate
+                }
             }
         }
 
@@ -96,6 +100,8 @@ struct AgentToolLauncher {
             "ZENTTY_INSTANCE_ID",
             "ZENTTY_CLAUDE_HOOKS_DISABLED",
             "ZENTTY_COPILOT_HOOKS_DISABLED",
+            "ZENTTY_CURSOR_HOOKS_DISABLED",
+            "ZENTTY_CURSOR_VERBOSE_HOOKS",
             "ZENTTY_CODEX_NOTIFY_DISABLED",
             "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
             "CODEX_HOME",
@@ -118,7 +124,7 @@ struct AgentToolLauncher {
         switch tool {
         case .claude:
             return EnvironmentPatch(set: [:], unset: ["CLAUDECODE"])
-        case .codex, .copilot, .gemini, .opencode:
+        case .codex, .copilot, .gemini, .opencode, .cursor:
             return EnvironmentPatch()
         }
     }
@@ -138,6 +144,8 @@ struct AgentToolLauncher {
             environmentPatch.set["ZENTTY_COPILOT_PID"] = "\(getpid())"
         case .gemini:
             environmentPatch.set["ZENTTY_GEMINI_PID"] = "\(getpid())"
+        case .cursor:
+            environmentPatch.set["ZENTTY_CURSOR_PID"] = "\(getpid())"
         case .opencode:
             break
         }
@@ -182,6 +190,7 @@ struct AgentToolLauncher {
             "ZENTTY_CODEX_PID",
             "ZENTTY_COPILOT_PID",
             "ZENTTY_GEMINI_PID",
+            "ZENTTY_CURSOR_PID",
         ]
         return Dictionary(uniqueKeysWithValues: keys.compactMap { key in
             guard let value = environment[key], !value.isEmpty else {

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -1,6 +1,9 @@
 import ArgumentParser
 import Darwin
 import Foundation
+import os
+
+private let ipcCLILogger = Logger(subsystem: "be.zenjoy.zentty", category: "IPC")
 
 @main
 struct ZenttyCLI: ParsableCommand {
@@ -18,8 +21,86 @@ struct ZenttyCLI: ParsableCommand {
             GeminiHookCommand.self,
             IPCCommand.self,
             LaunchCommand.self,
+            InstallCommand.self,
+            UninstallCommand.self,
         ]
     )
+}
+
+// MARK: - install / uninstall
+
+private enum IntegrationTarget: String, CaseIterable {
+    case cursorHooks = "cursor-hooks"
+
+    static func resolve(_ raw: String) throws -> IntegrationTarget {
+        guard let target = IntegrationTarget(rawValue: raw) else {
+            let supported = IntegrationTarget.allCases.map(\.rawValue).joined(separator: ", ")
+            throw ValidationError("Unknown target '\(raw)'. Supported: \(supported)")
+        }
+        return target
+    }
+}
+
+private func resolveInvokingCLIPath() -> String {
+    var size: UInt32 = 0
+    _ = _NSGetExecutablePath(nil, &size)
+    guard size > 0 else {
+        return CommandLine.arguments[0]
+    }
+    var buffer = [CChar](repeating: 0, count: Int(size))
+    let result = buffer.withUnsafeMutableBufferPointer { pointer in
+        _NSGetExecutablePath(pointer.baseAddress, &size)
+    }
+    guard result == 0 else {
+        return CommandLine.arguments[0]
+    }
+    return URL(fileURLWithPath: String(cString: buffer))
+        .resolvingSymlinksInPath()
+        .standardizedFileURL
+        .path
+}
+
+struct InstallCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install a Zentty agent integration.",
+        discussion: "Supported targets: \(IntegrationTarget.allCases.map(\.rawValue).joined(separator: ", "))"
+    )
+
+    @Argument(help: "Target integration name (e.g. cursor-hooks).")
+    var target: String
+
+    mutating func run() throws {
+        switch try IntegrationTarget.resolve(target) {
+        case .cursorHooks:
+            let hooksURL = CursorHooksInstaller.defaultUserHooksURL()
+            try CursorHooksInstaller.install(
+                at: hooksURL,
+                cliPath: resolveInvokingCLIPath()
+            )
+            print("Installed Zentty cursor hooks at \(hooksURL.path).")
+        }
+    }
+}
+
+struct UninstallCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "uninstall",
+        abstract: "Remove a previously-installed Zentty agent integration.",
+        discussion: "Supported targets: \(IntegrationTarget.allCases.map(\.rawValue).joined(separator: ", "))"
+    )
+
+    @Argument(help: "Target integration name (e.g. cursor-hooks).")
+    var target: String
+
+    mutating func run() throws {
+        switch try IntegrationTarget.resolve(target) {
+        case .cursorHooks:
+            let hooksURL = CursorHooksInstaller.defaultUserHooksURL()
+            try CursorHooksInstaller.uninstall(at: hooksURL)
+            print("Removed Zentty cursor hook entries from \(hooksURL.path).")
+        }
+    }
 }
 
 struct VersionCommand: ParsableCommand {
@@ -375,6 +456,7 @@ struct IPCCommand: ParsableCommand {
         "ZENTTY_CODEX_PID",
         "ZENTTY_COPILOT_PID",
         "ZENTTY_GEMINI_PID",
+        "ZENTTY_CURSOR_PID",
     ]
 
     @Argument(help: "Supported values: agent-event, agent-signal, agent-status")
@@ -384,28 +466,42 @@ struct IPCCommand: ParsableCommand {
     var arguments: [String] = []
 
     mutating func run() throws {
-        guard Self.supportedSubcommands.contains(subcommand) else {
-            throw ValidationError("Unsupported ipc subcommand: \(subcommand)")
+        let localSubcommand = subcommand
+        let localArguments = arguments
+        guard Self.supportedSubcommands.contains(localSubcommand) else {
+            throw ValidationError("Unsupported ipc subcommand: \(localSubcommand)")
         }
-        guard let socketPath = ProcessInfo.processInfo.environment["ZENTTY_INSTANCE_SOCKET"],
-              !socketPath.isEmpty,
-              Self.hasRequiredRoutingEnvironment(ProcessInfo.processInfo.environment) else {
+        let environment = ProcessInfo.processInfo.environment
+        guard let socketPath = environment["ZENTTY_INSTANCE_SOCKET"], !socketPath.isEmpty else {
+            ipcCLILogger.info("ipc \(localSubcommand, privacy: .public): skipping — ZENTTY_INSTANCE_SOCKET is not set")
+            return
+        }
+        guard Self.hasRequiredRoutingEnvironment(environment) else {
+            let missing = Self.missingRoutingEnvironmentKeys(environment).joined(separator: ",")
+            ipcCLILogger.info("ipc \(localSubcommand, privacy: .public): skipping — missing \(missing, privacy: .public)")
             return
         }
 
+        let stdinPayload = standardInput()
+        let stdinLength = stdinPayload?.utf8.count ?? 0
+        let stdinAttached = isatty(STDIN_FILENO) == 0
+        ipcCLILogger.debug("ipc \(localSubcommand, privacy: .public) reading stdin: attached=\(stdinAttached, privacy: .public) bytes=\(stdinLength)")
+
         let request = AgentIPCRequest(
             kind: .ipc,
-            arguments: arguments,
-            standardInput: standardInput(),
-            environment: Self.forwardedEnvironment(from: ProcessInfo.processInfo.environment),
+            arguments: localArguments,
+            standardInput: stdinPayload,
+            environment: Self.forwardedEnvironment(from: environment),
             expectsResponse: false,
-            subcommand: subcommand
+            subcommand: localSubcommand
         )
 
         do {
             _ = try AgentIPCClient.send(request: request, socketPath: socketPath)
+            ipcCLILogger.debug("ipc \(localSubcommand, privacy: .public) sent (args: \(localArguments.joined(separator: " "), privacy: .private))")
         } catch {
-            guard ProcessInfo.processInfo.environment["ZENTTY_CLI_DEBUG"] == "1" else {
+            ipcCLILogger.error("ipc \(localSubcommand, privacy: .public) send failed: \(error.localizedDescription, privacy: .private)")
+            guard environment["ZENTTY_CLI_DEBUG"] == "1" else {
                 return
             }
             FileHandle.standardError.write(Data(("zentty ipc send failed: \(error.localizedDescription)\n").utf8))
@@ -424,12 +520,13 @@ struct IPCCommand: ParsableCommand {
     }
 
     static func hasRequiredRoutingEnvironment(_ environment: [String: String]) -> Bool {
-        for key in ["ZENTTY_PANE_TOKEN", "ZENTTY_WORKLANE_ID", "ZENTTY_PANE_ID"] {
-            guard let value = environment[key], !value.isEmpty else {
-                return false
-            }
+        missingRoutingEnvironmentKeys(environment).isEmpty
+    }
+
+    static func missingRoutingEnvironmentKeys(_ environment: [String: String]) -> [String] {
+        ["ZENTTY_PANE_TOKEN", "ZENTTY_WORKLANE_ID", "ZENTTY_PANE_ID"].filter { key in
+            (environment[key] ?? "").isEmpty
         }
-        return true
     }
 
     static func forwardedEnvironment(from environment: [String: String]) -> [String: String] {
@@ -449,7 +546,7 @@ struct LaunchCommand: ParsableCommand {
         shouldDisplay: false
     )
 
-    @Argument(help: "Supported values: claude, codex, copilot, gemini, opencode")
+    @Argument(help: "Supported values: claude, codex, copilot, cursor, gemini, opencode")
     var tool: String
 
     @Argument(parsing: .captureForPassthrough, help: "Arguments forwarded to the real tool.")

--- a/ZenttyIntegrationTests/AgentWrapperTests.swift
+++ b/ZenttyIntegrationTests/AgentWrapperTests.swift
@@ -354,7 +354,7 @@ final class AgentWrapperTests: XCTestCase {
     }
 
     func test_tool_wrappers_delegate_to_launch_command_when_cli_is_available() throws {
-        for tool in ["claude", "codex", "copilot", "gemini", "opencode"] {
+        for tool in ["claude", "codex", "copilot", "cursor-agent", "gemini", "opencode"] {
             let harness = try WrapperHarness(copyingScriptsNamed: [tool, "zentty-agent-wrapper"])
             try harness.installRealBinary(
                 named: tool,
@@ -378,8 +378,11 @@ final class AgentWrapperTests: XCTestCase {
                 ]
             )
 
+            // cursor wrappers identify as the `cursor` tool regardless of which
+            // alias (`cursor-agent` or `agent`) the user invoked.
+            let expectedLaunchTool = tool == "cursor-agent" ? "cursor" : tool
             XCTAssertEqual(result.exitCode, 0, "\(tool): \(result.stderr)\n\(result.stdout)")
-            XCTAssertEqual(try harness.readArgumentCalls(named: "cli-args.log"), [["launch", tool, "hello"]], tool)
+            XCTAssertEqual(try harness.readArgumentCalls(named: "cli-args.log"), [["launch", expectedLaunchTool, "hello"]], tool)
             XCTAssertTrue(try harness.readLines(named: "real-args.log").isEmpty, tool)
         }
     }
@@ -730,7 +733,7 @@ private struct WrapperHarness {
     }
 
     private var publicWrapperDirectories: [URL] {
-        ["claude", "codex", "copilot", "gemini", "opencode"]
+        ["claude", "codex", "copilot", "cursor", "gemini", "opencode"]
             .map { wrapperBinURL.appendingPathComponent($0, isDirectory: true) }
             .filter { FileManager.default.fileExists(atPath: $0.path) }
     }
@@ -747,6 +750,8 @@ private struct WrapperHarness {
             return "codex/codex"
         case "copilot":
             return "copilot/copilot"
+        case "cursor-agent":
+            return "cursor/cursor-agent"
         case "gemini":
             return "gemini/gemini"
         case "opencode":

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -122,6 +122,101 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertEqual(loggedErrors.count, 1)
     }
 
+    func test_run_cursor_adapter_invalid_payload_still_fails_closed() throws {
+        var postedPayloads: [AgentStatusPayload] = []
+        var loggedErrors: [String] = []
+
+        let result = AgentEventBridge.run(
+            arguments: ["zentty", "agent-event", "--adapter=cursor"],
+            environment: defaultEnvironment,
+            inputData: Data(),
+            post: { postedPayloads.append($0) },
+            writeError: { loggedErrors.append(String(describing: $0)) }
+        )
+
+        XCTAssertEqual(result, EXIT_FAILURE)
+        XCTAssertTrue(postedPayloads.isEmpty)
+        XCTAssertEqual(loggedErrors.count, 1)
+    }
+
+    func test_cursor_adapter_session_start_includes_pid_when_env_set() throws {
+        var postedPayloads: [AgentStatusPayload] = []
+        let json = """
+        {"hook_event_name":"sessionStart","conversation_id":"c1","workspace_roots":["/tmp/ws"]}
+        """
+        let env = defaultEnvironment.merging(["ZENTTY_CURSOR_PID": "9999"]) { _, new in new }
+        let result = AgentEventBridge.run(
+            arguments: ["zentty", "agent-event", "--adapter=cursor"],
+            environment: env,
+            inputData: Data(json.utf8),
+            post: { postedPayloads.append($0) },
+            writeError: { XCTFail("unexpected error: \($0)") }
+        )
+
+        XCTAssertEqual(result, EXIT_SUCCESS)
+        XCTAssertEqual(postedPayloads.count, 2)
+        XCTAssertEqual(postedPayloads[0].signalKind, .pid)
+        XCTAssertEqual(postedPayloads[0].pid, 9999)
+        XCTAssertEqual(postedPayloads[0].toolName, "Cursor")
+        XCTAssertEqual(postedPayloads[1].state, .starting)
+        XCTAssertEqual(postedPayloads[1].toolName, "Cursor")
+        XCTAssertEqual(postedPayloads[1].sessionID, "c1")
+        XCTAssertEqual(postedPayloads[1].agentWorkingDirectory, "/tmp/ws")
+    }
+
+    func test_cursor_adapter_before_submit_prompt_maps_to_running() throws {
+        var postedPayloads: [AgentStatusPayload] = []
+        let json = #"{"hook_event_name":"beforeSubmitPrompt","conversation_id":"c-run"}"#
+        let result = AgentEventBridge.run(
+            arguments: ["zentty", "agent-event", "--adapter=cursor"],
+            environment: defaultEnvironment,
+            inputData: Data(json.utf8),
+            post: { postedPayloads.append($0) },
+            writeError: { XCTFail("unexpected error: \($0)") }
+        )
+
+        XCTAssertEqual(result, EXIT_SUCCESS)
+        XCTAssertEqual(postedPayloads.count, 1)
+        XCTAssertEqual(postedPayloads[0].state, .running)
+        XCTAssertEqual(postedPayloads[0].toolName, "Cursor")
+        XCTAssertEqual(postedPayloads[0].sessionID, "c-run")
+    }
+
+    func test_cursor_adapter_stop_completed_maps_to_idle() throws {
+        var postedPayloads: [AgentStatusPayload] = []
+        let json = #"{"hook_event_name":"stop","conversation_id":"c2","status":"completed"}"#
+        let result = AgentEventBridge.run(
+            arguments: ["zentty", "agent-event", "--adapter=cursor"],
+            environment: defaultEnvironment,
+            inputData: Data(json.utf8),
+            post: { postedPayloads.append($0) },
+            writeError: { XCTFail("unexpected error: \($0)") }
+        )
+
+        XCTAssertEqual(result, EXIT_SUCCESS)
+        XCTAssertEqual(postedPayloads.count, 1)
+        XCTAssertEqual(postedPayloads[0].state, .idle)
+        XCTAssertEqual(postedPayloads[0].lifecycleEvent, .update)
+        XCTAssertEqual(postedPayloads[0].toolName, "Cursor")
+    }
+
+    func test_cursor_adapter_stop_error_maps_to_unresolved_stop() throws {
+        var postedPayloads: [AgentStatusPayload] = []
+        let json = #"{"hook_event_name":"stop","conversation_id":"c3","status":"error"}"#
+        let result = AgentEventBridge.run(
+            arguments: ["zentty", "agent-event", "--adapter=cursor"],
+            environment: defaultEnvironment,
+            inputData: Data(json.utf8),
+            post: { postedPayloads.append($0) },
+            writeError: { XCTFail("unexpected error: \($0)") }
+        )
+
+        XCTAssertEqual(result, EXIT_SUCCESS)
+        XCTAssertEqual(postedPayloads.count, 1)
+        XCTAssertEqual(postedPayloads[0].state, .unresolvedStop)
+        XCTAssertEqual(postedPayloads[0].toolName, "Cursor")
+    }
+
     // MARK: - session.start
 
     func test_session_start_produces_pid_and_lifecycle_payloads() throws {

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -74,6 +74,11 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(AgentTool.resolveKnown(named: "Gemini"), .gemini)
     }
 
+    func test_agent_tool_recognizes_cursor() {
+        XCTAssertEqual(AgentTool.resolve(named: "cursor"), .cursor)
+        XCTAssertEqual(AgentTool.resolve(named: "Cursor Agent"), .cursor)
+    }
+
     func test_agent_status_helper_returns_nil_when_resource_directories_are_missing() throws {
         let bundle = try makeTemporaryBundle(named: "MissingResources")
 
@@ -90,10 +95,10 @@ final class AgentStatusSupportTests: XCTestCase {
 
         let binURL = resourcesURL.appendingPathComponent("bin", isDirectory: true)
         try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
-        for name in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let wrapperDirectoryURL = binURL.appendingPathComponent(name, isDirectory: true)
+        for (dirName, fileName) in wrapperLayoutPairs {
+            let wrapperDirectoryURL = binURL.appendingPathComponent(dirName, isDirectory: true)
             try FileManager.default.createDirectory(at: wrapperDirectoryURL, withIntermediateDirectories: true)
-            let fileURL = wrapperDirectoryURL.appendingPathComponent(name, isDirectory: false)
+            let fileURL = wrapperDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
             FileManager.default.createFile(atPath: fileURL.path, contents: Data("#!/bin/sh\n".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
         }
@@ -116,7 +121,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         XCTAssertEqual(
             AgentStatusHelper.wrapperDirectoryPaths(in: bundle),
-            ["claude", "codex", "copilot", "gemini", "opencode"].map {
+            ["claude", "codex", "copilot", "cursor", "gemini", "opencode"].map {
                 binURL.appendingPathComponent($0, isDirectory: true).path
             }
         )
@@ -132,10 +137,10 @@ final class AgentStatusSupportTests: XCTestCase {
 
         let binURL = resourcesURL.appendingPathComponent("bin", isDirectory: true)
         try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
-        for name in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let wrapperDirectoryURL = binURL.appendingPathComponent(name, isDirectory: true)
+        for (dirName, fileName) in wrapperLayoutPairs {
+            let wrapperDirectoryURL = binURL.appendingPathComponent(dirName, isDirectory: true)
             try FileManager.default.createDirectory(at: wrapperDirectoryURL, withIntermediateDirectories: true)
-            let fileURL = wrapperDirectoryURL.appendingPathComponent(name, isDirectory: false)
+            let fileURL = wrapperDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
             try "#!/bin/sh\n".write(to: fileURL, atomically: true, encoding: .utf8)
         }
         let sharedURL = binURL.appendingPathComponent("shared", isDirectory: true)
@@ -167,10 +172,10 @@ final class AgentStatusSupportTests: XCTestCase {
 
         let binURL = resourcesURL.appendingPathComponent("bin", isDirectory: true)
         try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
-        for name in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let wrapperDirectoryURL = binURL.appendingPathComponent(name, isDirectory: true)
+        for (dirName, fileName) in wrapperLayoutPairs {
+            let wrapperDirectoryURL = binURL.appendingPathComponent(dirName, isDirectory: true)
             try FileManager.default.createDirectory(at: wrapperDirectoryURL, withIntermediateDirectories: true)
-            let wrapperURL = wrapperDirectoryURL.appendingPathComponent(name, isDirectory: false)
+            let wrapperURL = wrapperDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
             try "#!/bin/sh\n".write(to: wrapperURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperURL.path)
         }
@@ -201,10 +206,10 @@ final class AgentStatusSupportTests: XCTestCase {
         let binURL = resourcesURL.appendingPathComponent("bin", isDirectory: true)
         try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
 
-        for name in ["claude", "codex", "copilot", "gemini", "opencode"] {
-            let wrapperDirectoryURL = binURL.appendingPathComponent(name, isDirectory: true)
+        for (dirName, fileName) in wrapperLayoutPairs {
+            let wrapperDirectoryURL = binURL.appendingPathComponent(dirName, isDirectory: true)
             try FileManager.default.createDirectory(at: wrapperDirectoryURL, withIntermediateDirectories: true)
-            let wrapperURL = wrapperDirectoryURL.appendingPathComponent(name, isDirectory: false)
+            let wrapperURL = wrapperDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
             try "#!/bin/sh\n".write(to: wrapperURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperURL.path)
         }
@@ -218,7 +223,9 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         let realBinURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: realBinURL, withIntermediateDirectories: true)
-        for name in ["claude", "gemini", "opencode"] {
+        // Real binaries Zentty's wrappers expect on PATH. Note cursor resolves to `cursor-agent`,
+        // not `cursor` (which is the Cursor IDE launcher).
+        for name in ["claude", "cursor-agent", "gemini", "opencode"] {
             let fileURL = realBinURL.appendingPathComponent(name, isDirectory: false)
             try "#!/bin/sh\n".write(to: fileURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
@@ -229,6 +236,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 binURL.appendingPathComponent("claude", isDirectory: true).path,
                 binURL.appendingPathComponent("codex", isDirectory: true).path,
                 binURL.appendingPathComponent("copilot", isDirectory: true).path,
+                binURL.appendingPathComponent("cursor", isDirectory: true).path,
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
                 sharedURL.path,
@@ -242,9 +250,50 @@ final class AgentStatusSupportTests: XCTestCase {
             AgentStatusHelper.enabledWrapperDirectoryPaths(in: bundle, processEnvironment: environment),
             [
                 binURL.appendingPathComponent("claude", isDirectory: true).path,
+                binURL.appendingPathComponent("cursor", isDirectory: true).path,
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
             ]
+        )
+    }
+
+    func test_agent_status_helper_skips_cursor_wrapper_when_only_cursor_ide_launcher_is_on_path() throws {
+        let bundleRoot = try makeTemporaryBundleRoot(named: "CursorIDEOnlyPath")
+        let resourcesURL = bundleRoot
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+        let binURL = resourcesURL.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+
+        for (dirName, fileName) in wrapperLayoutPairs {
+            let wrapperDirectoryURL = binURL.appendingPathComponent(dirName, isDirectory: true)
+            try FileManager.default.createDirectory(at: wrapperDirectoryURL, withIntermediateDirectories: true)
+            let wrapperURL = wrapperDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
+            try "#!/bin/sh\n".write(to: wrapperURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperURL.path)
+        }
+        let sharedURL = binURL.appendingPathComponent("shared", isDirectory: true)
+        try FileManager.default.createDirectory(at: sharedURL, withIntermediateDirectories: true)
+        let sharedWrapperURL = sharedURL.appendingPathComponent("zentty-agent-wrapper", isDirectory: false)
+        try "#!/bin/sh\n".write(to: sharedWrapperURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sharedWrapperURL.path)
+
+        let realBinURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: realBinURL, withIntermediateDirectories: true)
+        // Only `cursor` (the IDE launcher) exists — `cursor-agent` (the CLI) is absent.
+        let cursorIDE = realBinURL.appendingPathComponent("cursor", isDirectory: false)
+        try "#!/bin/sh\n".write(to: cursorIDE, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cursorIDE.path)
+
+        let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
+        let environment = [
+            "PATH": [realBinURL.path, "/usr/bin", "/bin"].joined(separator: ":"),
+        ]
+
+        XCTAssertFalse(
+            AgentStatusHelper.enabledWrapperDirectoryPaths(in: bundle, processEnvironment: environment)
+                .contains(binURL.appendingPathComponent("cursor", isDirectory: true).path),
+            "cursor wrapper should only activate when cursor-agent is on PATH, not the Cursor IDE launcher"
         )
     }
 
@@ -483,6 +532,25 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertFalse(geminiWrapper.contains("ZENTTY_AGENT_BIN"))
     }
 
+    func test_repository_cursor_wrapper_exposes_cursor_agent_and_agent() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let cursorDir = repositoryRoot
+            .appendingPathComponent("ZenttyResources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cursor", isDirectory: true)
+
+        let cursorAgentScript = cursorDir.appendingPathComponent("cursor-agent", isDirectory: false)
+        let wrapper = try String(contentsOf: cursorAgentScript, encoding: .utf8)
+        XCTAssertTrue(wrapper.contains("ZENTTY_AGENT_TOOL=\"cursor\""))
+        XCTAssertTrue(wrapper.contains("zentty-agent-wrapper"))
+
+        let agentLink = cursorDir.appendingPathComponent("agent", isDirectory: false)
+        let resolved = try FileManager.default.destinationOfSymbolicLink(atPath: agentLink.path)
+        XCTAssertEqual(resolved, "cursor-agent", "agent should be a symlink to cursor-agent in the same dir")
+    }
+
     func test_copy_agent_resources_build_script_marks_gemini_wrapper_executable() throws {
         let repositoryRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -491,6 +559,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let project = try String(contentsOf: projectURL, encoding: .utf8)
 
         XCTAssertTrue(project.contains("-o -path \"*/gemini/gemini\""))
+        XCTAssertTrue(project.contains("-o -path \"*/cursor/cursor-agent\""))
     }
 
     func test_agent_ipc_bridge_converts_agent_signal_message_to_payload() throws {
@@ -888,6 +957,389 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertTrue(overlayConfig.contains("session-start"))
         XCTAssertTrue(overlayConfig.contains("pre-tool-use"))
         XCTAssertTrue(overlayConfig.contains("echo existing"))
+    }
+
+    func test_agent_launch_bootstrap_sets_cursor_agent_tool_and_passthrough_arguments() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-cursor-runtime")
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["agent", "hello"],
+            standardInput: nil,
+            environment: [
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/cursor",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .cursor
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/cursor")
+        XCTAssertEqual(plan.arguments, ["agent", "hello"])
+        XCTAssertEqual(plan.setEnvironment["ZENTTY_AGENT_TOOL"], "cursor")
+    }
+
+    func test_agent_launch_bootstrap_cursor_respects_hooks_disabled() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-cursor-disabled-runtime")
+        let cursorHome = try makeTemporaryDirectory(named: "agent-launch-cursor-disabled-home")
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["agent", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": cursorHome.path,
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/cursor",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_CURSOR_HOOKS_DISABLED": "1",
+            ],
+            expectsResponse: true,
+            tool: .cursor
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/cursor")
+        XCTAssertEqual(plan.arguments, ["agent", "hello"])
+        XCTAssertTrue(plan.setEnvironment.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: cursorHome.appendingPathComponent(".cursor/hooks.json").path
+        ))
+    }
+
+    func test_agent_launch_bootstrap_cursor_installs_user_hooks_when_absent() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-cursor-install-runtime")
+        let cursorHome = try makeTemporaryDirectory(named: "agent-launch-cursor-install-home")
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["agent", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": cursorHome.path,
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/cursor",
+                "ZENTTY_CLI_BIN": "/opt/zentty/bin/zentty",
+            ],
+            expectsResponse: true,
+            tool: .cursor
+        )
+
+        _ = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        let hooksURL = cursorHome
+            .appendingPathComponent(".cursor", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+        let data = try Data(contentsOf: hooksURL)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["version"] as? Int, 1)
+
+        let hooks = try XCTUnwrap(object["hooks"] as? [String: Any])
+        for event in ["sessionStart", "sessionEnd", "beforeSubmitPrompt", "stop"] {
+            let entries = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertEqual(entries.count, 1, "\(event) should have one managed entry")
+            let command = try XCTUnwrap(entries.first?["command"] as? String)
+            XCTAssertTrue(command.contains("/opt/zentty/bin/zentty"))
+            XCTAssertTrue(command.contains("ipc agent-event --adapter=cursor"))
+            XCTAssertTrue(command.hasSuffix("--adapter=cursor"),
+                          "hook command must end cleanly so Cursor's heredoc binds to zentty (not a trailing || clause)")
+        }
+    }
+
+    func test_agent_launch_bootstrap_cursor_preserves_existing_user_hooks() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-cursor-merge-runtime")
+        let cursorHome = try makeTemporaryDirectory(named: "agent-launch-cursor-merge-home")
+        let cursorDir = cursorHome.appendingPathComponent(".cursor", isDirectory: true)
+        try FileManager.default.createDirectory(at: cursorDir, withIntermediateDirectories: true)
+        try #"""
+        {
+          "version": 1,
+          "hooks": {
+            "sessionStart": [
+              { "command": "/Users/peter/.superset/hooks/cursor-hook.sh Start" }
+            ],
+            "beforeShellExecution": [
+              { "command": "/Users/peter/.superset/hooks/cursor-hook.sh PermissionRequest" }
+            ]
+          }
+        }
+        """#.write(
+            to: cursorDir.appendingPathComponent("hooks.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["agent", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": cursorHome.path,
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/cursor",
+                "ZENTTY_CLI_BIN": "/opt/zentty/bin/zentty",
+            ],
+            expectsResponse: true,
+            tool: .cursor
+        )
+
+        _ = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        let data = try Data(contentsOf: cursorDir.appendingPathComponent("hooks.json", isDirectory: false))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try XCTUnwrap(object["hooks"] as? [String: Any])
+
+        let sessionStart = try XCTUnwrap(hooks["sessionStart"] as? [[String: Any]])
+        XCTAssertEqual(sessionStart.count, 2, "original sessionStart entry kept, Zentty entry appended")
+        XCTAssertEqual(sessionStart.first?["command"] as? String, "/Users/peter/.superset/hooks/cursor-hook.sh Start")
+        XCTAssertTrue((sessionStart.last?["command"] as? String ?? "").contains("/opt/zentty/bin/zentty"))
+
+        let beforeShell = try XCTUnwrap(hooks["beforeShellExecution"] as? [[String: Any]])
+        XCTAssertEqual(beforeShell.count, 1, "unmanaged event passed through untouched")
+        XCTAssertEqual(beforeShell.first?["command"] as? String, "/Users/peter/.superset/hooks/cursor-hook.sh PermissionRequest")
+    }
+
+    func test_agent_launch_bootstrap_cursor_install_is_idempotent_and_refreshes_cli_path() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-cursor-idempotent-runtime")
+        let cursorHome = try makeTemporaryDirectory(named: "agent-launch-cursor-idempotent-home")
+
+        func runPlan(cliPath: String) throws {
+            let request = AgentIPCRequest(
+                kind: .bootstrap,
+                arguments: ["agent", "hello"],
+                standardInput: nil,
+                environment: [
+                    "HOME": cursorHome.path,
+                    "ZENTTY_REAL_BINARY": "/usr/local/bin/cursor",
+                    "ZENTTY_CLI_BIN": cliPath,
+                ],
+                expectsResponse: true,
+                tool: .cursor
+            )
+            _ = try AgentLaunchBootstrap.makePlan(
+                request: request,
+                target: AgentIPCTarget(
+                    windowID: WindowID("window-main"),
+                    worklaneID: WorklaneID("worklane-main"),
+                    paneID: PaneID("pane-main")
+                ),
+                runtimeDirectoryURL: runtimeDirectory
+            )
+        }
+
+        try runPlan(cliPath: "/opt/old/zentty")
+        try runPlan(cliPath: "/opt/old/zentty")
+        try runPlan(cliPath: "/opt/new/zentty")
+
+        let hooksURL = cursorHome
+            .appendingPathComponent(".cursor", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+        let data = try Data(contentsOf: hooksURL)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try XCTUnwrap(object["hooks"] as? [String: Any])
+
+        for event in ["sessionStart", "sessionEnd", "stop"] {
+            let entries = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertEqual(entries.count, 1, "\(event) should have exactly one managed entry after three installs")
+            let command = try XCTUnwrap(entries.first?["command"] as? String)
+            XCTAssertTrue(command.contains("/opt/new/zentty"), "stale cliPath should have been replaced")
+            XCTAssertFalse(command.contains("/opt/old/zentty"))
+        }
+    }
+
+    // MARK: - CursorHooksInstaller
+
+    func test_cursor_hooks_installer_tolerates_jsonc_comments_and_trailing_commas() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-jsonc")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try #"""
+        {
+          // a comment — strict JSON would reject this
+          "version": 1,
+          "hooks": {
+            "sessionStart": [
+              { "command": "/custom/user-hook.sh", },
+            ],
+          },
+        }
+        """#.write(to: hooksURL, atomically: true, encoding: .utf8)
+
+        try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try Data(contentsOf: hooksURL)) as? [String: Any]
+        )
+        let hooks = try XCTUnwrap(object["hooks"] as? [String: Any])
+        let sessionStart = try XCTUnwrap(hooks["sessionStart"] as? [[String: Any]])
+        XCTAssertEqual(sessionStart.count, 2, "user entry preserved plus Zentty entry appended")
+        XCTAssertEqual(sessionStart.first?["command"] as? String, "/custom/user-hook.sh")
+        XCTAssertTrue((sessionStart.last?["command"] as? String ?? "").contains("/opt/zentty/bin/zentty"))
+    }
+
+    func test_cursor_hooks_installer_throws_on_unrecoverable_malformed_json() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-malformed")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try "{ this is not json at all }".write(to: hooksURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(
+            try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+        )
+
+        let unchanged = try String(contentsOf: hooksURL, encoding: .utf8)
+        XCTAssertEqual(unchanged, "{ this is not json at all }", "user file is never rewritten when unrecoverable")
+    }
+
+    func test_cursor_hooks_installer_skips_write_when_content_unchanged() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-skip")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+
+        try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+        let attributesBefore = try FileManager.default.attributesOfItem(atPath: hooksURL.path)
+        let mtimeBefore = try XCTUnwrap(attributesBefore[.modificationDate] as? Date)
+
+        // Ensure any mtime bump would be observable.
+        Thread.sleep(forTimeInterval: 1.1)
+        try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let attributesAfter = try FileManager.default.attributesOfItem(atPath: hooksURL.path)
+        let mtimeAfter = try XCTUnwrap(attributesAfter[.modificationDate] as? Date)
+        XCTAssertEqual(mtimeBefore, mtimeAfter, "identical re-install should not touch the file")
+    }
+
+    func test_cursor_hooks_installer_uninstall_preserves_user_entries_and_removes_managed_events() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-uninstall")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try #"""
+        {
+          "version": 1,
+          "hooks": {
+            "sessionStart": [
+              { "command": "/custom/start.sh" }
+            ],
+            "beforeShellExecution": [
+              { "command": "/custom/permission.sh" }
+            ]
+          }
+        }
+        """#.write(to: hooksURL, atomically: true, encoding: .utf8)
+        try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+
+        try CursorHooksInstaller.uninstall(at: hooksURL)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try Data(contentsOf: hooksURL)) as? [String: Any]
+        )
+        let hooks = try XCTUnwrap(object["hooks"] as? [String: Any])
+        let sessionStart = try XCTUnwrap(hooks["sessionStart"] as? [[String: Any]])
+        XCTAssertEqual(sessionStart.count, 1)
+        XCTAssertEqual(sessionStart.first?["command"] as? String, "/custom/start.sh")
+        XCTAssertNotNil(hooks["beforeShellExecution"], "unmanaged events passed through untouched")
+        XCTAssertNil(hooks["sessionEnd"], "managed event with no user entries should be removed")
+        XCTAssertNil(hooks["beforeSubmitPrompt"])
+        XCTAssertNil(hooks["stop"])
+    }
+
+    func test_cursor_hooks_installer_uninstall_deletes_file_when_nothing_user_owned_remains() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-uninstall-empty")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try CursorHooksInstaller.install(at: hooksURL, cliPath: "/opt/zentty/bin/zentty")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: hooksURL.path))
+
+        try CursorHooksInstaller.uninstall(at: hooksURL)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: hooksURL.path),
+            "file should be deleted when only Zentty-managed entries were present"
+        )
+    }
+
+    func test_cursor_hooks_installer_uninstall_on_missing_file_is_noop() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-uninstall-missing")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+
+        XCTAssertNoThrow(try CursorHooksInstaller.uninstall(at: hooksURL))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hooksURL.path))
+    }
+
+    func test_cursor_hooks_installer_uninstall_leaves_unrelated_jsonc_content_unchanged() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-uninstall-jsonc")
+        let hooksURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        // JSONC with comments + trailing commas — Zentty never installed anything.
+        let original = #"""
+        {
+          // user-managed hooks, no Zentty entries
+          "version": 1,
+          "hooks": {
+            "beforeShellExecution": [
+              { "command": "/custom/permission.sh", },
+            ],
+          },
+        }
+        """#
+        try original.write(to: hooksURL, atomically: true, encoding: .utf8)
+        let mtimeBefore = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: hooksURL.path)[.modificationDate] as? Date
+        )
+
+        Thread.sleep(forTimeInterval: 1.1)
+        try CursorHooksInstaller.uninstall(at: hooksURL)
+
+        let after = try String(contentsOf: hooksURL, encoding: .utf8)
+        XCTAssertEqual(after, original, "uninstall must not rewrite files it has no entries to remove from")
+        let mtimeAfter = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: hooksURL.path)[.modificationDate] as? Date
+        )
+        XCTAssertEqual(mtimeBefore, mtimeAfter, "mtime should be preserved when there is nothing to remove")
+    }
+
+    func test_cursor_hooks_installer_install_if_possible_treats_whitespace_env_as_blank() throws {
+        let directory = try makeTemporaryDirectory(named: "cursor-hooks-installer-blank-env")
+        let hooksURL = directory
+            .appendingPathComponent(".cursor", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+
+        // Whitespace-only HOME / cli path should be ignored — no file should be created.
+        CursorHooksInstaller.installIfPossible(environment: [
+            "HOME": "   ",
+            "ZENTTY_CLI_BIN": "\t",
+        ])
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: hooksURL.path),
+            "installIfPossible must reject whitespace-only env values"
+        )
     }
 
     func test_agent_launch_bootstrap_builds_gemini_system_settings_overlay_and_forces_notifications() throws {
@@ -4264,6 +4716,21 @@ final class AgentStatusSupportTests: XCTestCase {
             stderr: stderrText,
             logPath: logURL.path
         )
+    }
+
+    /// Wrapper dirs and the canonical binary filename each must contain so that
+    /// AgentStatusHelper accepts the bundle layout. For most tools dir == file name;
+    /// cursor wraps the Cursor CLI binary `cursor-agent` (the `cursor` name belongs to
+    /// the Cursor IDE launcher, which we do not want to intercept).
+    private var wrapperLayoutPairs: [(dirName: String, fileName: String)] {
+        [
+            ("claude", "claude"),
+            ("codex", "codex"),
+            ("copilot", "copilot"),
+            ("cursor", "cursor-agent"),
+            ("gemini", "gemini"),
+            ("opencode", "opencode"),
+        ]
     }
 
     private func makeTemporaryDirectory(named name: String) throws -> URL {

--- a/ZenttyLogicTests/PaneStripStoreTests.swift
+++ b/ZenttyLogicTests/PaneStripStoreTests.swift
@@ -2317,6 +2317,7 @@ final class PaneStripStoreTests: XCTestCase {
         if let allWrapperDirs = request.environmentVariables["ZENTTY_ALL_WRAPPER_BIN_DIRS"] {
             XCTAssertTrue(allWrapperDirs.contains("/Contents/Resources/bin/claude"))
             XCTAssertTrue(allWrapperDirs.contains("/Contents/Resources/bin/codex"))
+            XCTAssertTrue(allWrapperDirs.contains("/Contents/Resources/bin/cursor"))
             XCTAssertTrue(allWrapperDirs.contains("/Contents/Resources/bin/opencode"))
         }
         let path = try XCTUnwrap(request.environmentVariables["PATH"])

--- a/ZenttyResources/bin/cursor/agent
+++ b/ZenttyResources/bin/cursor/agent
@@ -1,0 +1,1 @@
+cursor-agent

--- a/ZenttyResources/bin/cursor/cursor-agent
+++ b/ZenttyResources/bin/cursor/cursor-agent
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export ZENTTY_AGENT_TOOL="cursor"
+exec "$(cd "$(dirname "$0")" && pwd)/../shared/zentty-agent-wrapper" "$@"

--- a/ZenttyResources/bin/shared/zentty-agent-wrapper
+++ b/ZenttyResources/bin/shared/zentty-agent-wrapper
@@ -4,8 +4,17 @@ set -euo pipefail
 
 tool_basename="${ZENTTY_AGENT_TOOL:-$(basename "$0")}"
 
+# Tools whose wrapper directory name differs from the real CLI binary name.
+# cursor's CLI ships as `cursor-agent` (`cursor` itself is the IDE launcher).
+real_binary_candidates() {
+    case "$tool_basename" in
+        cursor) printf '%s\n' cursor-agent ;;
+        *)      printf '%s\n' "$tool_basename" ;;
+    esac
+}
+
 find_real_binary() {
-    local self_dir wrapper_root path_entry
+    local self_dir wrapper_root path_entry candidate
     self_dir="$(cd "$(dirname "$0")" && pwd)"
     wrapper_root="$(cd "${self_dir}/.." && pwd)"
     local IFS=:
@@ -14,9 +23,11 @@ find_real_binary() {
         [[ "$path_entry" == "$self_dir" ]] && continue
         [[ "$path_entry" == "$wrapper_root" ]] && continue
         [[ "$path_entry" == "${wrapper_root}/${tool_basename}" ]] && continue
-        [[ -x "$path_entry/$tool_basename" ]] || continue
-        printf '%s\n' "$path_entry/$tool_basename"
-        return 0
+        while IFS= read -r candidate; do
+            [[ -x "$path_entry/$candidate" ]] || continue
+            printf '%s\n' "$path_entry/$candidate"
+            return 0
+        done < <(real_binary_candidates)
     done
     return 1
 }
@@ -31,13 +42,13 @@ zentty_cli_bin() {
     command -v zentty
 }
 
+if cli_bin="$(zentty_cli_bin 2>/dev/null)"; then
+    exec "$cli_bin" launch "$tool_basename" "$@"
+fi
+
 real_binary="$(find_real_binary)" || {
     echo "Error: $tool_basename not found in PATH" >&2
     exit 127
 }
-
-if cli_bin="$(zentty_cli_bin 2>/dev/null)"; then
-    exec "$cli_bin" launch "$tool_basename" "$@"
-fi
 
 exec "$real_binary" "$@"

--- a/project.yml
+++ b/project.yml
@@ -51,6 +51,8 @@ targets:
     sources:
       - path: ZenttyCLI
       - path: Zentty/AppState/Agent/AgentIPCProtocol.swift
+      - path: Zentty/AppState/Agent/CursorHooksInstaller.swift
+      - path: Zentty/AppState/Agent/JSONCRelaxedParse.swift
     dependencies:
       - package: ArgumentParser
         product: ArgumentParser
@@ -119,7 +121,7 @@ targets:
           mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
           rsync -a --delete "${RESOURCES_SRC}/bin/" "${RESOURCES_DST}/bin/"
           install -m 755 "${BUILT_PRODUCTS_DIR}/zentty" "${RESOURCES_DST}/bin/shared/zentty"
-          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/gemini/gemini" -o -path "*/opencode/opencode" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
+          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/gemini/gemini" -o -path "*/opencode/opencode" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
           rsync -a --delete "${RESOURCES_SRC}/shell-integration/" "${RESOURCES_DST}/shell-integration/"
           rsync -a --delete "${RESOURCES_SRC}/opencode/" "${RESOURCES_DST}/opencode/"
           rsync -a --delete "${RESOURCES_SRC}/ghostty/" "${RESOURCES_DST}/ghostty/"


### PR DESCRIPTION
## Summary

Adds first-class Zentty integration for the Cursor CLI agent (`cursor-agent` / `agent`), joining Claude, Codex, Copilot, Gemini, OpenCode, and Pi. Hooks auto-install into `~/.cursor/hooks.json` on first `zentty launch cursor`, and the pane sidebar mirrors agent lifecycle via `sessionStart` → `beforeSubmitPrompt` → `stop` → `sessionEnd`.

## Highlights

- **Wrapper split from the IDE launcher**: `/usr/local/bin/cursor` is Cursor's *IDE* launcher, not its CLI. `bin/cursor/cursor-agent` is the real wrapper, with `bin/cursor/agent` as a symlink. `AgentBootstrapTool.realBinaryNames` maps `.cursor` → `cursor-agent` so PATH resolution never accidentally launches the IDE.
- **Heredoc-safe hook command**: Cursor wraps the configured hook command in a shell heredoc before invoking `/bin/sh`, so a trailing `|| true` would swallow the JSON. The installed command is a bare `"<cli>" ipc agent-event --adapter=cursor`.
- **Idempotent, JSONC-tolerant installer** (`CursorHooksInstaller`): preserves existing user/superset hooks, refreshes stale cliPath in place, skips writes when content is unchanged, and surfaces malformed `hooks.json` with an actionable error instead of destroying user data.
- **Opt-in CLI management**: new top-level `zentty install cursor-hooks` and `zentty uninstall cursor-hooks` subcommands — uninstall is a true no-op on files that never contained Zentty entries. `ZENTTY_CURSOR_HOOKS_DISABLED=1` still bypasses the auto-install on launch.
- **Shared `JSONCRelaxedParse`** helper hoisted out of `AgentLaunchBootstrap` so the cursor and copilot paths use one tolerant parser.
- **Observability**: new `os.Logger` categories `CursorHookInstall`, `CursorAdapter`, `AgentEventBridge`, and `IPC`. Success chatter at `.debug`, skip/error at `.info`/`.error`. IPC argument interpolations marked `.private`.

## Test plan

- [x] `TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test -scheme Zentty -destination 'platform=macOS' -only-testing:ZenttyLogicTests` — all green.
- [x] `-only-testing:ZenttyIntegrationTests/AgentWrapperTests` — wrapper integration green.
- [x] In a Zentty pane, `agent` auto-installs hooks, sidebar flips `running` ↔ `idle` on prompt.
- [x] `zentty install cursor-hooks` and `zentty uninstall cursor-hooks` round-trip leaves the file untouched.
- [ ] Verify a pre-existing superset (or equivalent) hook entry survives install + uninstall.