### PR TITLE
feat: add first-class Kimi CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - **Resume your workspace** Zentty restores your worklanes on relaunch and can reopen agent sessions that were closed without finishing.
 - **Command palette** A fuzzy-searchable list of every action in the app, with your recent commands on top.
 - **Global search** Search inside the current pane or across every worklane with a single shortcut. Search without losing flow.
-- **Agent-aware.** Claude Code, Codex, Copilot CLI, Gemini CLI, and OpenCode report their status into the sidebar, so you see what they're doing, what they're asking, and when they need you, without switching panes.
+- **Agent-aware.** Claude Code, Codex, Copilot CLI, Gemini CLI, Kimi CLI, and OpenCode report their status into the sidebar, so you see what they're doing, what they're asking, and when they need you, without switching panes.
 - **Native Ghostty themes.** Zentty reads Ghostty themes directly, with a built-in picker, live preview, opacity, and blur. And if you've never installed
    Ghostty, the default experience is polished out of the box.
 - **Scriptable control** Interaction with worklanes or panes is scriptable via the embedded zentty CLI.
@@ -94,6 +94,8 @@ xcodebuild test -scheme Zentty -destination 'platform=macOS'
 Zentty bundles helper commands and environment variables for agent-aware workflows inside terminal panes.
 
 Hook configuration details are documented in [`docs/agent-hooks.md`](docs/agent-hooks.md).
+
+For Kimi specifically: do first-time auth with `kimi login` before using wrapped `kimi` inside Zentty. Zentty passthroughs Kimi's management commands directly to the real Kimi binary so login/logout keep using the default Kimi config. If you want a specific model, prefer `kimi --model <model-id>` or set `default_model` in `~/.kimi/config.toml`.
 
 ## Contributing
 

--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		9977740E789BA5C77113EBE4 /* CommandPaletteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A52BCC7DF27C885882E1630 /* CommandPaletteItem.swift */; };
 		9AEA030AF6FDAF94B9D2C2F7 /* ShortcutPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F75411847A448AECDBD466 /* ShortcutPreset.swift */; };
 		9D7CF3435362B15C9801875B /* PaneFocusHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54894343178398AA618315E4 /* PaneFocusHistory.swift */; };
+		9F1FB182E98F22E9F961AFE0 /* KimiHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1703E7CBF1D46D10D30281FC /* KimiHooksInstaller.swift */; };
 		A1D6E61EF7D669A5DAE672B0 /* SidebarStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02126D22E8F87E9B608D3CB9 /* SidebarStatusResolver.swift */; };
 		A313F3492C53D5CEF8A025F5 /* PaneFocusHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FE6D2FE3D589C3CEF772F6 /* PaneFocusHistoryTests.swift */; };
 		A31E0FD93C75D6B6059E3809 /* SidebarMotionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162C940D9CBDBBB47552AA86 /* SidebarMotionCoordinator.swift */; };
@@ -194,6 +195,7 @@
 		AFA0CB1E830B1464903655D6 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAD1A9BF197EEA6E4F636D7 /* MainWindowController.swift */; };
 		B1CBEE7D6E77065CD6C7C157 /* GhosttyConfigWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94E63B3F239632916F0BDE2 /* GhosttyConfigWriter.swift */; };
 		B22ACD7ABE0FB7A703022BC4 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C3FED8AC4087BC3A3CFCC755 /* Sparkle */; };
+		B32F85F567CD87464A187C57 /* KimiHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1703E7CBF1D46D10D30281FC /* KimiHooksInstaller.swift */; };
 		B38B8A60FEC01BE8385B6ED1 /* WorklaneGitContextResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D282138FCDC94B5D876B4D /* WorklaneGitContextResolverTests.swift */; };
 		BA9D0265E08E22F14A7E1C8A /* AgentWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5C60D4800BDD040F2D5B12 /* AgentWrapperTests.swift */; };
 		BB5B3519D7A006621A08A991 /* AppUpdateStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BF48FCF3548F4ABF45950F /* AppUpdateStateStore.swift */; };
@@ -328,6 +330,7 @@
 		163D5C0FE862CC71E8B354E2 /* SidebarVisibilityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityController.swift; sourceTree = "<group>"; };
 		1664363F6DAF16AD33EECA9D /* CommandPaletteResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteResultRow.swift; sourceTree = "<group>"; };
 		16FEAF3CA4E96E1EB18692E8 /* ShellMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellMetrics.swift; sourceTree = "<group>"; };
+		1703E7CBF1D46D10D30281FC /* KimiHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiHooksInstaller.swift; sourceTree = "<group>"; };
 		172E7F852B70FDD655345CF4 /* CodexTitlePromotionReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTitlePromotionReducer.swift; sourceTree = "<group>"; };
 		19801FEA1E31AE1665776372 /* OpenWithCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenWithCatalog.swift; sourceTree = "<group>"; };
 		1AE59622A5FC54739F5CC7AA /* ZenttyCLIDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenttyCLIDiscoveryTests.swift; sourceTree = "<group>"; };
@@ -815,6 +818,7 @@
 				D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */,
 				8E60EACABB7717596CA70DEE /* DiscoveryIPCHandler.swift */,
 				24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */,
+				1703E7CBF1D46D10D30281FC /* KimiHooksInstaller.swift */,
 				898B152AC508F23715DB2518 /* OpenCodeLiveThemeSync.swift */,
 				14B5D7C3DB0445971F90C314 /* OpenCodeOverlayLayout.swift */,
 				D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */,
@@ -1341,7 +1345,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/gemini/gemini\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
+			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/gemini/gemini\" -o -path \"*/kimi/kimi\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
 		};
 		C7055FCE2E5119172F74E931 /* Verify GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1507,6 +1511,7 @@
 				DE22542885A2BE164FE9090E /* KeyboardShortcutPreview.swift in Sources */,
 				066389EC522A58949B0D4A67 /* KeyboardShortcutPreviewView.swift in Sources */,
 				801ECD25402540B6F022BC3F /* KeyboardShortcutResolver.swift in Sources */,
+				9F1FB182E98F22E9F961AFE0 /* KimiHooksInstaller.swift in Sources */,
 				BC0AC74F991917A3539038CB /* LeadingChromeControlsBar.swift in Sources */,
 				064942C21BFD943CB5C8D46F /* LibghosttyAdapter.swift in Sources */,
 				6D1FE5590C9482B094476836 /* LibghosttyRuntime.swift in Sources */,
@@ -1656,6 +1661,7 @@
 				F5A26C1A6A89ED60FFF6F341 /* AgentToolLauncher.swift in Sources */,
 				BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */,
 				99451BC2B09FAA072A3B3A88 /* JSONCRelaxedParse.swift in Sources */,
+				B32F85F567CD87464A187C57 /* KimiHooksInstaller.swift in Sources */,
 				0353FE3D437A0B9370A6261B /* TopologyCLI.swift in Sources */,
 				C4F35E741F4A20FEA6E0B5C4 /* ZenttyCLI.swift in Sources */,
 			);

--- a/Zentty/AppState/Agent/AgentEventAdapters.swift
+++ b/Zentty/AppState/Agent/AgentEventAdapters.swift
@@ -129,6 +129,148 @@ extension AgentEventBridge {
     }
 }
 
+// MARK: - Kimi Adapter
+
+extension AgentEventBridge {
+    static func kimiAdapter(
+        data: Data,
+        environment: [String: String]
+    ) throws -> [AgentStatusPayload] {
+        let jsonObject = data.isEmpty ? [:] : (try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:])
+        guard let hookEventName = firstString(in: jsonObject, keys: ["hook_event_name", "hookEventName"]) else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+
+        guard currentTargetIfAvailable(from: environment) != nil else {
+            return []
+        }
+
+        let target = try currentTarget(from: environment)
+        let toolName = AgentTool.kimi.displayName
+        let sessionID = firstString(in: jsonObject, keys: ["session_id", "sessionId"])
+        let cwd = firstString(in: jsonObject, keys: ["cwd", "working_directory", "workingDirectory", "project_dir", "projectDir"])
+        let notificationType = firstString(in: jsonObject, keys: ["notification_type", "notificationType"])
+        let payloadToolName = firstString(in: jsonObject, keys: ["tool_name", "toolName"])
+        let toolInput = jsonObject["tool_input"] as? [String: Any]
+        let pid = parseAgentPID(from: environment, key: "ZENTTY_KIMI_PID")
+
+        switch hookEventName {
+        case "SessionStart":
+            var payloads: [AgentStatusPayload] = []
+            if let pid {
+                payloads.append(pidPayload(target: target, toolName: toolName, pid: pid, event: .attach, sessionID: sessionID))
+            }
+            payloads.append(lifecyclePayload(target: target, toolName: toolName, state: .starting, sessionID: sessionID, cwd: cwd))
+            return payloads
+
+        case "UserPromptSubmit":
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd)]
+
+        case "Stop":
+            return [lifecyclePayload(target: target, toolName: toolName, state: .idle, sessionID: sessionID, cwd: cwd)]
+
+        case "SessionEnd":
+            return [
+                AgentStatusPayload(
+                    windowID: target.windowID,
+                    worklaneID: target.worklaneID,
+                    paneID: target.paneID,
+                    signalKind: .lifecycle,
+                    state: nil,
+                    origin: .explicitHook,
+                    toolName: toolName,
+                    text: nil,
+                    sessionID: sessionID,
+                    artifactKind: nil,
+                    artifactLabel: nil,
+                    artifactURL: nil
+                ),
+                pidPayload(target: target, toolName: toolName, pid: nil, event: .clear, sessionID: sessionID),
+            ]
+
+        case "Notification":
+            guard notificationType?.caseInsensitiveCompare("permission_prompt") == .orderedSame else {
+                return []
+            }
+            let message = AgentInteractionClassifier.trimmed(
+                firstString(in: jsonObject, keys: ["title", "body", "message", "text"])
+            ) ?? "Kimi needs your approval"
+            return [AgentStatusPayload(
+                windowID: target.windowID,
+                worklaneID: target.worklaneID,
+                paneID: target.paneID,
+                state: .needsInput,
+                origin: .explicitHook,
+                toolName: toolName,
+                text: message,
+                lifecycleEvent: .update,
+                interactionKind: .approval,
+                confidence: .explicit,
+                sessionID: sessionID,
+                artifactKind: nil,
+                artifactLabel: nil,
+                artifactURL: nil,
+                agentWorkingDirectory: cwd
+            )]
+
+        case "PreToolUse":
+            guard payloadToolName == "AskUserQuestion" else {
+                return []
+            }
+            let question = kimiQuestionText(from: toolInput) ?? "Kimi is waiting for your input"
+            return [AgentStatusPayload(
+                windowID: target.windowID,
+                worklaneID: target.worklaneID,
+                paneID: target.paneID,
+                state: .needsInput,
+                origin: .explicitHook,
+                toolName: toolName,
+                text: question,
+                lifecycleEvent: .update,
+                interactionKind: .question,
+                confidence: .explicit,
+                sessionID: sessionID,
+                artifactKind: nil,
+                artifactLabel: nil,
+                artifactURL: nil,
+                agentWorkingDirectory: cwd
+            )]
+
+        case "PostToolUse":
+            guard payloadToolName == "AskUserQuestion" else {
+                return []
+            }
+            return [AgentStatusPayload(
+                windowID: target.windowID,
+                worklaneID: target.worklaneID,
+                paneID: target.paneID,
+                state: .running,
+                origin: .explicitHook,
+                toolName: toolName,
+                text: nil,
+                lifecycleEvent: .update,
+                interactionKind: .none,
+                confidence: .explicit,
+                sessionID: sessionID,
+                artifactKind: nil,
+                artifactLabel: nil,
+                artifactURL: nil,
+                agentWorkingDirectory: cwd
+            )]
+
+        default:
+            return []
+        }
+    }
+
+    private static func kimiQuestionText(from toolInput: [String: Any]?) -> String? {
+        guard let toolInput else {
+            return nil
+        }
+        return firstString(in: toolInput, keys: ["question", "prompt", "message", "title"])
+    }
+}
+
 // MARK: - Cursor Adapter
 
 extension AgentEventBridge {

--- a/Zentty/AppState/Agent/AgentEventBridge.swift
+++ b/Zentty/AppState/Agent/AgentEventBridge.swift
@@ -67,6 +67,8 @@ enum AgentEventBridge {
                 payloads = try geminiAdapter(data: inputData, environment: environment)
             case "cursor":
                 payloads = try cursorAdapter(data: inputData, environment: environment)
+            case "kimi":
+                payloads = try kimiAdapter(data: inputData, environment: environment)
             case .none:
                 let input = try parseInput(inputData)
                 payloads = try makePayloads(from: input, environment: environment)

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -18,6 +18,7 @@ enum AgentBootstrapTool: String, Codable, Equatable {
     case copilot
     case cursor
     case gemini
+    case kimi
     case opencode
     case pi
 
@@ -28,7 +29,7 @@ enum AgentBootstrapTool: String, Codable, Equatable {
         switch self {
         case .cursor:
             return ["cursor-agent"]
-        case .claude, .codex, .copilot, .gemini, .opencode, .pi:
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi:
             return [rawValue]
         }
     }

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -69,6 +69,15 @@ enum AgentLaunchBootstrap {
                 runtimeDirectoryURL: runtimeDirectoryURL,
                 fileManager: fileManager
             )
+        case .kimi:
+            return try kimiPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                environment: environment,
+                target: target,
+                runtimeDirectoryURL: runtimeDirectoryURL,
+                fileManager: fileManager
+            )
         case .opencode:
             return try opencodePlan(
                 executablePath: resolvedOpenCodeExecutablePath(
@@ -161,6 +170,53 @@ enum AgentLaunchBootstrap {
                     standardInput: sessionStartJSON
                 ),
             ]
+        )
+    }
+
+    private static func kimiPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        target: AgentIPCTarget,
+        runtimeDirectoryURL: URL,
+        fileManager: FileManager
+    ) throws -> AgentLaunchPlan {
+        if environment["ZENTTY_KIMI_HOOKS_DISABLED"] == "1" {
+            return directPlan(executablePath: executablePath, arguments: arguments)
+        }
+
+        guard let cliPath = environment["ZENTTY_CLI_BIN"]?.nilIfBlank else {
+            return AgentLaunchPlan(
+                executablePath: executablePath,
+                arguments: arguments,
+                setEnvironment: [
+                    "ZENTTY_AGENT_TOOL": "kimi",
+                ],
+                unsetEnvironment: [],
+                preLaunchActions: []
+            )
+        }
+
+        let (forwardedArguments, configSource) = parseKimiConfig(arguments: arguments, environment: environment)
+        let overlayDirectoryURL = try prepareToolDirectory(
+            tool: .kimi,
+            target: target,
+            runtimeDirectoryURL: runtimeDirectoryURL,
+            fileManager: fileManager
+        )
+        let overlayConfigURL = overlayDirectoryURL.appendingPathComponent("config.toml", isDirectory: false)
+        let existingConfig = try kimiConfigContents(from: configSource, fileManager: fileManager)
+        let mergedConfig = try KimiHooksInstaller.mergedConfigText(existingConfig: existingConfig, cliPath: cliPath)
+        try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
+
+        return AgentLaunchPlan(
+            executablePath: executablePath,
+            arguments: ["--config-file", overlayConfigURL.path] + forwardedArguments,
+            setEnvironment: [
+                "ZENTTY_AGENT_TOOL": "kimi",
+            ],
+            unsetEnvironment: [],
+            preLaunchActions: []
         )
     }
 
@@ -567,6 +623,32 @@ enum AgentLaunchBootstrap {
         return overlaySettingsURL.path
     }
 
+    private static func kimiConfigContents(
+        from source: KimiConfigSource,
+        fileManager: FileManager
+    ) throws -> String {
+        switch source {
+        case let .inline(configText):
+            return configText
+        case let .defaultFile(url):
+            guard fileManager.fileExists(atPath: url.path) else {
+                return ""
+            }
+            return try String(contentsOf: url, encoding: .utf8)
+        case let .explicitFile(url):
+            guard fileManager.fileExists(atPath: url.path) else {
+                throw CocoaError(
+                    .fileNoSuchFile,
+                    userInfo: [
+                        NSFilePathErrorKey: url.path,
+                        NSLocalizedDescriptionKey: "Kimi config file not found at \(url.path)",
+                    ]
+                )
+            }
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+    }
+
     private static func prepareToolDirectory(
         tool: AgentBootstrapTool,
         target: AgentIPCTarget,
@@ -850,6 +932,47 @@ enum AgentLaunchBootstrap {
         return false
     }
 
+    private static func parseKimiConfig(
+        arguments: [String],
+        environment: [String: String]
+    ) -> (forwardedArguments: [String], source: KimiConfigSource) {
+        var forwarded = [String]()
+        var iterator = arguments.makeIterator()
+        var source: KimiConfigSource = .defaultFile(KimiHooksInstaller.defaultUserConfigURL(
+            home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory()
+        ))
+
+        while let argument = iterator.next() {
+            switch argument {
+            case "--config-file":
+                if let value = iterator.next() {
+                    source = .explicitFile(URL(fileURLWithPath: value, isDirectory: false))
+                } else {
+                    forwarded.append(argument)
+                }
+            case let value where value.hasPrefix("--config-file="):
+                source = .explicitFile(
+                    URL(
+                        fileURLWithPath: String(value.dropFirst("--config-file=".count)),
+                        isDirectory: false
+                    )
+                )
+            case "--config":
+                if let value = iterator.next() {
+                    source = .inline(value)
+                } else {
+                    forwarded.append(argument)
+                }
+            case let value where value.hasPrefix("--config="):
+                source = .inline(String(value.dropFirst("--config=".count)))
+            default:
+                forwarded.append(argument)
+            }
+        }
+
+        return (forwarded, source)
+    }
+
     private static func directPlan(
         executablePath: String,
         arguments: [String],
@@ -1020,6 +1143,12 @@ enum AgentLaunchBootstrap {
 
         return config
     }
+}
+
+private enum KimiConfigSource {
+    case defaultFile(URL)
+    case explicitFile(URL)
+    case inline(String)
 }
 
 private extension String {

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -6,6 +6,7 @@ enum AgentTool: Equatable, Sendable {
     case copilot
     case cursor
     case gemini
+    case kimi
     case openCode
     case pi
     case custom(String)
@@ -22,6 +23,8 @@ enum AgentTool: Equatable, Sendable {
             return "Cursor"
         case .gemini:
             return "Gemini"
+        case .kimi:
+            return "Kimi"
         case .openCode:
             return "OpenCode"
         case .pi:
@@ -51,6 +54,9 @@ enum AgentTool: Equatable, Sendable {
         if normalized.contains("gemini") {
             return .gemini
         }
+        if normalized.contains("kimi") {
+            return .kimi
+        }
         if normalized.contains("opencode") || normalized.contains("open code") {
             return .openCode
         }
@@ -78,6 +84,9 @@ enum AgentTool: Equatable, Sendable {
         }
         if normalized.contains("gemini") {
             return .gemini
+        }
+        if normalized.contains("kimi") {
+            return .kimi
         }
         if normalized.contains("opencode") || normalized.contains("open code") {
             return .openCode

--- a/Zentty/AppState/Agent/AgentStatusHelper.swift
+++ b/Zentty/AppState/Agent/AgentStatusHelper.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 enum AgentStatusHelper {
-    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "gemini", "opencode", "pi"]
+    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"]
     private static let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
     static func runIfNeeded(arguments: [String], environment: [String: String]) -> Int32? {
@@ -56,6 +56,7 @@ enum AgentStatusHelper {
                     "copilot/copilot",
                     "cursor/cursor-agent",
                     "gemini/gemini",
+                    "kimi/kimi",
                     "opencode/opencode",
                     "pi/pi",
                     "shared/zentty-agent-wrapper",
@@ -66,6 +67,7 @@ enum AgentStatusHelper {
                     "copilot/copilot",
                     "cursor/cursor-agent",
                     "gemini/gemini",
+                    "kimi/kimi",
                     "opencode/opencode",
                     "pi/pi",
                     "shared/zentty-agent-wrapper",

--- a/Zentty/AppState/Agent/KimiHooksInstaller.swift
+++ b/Zentty/AppState/Agent/KimiHooksInstaller.swift
@@ -156,8 +156,14 @@ enum KimiHooksInstaller {
     }
 
     private static func managedBlockRange(in source: String) throws -> Range<String.Index>? {
-        let beginRange = source.range(of: beginMarker)
-        let endRange = source.range(of: endMarker)
+        let beginRange = source.range(
+            of: #"(?m)^### BEGIN ZENTTY KIMI HOOKS[ \t]*$"#,
+            options: .regularExpression
+        )
+        let endRange = source.range(
+            of: #"(?m)^### END ZENTTY KIMI HOOKS[ \t]*$"#,
+            options: .regularExpression
+        )
 
         switch (beginRange, endRange) {
         case (nil, nil):

--- a/Zentty/AppState/Agent/KimiHooksInstaller.swift
+++ b/Zentty/AppState/Agent/KimiHooksInstaller.swift
@@ -1,0 +1,522 @@
+import Foundation
+import os
+
+private let kimiInstallerLogger = Logger(subsystem: "be.zenjoy.zentty", category: "KimiHookInstall")
+
+enum KimiHooksInstaller {
+    static let beginMarker = "### BEGIN ZENTTY KIMI HOOKS"
+    static let endMarker = "### END ZENTTY KIMI HOOKS"
+    private static let styleMarkerPrefix = "# zentty-managed-style = "
+    private static let emptyHooksPlaceholder = "hooks = []"
+
+    static func defaultUserConfigURL(
+        home: String = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+    ) -> URL {
+        URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".kimi", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+    }
+
+    static func install(
+        at configURL: URL,
+        cliPath: String,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let existing = fileManager.fileExists(atPath: configURL.path)
+            ? try String(contentsOf: configURL, encoding: .utf8)
+            : ""
+
+        let updated = try mergedConfigText(existingConfig: existing, cliPath: cliPath)
+
+        if existing == updated {
+            return
+        }
+
+        try updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    static func uninstall(
+        at configURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.fileExists(atPath: configURL.path) else {
+            return
+        }
+
+        let existing = try String(contentsOf: configURL, encoding: .utf8)
+        let updated = try replacingManagedBlock(in: existing, with: uninstallReplacement(for: existing))
+
+        if updated.isEmpty {
+            try fileManager.removeItem(at: configURL)
+            return
+        }
+
+        if updated == existing {
+            return
+        }
+
+        try updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    static func installIfPossible(
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) {
+        guard let cliPath = environment["ZENTTY_CLI_BIN"]?.nonBlank else {
+            kimiInstallerLogger.debug("Skipping kimi hook install: ZENTTY_CLI_BIN is not set")
+            return
+        }
+        guard let home = environment["HOME"]?.nonBlank else {
+            kimiInstallerLogger.debug("Skipping kimi hook install: HOME is not set")
+            return
+        }
+
+        let configURL = defaultUserConfigURL(home: home)
+        do {
+            try install(at: configURL, cliPath: cliPath, fileManager: fileManager)
+            kimiInstallerLogger.info("Installed Zentty Kimi hooks in \(configURL.path, privacy: .public)")
+        } catch {
+            kimiInstallerLogger.error(
+                "Failed to install Kimi hooks at \(configURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    static func mergedConfigText(existingConfig: String, cliPath: String) throws -> String {
+        let style = installationStyle(for: existingConfig)
+        return try installedConfig(from: existingConfig, cliPath: cliPath, style: style)
+    }
+
+    private static func replacingManagedBlock(
+        in source: String,
+        with replacement: String?
+    ) throws -> String {
+        let range = try removableManagedBlockRange(in: source)
+        let replacementText = replacement ?? ""
+
+        if let range {
+            let updated = source.replacingCharacters(in: range, with: replacementText)
+            return updated.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard let replacement else {
+            return source
+        }
+
+        if source.isEmpty {
+            return replacement
+        }
+
+        let separator = source.hasSuffix("\n") ? "\n" : "\n\n"
+        return source + separator + replacement
+    }
+
+    private static func installedConfig(
+        from source: String,
+        cliPath: String,
+        style: HookConfigStyle
+    ) throws -> String {
+        if style == .inlineArray {
+            if let blockRange = try managedBlockRange(in: source) {
+                let blockText = String(source[blockRange])
+                let replacement: String
+                if blockText.contains("hooks = [") {
+                    replacement = managedInlineArrayAssignment(cliPath: cliPath)
+                } else {
+                    replacement = managedInlineHookEntriesBlock(
+                        cliPath: cliPath,
+                        trailingComma: inlineHooksArrayHasElements(
+                            afterManagedBlockRange: blockRange,
+                            in: source
+                        )
+                    )
+                }
+                return source.replacingCharacters(in: blockRange, with: replacement)
+            }
+
+            if let replacedPlaceholder = replacingEmptyHooksPlaceholder(
+                in: source,
+                with: managedInlineArrayAssignment(cliPath: cliPath)
+            ) {
+                return replacedPlaceholder
+            }
+
+            if let insertedInlineHooks = insertingManagedInlineHooks(in: source, cliPath: cliPath) {
+                return insertedInlineHooks
+            }
+        }
+
+        let replacement = managedHookBlock(cliPath: cliPath, style: style)
+        return try replacingManagedBlock(in: source, with: replacement)
+    }
+
+    private static func managedBlockRange(in source: String) throws -> Range<String.Index>? {
+        let beginRange = source.range(of: beginMarker)
+        let endRange = source.range(of: endMarker)
+
+        switch (beginRange, endRange) {
+        case (nil, nil):
+            return nil
+        case (.some, nil), (nil, .some):
+            throw CocoaError(
+                .fileReadCorruptFile,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "Kimi config contains an incomplete Zentty-managed block; remove it or run `zentty uninstall kimi-hooks` after fixing the file"]
+            )
+        case let (beginRange?, endRange?):
+            guard beginRange.lowerBound <= endRange.lowerBound else {
+                throw CocoaError(
+                    .fileReadCorruptFile,
+                    userInfo: [NSLocalizedDescriptionKey:
+                        "Kimi config contains an invalid Zentty-managed block ordering; fix \(defaultUserConfigURL().path) and retry"]
+                )
+            }
+
+            var upperBound = endRange.upperBound
+            if upperBound < source.endIndex, source[upperBound] == "\n" {
+                upperBound = source.index(after: upperBound)
+            }
+            while upperBound < source.endIndex {
+                let next = source[upperBound]
+                guard next == "\n" else { break }
+                upperBound = source.index(after: upperBound)
+            }
+            return beginRange.lowerBound..<upperBound
+        }
+    }
+
+    private static func managedHookBlock(cliPath: String, style: HookConfigStyle) -> String {
+        let command = tomlEscapeBasicString(
+            "\"\(shellEscapeDoubleQuoted(cliPath))\" ipc agent-event --adapter=kimi"
+        )
+        switch style {
+        case .arrayTables:
+            return """
+            \(beginMarker)
+            \(styleMarkerPrefix)\(style.rawValue)
+            [[hooks]]
+            event = "SessionStart"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "SessionEnd"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "UserPromptSubmit"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "Stop"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "Notification"
+            matcher = "permission_prompt"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "PreToolUse"
+            matcher = "AskUserQuestion"
+            command = "\(command)"
+
+            [[hooks]]
+            event = "PostToolUse"
+            matcher = "AskUserQuestion"
+            command = "\(command)"
+            \(endMarker)
+            """
+        case .inlineArray:
+            return managedInlineArrayAssignment(cliPath: cliPath)
+        }
+    }
+
+    private static func managedInlineArrayAssignment(cliPath: String) -> String {
+        """
+        \(beginMarker)
+        \(styleMarkerPrefix)\(HookConfigStyle.inlineArray.rawValue)
+        hooks = [
+        \(inlineHookEntries(cliPath: cliPath, trailingComma: false))
+        ]
+        \(endMarker)
+        """
+    }
+
+    private static func managedInlineHookEntriesBlock(
+        cliPath: String,
+        trailingComma: Bool
+    ) -> String {
+        """
+        \(beginMarker)
+        \(styleMarkerPrefix)\(HookConfigStyle.inlineArray.rawValue)
+        \(inlineHookEntries(cliPath: cliPath, trailingComma: trailingComma))
+        \(endMarker)
+        """
+    }
+
+    private static func inlineHookEntries(
+        cliPath: String,
+        trailingComma: Bool
+    ) -> String {
+        let command = tomlEscapeBasicString(
+            "\"\(shellEscapeDoubleQuoted(cliPath))\" ipc agent-event --adapter=kimi"
+        )
+        let trailingCommaSuffix = trailingComma ? "," : ""
+        return """
+          { event = "SessionStart", command = "\(command)" },
+          { event = "SessionEnd", command = "\(command)" },
+          { event = "UserPromptSubmit", command = "\(command)" },
+          { event = "Stop", command = "\(command)" },
+          { event = "Notification", matcher = "permission_prompt", command = "\(command)" },
+          { event = "PreToolUse", matcher = "AskUserQuestion", command = "\(command)" },
+          { event = "PostToolUse", matcher = "AskUserQuestion", command = "\(command)" }\(trailingCommaSuffix)
+        """
+    }
+
+    private static func installationStyle(for source: String) -> HookConfigStyle {
+        if let existingStyle = existingManagedBlockStyle(in: source) {
+            return existingStyle
+        }
+        if inlineHooksArrayContext(in: source) != nil {
+            return .inlineArray
+        }
+        return .arrayTables
+    }
+
+    private static func existingManagedBlockStyle(in source: String) -> HookConfigStyle? {
+        guard let blockRange = try? managedBlockRange(in: source) else {
+            return nil
+        }
+        let blockText = source[blockRange]
+        for style in HookConfigStyle.allCases {
+            if blockText.contains("\(styleMarkerPrefix)\(style.rawValue)") {
+                return style
+            }
+        }
+        return nil
+    }
+
+    private static func insertingManagedInlineHooks(
+        in source: String,
+        cliPath: String
+    ) -> String? {
+        guard let context = inlineHooksArrayContext(in: source) else {
+            return nil
+        }
+
+        let insertion = "\n" + managedInlineHookEntriesBlock(
+            cliPath: cliPath,
+            trailingComma: context.hasElements
+        ) + "\n"
+        var updated = source
+        updated.insert(contentsOf: insertion, at: source.index(after: context.openBracketIndex))
+        return updated
+    }
+
+    private static func inlineHooksArrayHasElements(
+        afterManagedBlockRange blockRange: Range<String.Index>,
+        in source: String
+    ) -> Bool {
+        guard let context = inlineHooksArrayContext(in: source) else {
+            return false
+        }
+        let trailingBodyRange = blockRange.upperBound..<context.bodyRange.upperBound
+        return inlineHooksBodyHasElements(in: source[trailingBodyRange])
+    }
+
+    private static func inlineHooksArrayContext(in source: String) -> InlineHooksArrayContext? {
+        guard let assignmentRange = source.range(
+            of: #"(?m)^[ \t]*hooks[ \t]*="#,
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+
+        var index = assignmentRange.upperBound
+        while index < source.endIndex, source[index].isWhitespace {
+            index = source.index(after: index)
+        }
+        guard index < source.endIndex, source[index] == "[" else {
+            return nil
+        }
+
+        let openBracketIndex = index
+        var current = index
+        var bracketDepth = 0
+        var inString = false
+        var inComment = false
+        var escaped = false
+
+        while current < source.endIndex {
+            let character = source[current]
+            if inComment {
+                if character == "\n" {
+                    inComment = false
+                }
+            } else if inString {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+            } else {
+                switch character {
+                case "#":
+                    inComment = true
+                case "\"":
+                    inString = true
+                case "[":
+                    bracketDepth += 1
+                case "]":
+                    bracketDepth -= 1
+                    if bracketDepth == 0 {
+                        let bodyStart = source.index(after: openBracketIndex)
+                        let bodyRange = bodyStart..<current
+                        return InlineHooksArrayContext(
+                            assignmentRange: assignmentRange.lowerBound..<source.index(after: current),
+                            openBracketIndex: openBracketIndex,
+                            bodyRange: bodyRange,
+                            hasElements: inlineHooksBodyHasElements(in: source[bodyRange])
+                        )
+                    }
+                default:
+                    break
+                }
+            }
+
+            current = source.index(after: current)
+        }
+
+        return nil
+    }
+
+    private static func inlineHooksBodyHasElements(in body: Substring) -> Bool {
+        var inString = false
+        var inComment = false
+        var escaped = false
+
+        for character in body {
+            if inComment {
+                if character == "\n" {
+                    inComment = false
+                }
+                continue
+            }
+
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            switch character {
+            case "#":
+                inComment = true
+            case "\"":
+                inString = true
+            case "{":
+                return true
+            default:
+                continue
+            }
+        }
+
+        return false
+    }
+
+    private struct InlineHooksArrayContext {
+        let assignmentRange: Range<String.Index>
+        let openBracketIndex: String.Index
+        let bodyRange: Range<String.Index>
+        let hasElements: Bool
+    }
+
+    private static func uninstallReplacement(for source: String) -> String? {
+        guard let blockRange = try? managedBlockRange(in: source),
+              source[blockRange].contains("\(styleMarkerPrefix)\(HookConfigStyle.inlineArray.rawValue)") else {
+            return nil
+        }
+
+        guard source[blockRange].contains("hooks = [") else {
+            return nil
+        }
+
+        return emptyHooksPlaceholder
+    }
+
+    private static func removableManagedBlockRange(in source: String) throws -> Range<String.Index>? {
+        guard let blockRange = try managedBlockRange(in: source) else {
+            return nil
+        }
+
+        let blockText = source[blockRange]
+        guard blockText.contains("\(styleMarkerPrefix)\(HookConfigStyle.inlineArray.rawValue)"),
+              !blockText.contains("hooks = ["),
+              blockRange.lowerBound > source.startIndex else {
+            return blockRange
+        }
+
+        let precedingIndex = source.index(before: blockRange.lowerBound)
+        guard source[precedingIndex] == "\n" else {
+            return blockRange
+        }
+
+        return precedingIndex..<blockRange.upperBound
+    }
+
+    private static func hasEmptyHooksPlaceholder(in source: String) -> Bool {
+        source
+            .split(whereSeparator: \.isNewline)
+            .contains { $0.trimmingCharacters(in: .whitespaces) == emptyHooksPlaceholder }
+    }
+
+    private static func replacingEmptyHooksPlaceholder(in source: String, with replacement: String) -> String? {
+        let lines = source.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        guard let index = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == emptyHooksPlaceholder
+        }) else {
+            return nil
+        }
+
+        var updatedLines = lines.map(String.init)
+        updatedLines[index] = replacement
+        return updatedLines.joined(separator: "\n")
+    }
+
+    private static func shellEscapeDoubleQuoted(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
+    }
+
+    private static func tomlEscapeBasicString(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
+
+private enum HookConfigStyle: String, CaseIterable {
+    case arrayTables = "array-tables"
+    case inlineArray = "inline-array"
+}
+
+private extension String {
+    var nonBlank: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
+}

--- a/Zentty/AppState/Agent/PaneAgentReducer.swift
+++ b/Zentty/AppState/Agent/PaneAgentReducer.swift
@@ -263,6 +263,36 @@ struct PaneAgentReducerState: Equatable, Sendable {
         return true
     }
 
+    @discardableResult
+    mutating func markExplicitKimiSessionIdleFromUserInterrupt(now: Date = Date()) -> Bool {
+        let candidateSessions = sessionsByID.values.filter { session in
+            session.tool == .kimi
+                && session.source == .explicit
+                && session.origin != .shell
+                && (
+                    session.state == .running
+                        || (session.state == .starting && !session.interactionKind.requiresHumanAttention)
+                )
+        }
+        guard let sessionID = candidateSessions.sorted(by: Self.preferred(lhs:rhs:)).first?.sessionID,
+              var session = sessionsByID[sessionID]
+        else {
+            return false
+        }
+        let previousState = session.state
+
+        session.state = .idle
+        session.text = nil
+        session.interactionKind = .none
+        session.completionCandidateDeadline = nil
+        session.idleVisibleUntil = now.addingTimeInterval(Self.idleVisibilityWindow)
+        session.unresolvedStopVisibleUntil = nil
+        session.updatedAt = now
+        session.hasObservedRunning = session.hasObservedRunning || previousState == .running
+        sessionsByID[sessionID] = session
+        return true
+    }
+
     func reducedStatus(now: Date = Date()) -> PaneAgentStatus? {
         let sessions = sessionsByID.values.filter { session in
             if session.state == .idle,

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -756,6 +756,8 @@ enum PanePresentationNormalizer {
             return ["cursor"].contains(normalized)
         case .gemini:
             return ["gemini", "gemini cli"].contains(normalized)
+        case .kimi:
+            return ["kimi", "kimi cli"].contains(normalized)
         case .openCode:
             return ["opencode", "open code"].contains(normalized)
         case .pi:

--- a/Zentty/AppState/WorklaneStore+AgentStatus.swift
+++ b/Zentty/AppState/WorklaneStore+AgentStatus.swift
@@ -16,6 +16,7 @@ extension WorklaneStore {
 
         var worklane = worklanes[worklaneIndex]
         let previousWorklane = worklane
+        var suppressReadyAfterRecompute = false
         switch event {
         case .shellReady:
             break
@@ -77,6 +78,23 @@ extension WorklaneStore {
                 now: now,
                 in: &worklane
             )
+        case .userInterrupted:
+            let now = Date()
+            var auxiliaryState = worklane.auxiliaryStateByPaneID[paneID, default: PaneAuxiliaryState()]
+            auxiliaryState.terminalProgress = nil
+            auxiliaryState.agentReducerState = Self.seededReducerState(
+                auxiliaryState.agentReducerState,
+                from: auxiliaryState.agentStatus
+            )
+            if auxiliaryState.agentReducerState.markExplicitKimiSessionIdleFromUserInterrupt(now: now) {
+                auxiliaryState.agentStatus = Self.hydratedStatus(
+                    auxiliaryState.agentReducerState.reducedStatus(),
+                    existingStatus: auxiliaryState.agentStatus,
+                    payloadWorkingDirectory: nil
+                )
+                worklane.auxiliaryStateByPaneID[paneID] = auxiliaryState
+                suppressReadyAfterRecompute = true
+            }
         case .commandFinished:
             worklane.auxiliaryStateByPaneID[paneID]?.terminalProgress = nil
             let existingStatus = worklane.auxiliaryStateByPaneID[paneID]?.agentStatus
@@ -147,6 +165,9 @@ extension WorklaneStore {
         }
 
         recomputePresentation(for: paneID, in: &worklane)
+        if suppressReadyAfterRecompute {
+            clearReadyStatusIfNeeded(for: paneID, in: &worklane)
+        }
         worklanes[worklaneIndex] = worklane
         let impacts = auxiliaryInvalidation(for: paneID, previousWorklane: previousWorklane, nextWorklane: worklane)
         if !impacts.isEmpty {

--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -578,6 +578,7 @@ extension WorklaneStore {
             case .copilot: return "gh copilot"
             case .cursor: return "cursor"
             case .gemini: return "gemini"
+            case .kimi: return "kimi"
             case .openCode: return "opencode"
             case .pi: return "pi"
             case .custom(let name): return name

--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -369,6 +369,12 @@ enum AgentResumeCommandBuilder {
             return "copilot --resume=\(sessionID)"
         case .gemini:
             return "gemini --resume"
+        case .kimi:
+            guard let sessionID = validatedKimiSessionID(from: draft.sessionID) else {
+                logRejectedSessionID(for: draft)
+                return nil
+            }
+            return "kimi -r \(sessionID)"
         case .cursor:
             return nil
         case .pi:
@@ -411,6 +417,13 @@ enum AgentResumeCommandBuilder {
     }
 
     private static func validatedCopilotSessionID(from sessionID: String) -> String? {
+        guard let uuid = UUID(uuidString: sessionID) else {
+            return nil
+        }
+        return uuid.uuidString.lowercased()
+    }
+
+    private static func validatedKimiSessionID(from sessionID: String) -> String? {
         guard let uuid = UUID(uuidString: sessionID) else {
             return nil
         }

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -853,6 +853,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let shouldEmitUserSubmittedInput = Self.shouldEmitUserSubmittedInput(for: event)
         let shouldEmitUserEditedInput = Self.shouldEmitUserEditedInput(for: event)
+        let shouldEmitUserInterrupted = Self.shouldEmitUserInterrupted(for: event)
         if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) && !hasMarkedText() {
             let controlText = event.charactersIgnoringModifiers ?? event.characters
             let handled = surfaceController.sendKey(
@@ -867,6 +868,9 @@ final class LibghosttyView: NSView, TerminalFocusReporting {
                 }
                 if shouldEmitUserEditedInput {
                     onLocalEventDidOccur?(.userEditedInput)
+                }
+                if shouldEmitUserInterrupted {
+                    onLocalEventDidOccur?(.userInterrupted)
                 }
                 return
             }
@@ -886,6 +890,9 @@ final class LibghosttyView: NSView, TerminalFocusReporting {
         }
         if shouldEmitUserEditedInput {
             onLocalEventDidOccur?(.userEditedInput)
+        }
+        if shouldEmitUserInterrupted {
+            onLocalEventDidOccur?(.userInterrupted)
         }
         keyTextAccumulator = ""
     }
@@ -1018,6 +1025,10 @@ final class LibghosttyView: NSView, TerminalFocusReporting {
         }
 
         return sanitizedInputText(characters) != nil
+    }
+
+    private static func shouldEmitUserInterrupted(for event: NSEvent) -> Bool {
+        TerminalInterruptKeyRecognizer.matchesUserInterrupt(event)
     }
 
     private static func shouldDeferToSystemWindowTiling(for event: NSEvent) -> Bool {

--- a/Zentty/Terminal/TerminalAdapter.swift
+++ b/Zentty/Terminal/TerminalAdapter.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 
 enum TerminalSurfaceContext: Equatable, Sendable {
     case window
@@ -86,9 +87,35 @@ enum TerminalEvent: Equatable, Sendable {
     case progressReport(TerminalProgressReport)
     case commandFinished(exitCode: Int?, durationNanoseconds: UInt64)
     case desktopNotification(TerminalDesktopNotification)
+    case userInterrupted
     case userEditedInput
     case userSubmittedInput
     case surfaceClosed
+}
+
+enum TerminalInterruptKeyRecognizer {
+    static func matchesUserInterrupt(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown, !event.isARepeat else {
+            return false
+        }
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags == [.control] {
+            let observedCharacters = [event.characters, event.charactersIgnoringModifiers]
+                .compactMap { $0 }
+            if observedCharacters.contains("\u{3}") {
+                return true
+            }
+
+            return event.keyCode == UInt16(kVK_ANSI_C)
+        }
+
+        if flags.isEmpty, event.keyCode == UInt16(kVK_Escape) {
+            return true
+        }
+
+        return false
+    }
 }
 
 enum PaneSearchHUDCorner: String, CaseIterable, Equatable, Sendable {

--- a/Zentty/Terminal/TerminalAdapter.swift
+++ b/Zentty/Terminal/TerminalAdapter.swift
@@ -100,21 +100,29 @@ enum TerminalInterruptKeyRecognizer {
         }
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if flags == [.control] {
-            let observedCharacters = [event.characters, event.charactersIgnoringModifiers]
-                .compactMap { $0 }
-            if observedCharacters.contains("\u{3}") {
-                return true
-            }
-
-            return event.keyCode == UInt16(kVK_ANSI_C)
+        guard flags == [.control] else {
+            return false
         }
 
-        if flags.isEmpty, event.keyCode == UInt16(kVK_Escape) {
+        let observedCharacters = [event.characters, event.charactersIgnoringModifiers]
+            .compactMap { $0 }
+        if observedCharacters.contains("\u{3}") {
             return true
         }
 
-        return false
+        return event.keyCode == UInt16(kVK_ANSI_C)
+    }
+
+    // Bare Escape is only meaningful as an interrupt inside a Kimi session —
+    // most other TUIs (vim, fzf, lazygit, …) use Escape for navigation. Callers
+    // MUST gate this recognizer on Kimi context before emitting `.userInterrupted`.
+    static func matchesKimiInterruptEscape(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown, !event.isARepeat else {
+            return false
+        }
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return flags.isEmpty && event.keyCode == UInt16(kVK_Escape)
     }
 }
 

--- a/Zentty/Terminal/TerminalMetadata.swift
+++ b/Zentty/Terminal/TerminalMetadata.swift
@@ -941,6 +941,8 @@ final class TerminalDiagnostics: @unchecked Sendable {
             return "cursor"
         case .gemini:
             return "gemini"
+        case .kimi:
+            return "kimi"
         case .openCode:
             return "opencode"
         case .pi:

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -2,6 +2,28 @@ import AppKit
 import QuartzCore
 import os
 
+enum FocusedTerminalInterruptBridge {
+    static func paneIDForUserInterrupt(
+        event: NSEvent,
+        activeWorklane: WorklaneState?,
+        isFocusedPaneTerminalFocused: Bool
+    ) -> PaneID? {
+        guard TerminalInterruptKeyRecognizer.matchesUserInterrupt(event),
+              isFocusedPaneTerminalFocused,
+              let activeWorklane,
+              let paneID = activeWorklane.paneStripState.focusedPaneID,
+              let status = activeWorklane.auxiliaryStateByPaneID[paneID]?.agentStatus,
+              status.tool == .kimi,
+              status.source == .explicit,
+              status.state == .running || status.state == .starting
+        else {
+            return nil
+        }
+
+        return paneID
+    }
+}
+
 @MainActor
 final class RootViewController: NSViewController {
     private final class LocalEventMonitor {
@@ -928,6 +950,14 @@ final class RootViewController: NSViewController {
 
             guard self.view.window?.isKeyWindow == true else {
                 return event
+            }
+
+            if let paneID = FocusedTerminalInterruptBridge.paneIDForUserInterrupt(
+                event: event,
+                activeWorklane: self.worklaneStore.activeWorklane,
+                isFocusedPaneTerminalFocused: self.focusedPaneRuntime()?.hostView.isTerminalFocused == true
+            ) {
+                self.handleTerminalEvent(paneID: paneID, event: .userInterrupted)
             }
 
             guard let shortcut = KeyboardShortcut(event: event),

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -8,7 +8,9 @@ enum FocusedTerminalInterruptBridge {
         activeWorklane: WorklaneState?,
         isFocusedPaneTerminalFocused: Bool
     ) -> PaneID? {
-        guard TerminalInterruptKeyRecognizer.matchesUserInterrupt(event),
+        let matchesInterrupt = TerminalInterruptKeyRecognizer.matchesUserInterrupt(event)
+            || TerminalInterruptKeyRecognizer.matchesKimiInterruptEscape(event)
+        guard matchesInterrupt,
               isFocusedPaneTerminalFocused,
               let activeWorklane,
               let paneID = activeWorklane.paneStripState.focusedPaneID,

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -53,6 +53,17 @@ struct AgentToolLauncher {
             return environment["ZENTTY_COPILOT_HOOKS_DISABLED"] != "1"
         case .cursor:
             return environment["ZENTTY_CURSOR_HOOKS_DISABLED"] != "1"
+        case .kimi:
+            if environment["ZENTTY_KIMI_HOOKS_DISABLED"] == "1" {
+                return false
+            }
+            if Self.kimiPassthroughSubcommands.contains(arguments.first ?? "") {
+                return false
+            }
+            if arguments.contains(where: { Self.kimiEarlyExitFlags.contains($0) }) {
+                return false
+            }
+            return true
         case .pi:
             // Pi has management subcommands (install/remove/update/list/…)
             // and early-exit flags (--help, --version, --list-models, …).
@@ -84,6 +95,14 @@ struct AgentToolLauncher {
 
     static let piEarlyExitFlags: Set<String> = [
         "--help", "-h", "--version", "-v", "--list-models", "--export",
+    ]
+
+    static let kimiPassthroughSubcommands: Set<String> = [
+        "login", "logout", "term", "acp", "info", "export", "mcp", "plugin", "vis", "web",
+    ]
+
+    static let kimiEarlyExitFlags: Set<String> = [
+        "--help", "-h", "--version", "-V",
     ]
 
     private func findRealBinary() throws -> String {
@@ -130,6 +149,7 @@ struct AgentToolLauncher {
             "ZENTTY_COPILOT_HOOKS_DISABLED",
             "ZENTTY_CURSOR_HOOKS_DISABLED",
             "ZENTTY_CURSOR_VERBOSE_HOOKS",
+            "ZENTTY_KIMI_HOOKS_DISABLED",
             "ZENTTY_CODEX_NOTIFY_DISABLED",
             "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
             "CODEX_HOME",
@@ -152,7 +172,7 @@ struct AgentToolLauncher {
         switch tool {
         case .claude:
             return EnvironmentPatch(set: [:], unset: ["CLAUDECODE"])
-        case .codex, .copilot, .cursor, .gemini, .opencode, .pi:
+        case .codex, .copilot, .cursor, .gemini, .kimi, .opencode, .pi:
             return EnvironmentPatch()
         }
     }
@@ -174,6 +194,8 @@ struct AgentToolLauncher {
             environmentPatch.set["ZENTTY_GEMINI_PID"] = "\(getpid())"
         case .cursor:
             environmentPatch.set["ZENTTY_CURSOR_PID"] = "\(getpid())"
+        case .kimi:
+            environmentPatch.set["ZENTTY_KIMI_PID"] = "\(getpid())"
         case .opencode, .pi:
             break
         }
@@ -219,6 +241,7 @@ struct AgentToolLauncher {
             "ZENTTY_COPILOT_PID",
             "ZENTTY_GEMINI_PID",
             "ZENTTY_CURSOR_PID",
+            "ZENTTY_KIMI_PID",
         ]
         return Dictionary(uniqueKeysWithValues: keys.compactMap { key in
             guard let value = environment[key], !value.isEmpty else {

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -35,6 +35,7 @@ struct ZenttyCLI: ParsableCommand {
 
 private enum IntegrationTarget: String, CaseIterable {
     case cursorHooks = "cursor-hooks"
+    case kimiHooks = "kimi-hooks"
 
     static func resolve(_ raw: String) throws -> IntegrationTarget {
         guard let target = IntegrationTarget(rawValue: raw) else {
@@ -71,7 +72,7 @@ struct InstallCommand: ParsableCommand {
         discussion: "Supported targets: \(IntegrationTarget.allCases.map(\.rawValue).joined(separator: ", "))"
     )
 
-    @Argument(help: "Target integration name (e.g. cursor-hooks).")
+    @Argument(help: "Target integration name (e.g. cursor-hooks, kimi-hooks).")
     var target: String
 
     mutating func run() throws {
@@ -83,6 +84,13 @@ struct InstallCommand: ParsableCommand {
                 cliPath: resolveInvokingCLIPath()
             )
             print("Installed Zentty cursor hooks at \(hooksURL.path).")
+        case .kimiHooks:
+            let configURL = KimiHooksInstaller.defaultUserConfigURL()
+            try KimiHooksInstaller.install(
+                at: configURL,
+                cliPath: resolveInvokingCLIPath()
+            )
+            print("Installed Zentty Kimi hooks at \(configURL.path).")
         }
     }
 }
@@ -94,7 +102,7 @@ struct UninstallCommand: ParsableCommand {
         discussion: "Supported targets: \(IntegrationTarget.allCases.map(\.rawValue).joined(separator: ", "))"
     )
 
-    @Argument(help: "Target integration name (e.g. cursor-hooks).")
+    @Argument(help: "Target integration name (e.g. cursor-hooks, kimi-hooks).")
     var target: String
 
     mutating func run() throws {
@@ -103,6 +111,10 @@ struct UninstallCommand: ParsableCommand {
             let hooksURL = CursorHooksInstaller.defaultUserHooksURL()
             try CursorHooksInstaller.uninstall(at: hooksURL)
             print("Removed Zentty cursor hook entries from \(hooksURL.path).")
+        case .kimiHooks:
+            let configURL = KimiHooksInstaller.defaultUserConfigURL()
+            try KimiHooksInstaller.uninstall(at: configURL)
+            print("Removed Zentty Kimi hook entries from \(configURL.path).")
         }
     }
 }
@@ -474,6 +486,7 @@ struct IPCCommand: ParsableCommand {
         "ZENTTY_COPILOT_PID",
         "ZENTTY_GEMINI_PID",
         "ZENTTY_CURSOR_PID",
+        "ZENTTY_KIMI_PID",
     ]
 
     @Argument(help: "Supported values: agent-event, agent-signal, agent-status")
@@ -563,7 +576,7 @@ struct LaunchCommand: ParsableCommand {
         shouldDisplay: false
     )
 
-    @Argument(help: "Supported values: claude, codex, copilot, cursor, gemini, opencode, pi")
+    @Argument(help: "Supported values: claude, codex, copilot, cursor, gemini, kimi, opencode, pi")
     var tool: String
 
     @Argument(parsing: .captureForPassthrough, help: "Arguments forwarded to the real tool.")

--- a/ZenttyIntegrationTests/AgentWrapperTests.swift
+++ b/ZenttyIntegrationTests/AgentWrapperTests.swift
@@ -354,7 +354,7 @@ final class AgentWrapperTests: XCTestCase {
     }
 
     func test_tool_wrappers_delegate_to_launch_command_when_cli_is_available() throws {
-        for tool in ["claude", "codex", "copilot", "cursor-agent", "gemini", "opencode", "pi"] {
+        for tool in ["claude", "codex", "copilot", "cursor-agent", "gemini", "kimi", "opencode", "pi"] {
             let harness = try WrapperHarness(copyingScriptsNamed: [tool, "zentty-agent-wrapper"])
             try harness.installRealBinary(
                 named: tool,
@@ -385,6 +385,37 @@ final class AgentWrapperTests: XCTestCase {
             XCTAssertEqual(try harness.readArgumentCalls(named: "cli-args.log"), [["launch", expectedLaunchTool, "hello"]], tool)
             XCTAssertTrue(try harness.readLines(named: "real-args.log").isEmpty, tool)
         }
+    }
+
+    func test_kimi_wrapper_passthroughs_login_to_real_binary_even_when_cli_is_available() throws {
+        let harness = try WrapperHarness(copyingScriptsNamed: ["kimi", "zentty-agent-wrapper"])
+        try harness.installRealBinary(
+            named: "kimi",
+            script: """
+            #!/bin/bash
+            set -euo pipefail
+            for arg in "$@"; do
+              printf '%s\n' "$arg" >> "$REAL_ARGS_LOG"
+            done
+            """
+        )
+        try harness.installCliStub()
+
+        let result = try harness.run(
+            tool: "kimi",
+            arguments: ["login"],
+            extraEnvironment: [
+                "ZENTTY_CLI_BIN": harness.cliPath,
+                "ZENTTY_INSTANCE_SOCKET": harness.socketPath,
+                "ZENTTY_PANE_TOKEN": harness.paneToken,
+                "ZENTTY_WORKLANE_ID": "worklane-main",
+                "ZENTTY_PANE_ID": "pane-main",
+            ]
+        )
+
+        XCTAssertEqual(result.exitCode, 0, "\(result.stderr)\n\(result.stdout)")
+        XCTAssertEqual(try harness.readLines(named: "real-args.log"), ["login"])
+        XCTAssertTrue(try harness.readArgumentCalls(named: "cli-args.log").isEmpty)
     }
 
     func test_generic_wrapper_delegates_selected_tool_to_launch_command() throws {
@@ -733,7 +764,7 @@ private struct WrapperHarness {
     }
 
     private var publicWrapperDirectories: [URL] {
-        ["claude", "codex", "copilot", "cursor", "gemini", "opencode", "pi"]
+        ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"]
             .map { wrapperBinURL.appendingPathComponent($0, isDirectory: true) }
             .filter { FileManager.default.fileExists(atPath: $0.path) }
     }
@@ -754,6 +785,8 @@ private struct WrapperHarness {
             return "cursor/cursor-agent"
         case "gemini":
             return "gemini/gemini"
+        case "kimi":
+            return "kimi/kimi"
         case "opencode":
             return "opencode/opencode"
         case "pi":

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -478,6 +478,19 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertTrue(script.contains("find_real_pi"))
     }
 
+    func test_kimi_wrapper_delegates_to_shared_agent_wrapper() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let wrapperPath = repoRoot
+            .appendingPathComponent("ZenttyResources/bin/kimi/kimi")
+            .path
+        let script = try String(contentsOfFile: wrapperPath, encoding: .utf8)
+
+        XCTAssertTrue(script.contains("ZENTTY_AGENT_TOOL=\"kimi\""))
+        XCTAssertTrue(script.contains("zentty-agent-wrapper"))
+    }
+
     // MARK: - Environment
 
     func test_missing_worklane_id_throws() throws {
@@ -568,6 +581,82 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads[0].state, .idle)
         XCTAssertEqual(payloads[0].lifecycleEvent, .update)
+    }
+
+    // MARK: - Kimi Adapter
+
+    func test_kimi_adapter_session_start_with_pid() throws {
+        let json = #"{"hook_event_name": "SessionStart", "session_id": "s1", "cwd": "/tmp"}"#
+        let env = kimiEnvironment(pid: "42")
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: env)
+
+        XCTAssertEqual(payloads.count, 2)
+        XCTAssertEqual(payloads[0].signalKind, .pid)
+        XCTAssertEqual(payloads[0].pid, 42)
+        XCTAssertEqual(payloads[0].pidEvent, .attach)
+        XCTAssertEqual(payloads[1].state, .starting)
+        XCTAssertEqual(payloads[1].toolName, "Kimi")
+    }
+
+    func test_kimi_adapter_user_prompt_submit() throws {
+        let json = #"{"hook_event_name": "UserPromptSubmit", "session_id": "s1", "cwd": "/tmp/project"}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads[0].state, .running)
+        XCTAssertEqual(payloads[0].sessionID, "s1")
+        XCTAssertEqual(payloads[0].agentWorkingDirectory, "/tmp/project")
+    }
+
+    func test_kimi_adapter_stop() throws {
+        let json = #"{"hook_event_name": "Stop", "session_id": "s1"}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads[0].state, .idle)
+        XCTAssertEqual(payloads[0].lifecycleEvent, .update)
+    }
+
+    func test_kimi_adapter_session_end_clears_status_and_pid_mapping() throws {
+        let json = #"{"hook_event_name": "SessionEnd", "session_id": "s1"}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 2)
+        XCTAssertEqual(payloads[0].signalKind, .lifecycle)
+        XCTAssertNil(payloads[0].state)
+        XCTAssertEqual(payloads[1].signalKind, .pid)
+        XCTAssertNil(payloads[1].pid)
+        XCTAssertEqual(payloads[1].pidEvent, .clear)
+    }
+
+    func test_kimi_adapter_permission_prompt_notification_maps_to_needs_input_payload() throws {
+        let json = #"{"hook_event_name": "Notification", "session_id": "s1", "cwd": "/tmp/project", "notification_type": "permission_prompt", "title": "Allow edit", "body": "project.yml"}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads[0].state, .needsInput)
+        XCTAssertEqual(payloads[0].interactionKind, .approval)
+        XCTAssertEqual(payloads[0].text, "Allow edit")
+        XCTAssertEqual(payloads[0].agentWorkingDirectory, "/tmp/project")
+    }
+
+    func test_kimi_adapter_pre_tool_use_ask_user_question_maps_to_question_payload() throws {
+        let json = #"{"hook_event_name":"PreToolUse","session_id":"s1","cwd":"/tmp/project","tool_name":"AskUserQuestion","tool_input":{"question":"Which file?"}}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads[0].state, .needsInput)
+        XCTAssertEqual(payloads[0].interactionKind, .question)
+        XCTAssertEqual(payloads[0].text, "Which file?")
+    }
+
+    func test_kimi_adapter_post_tool_use_ask_user_question_restores_running_payload() throws {
+        let json = #"{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/tmp/project","tool_name":"AskUserQuestion"}"#
+        let payloads = try AgentEventBridge.kimiAdapter(data: json.data(using: .utf8)!, environment: kimiEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads[0].state, .running)
+        XCTAssertEqual(payloads[0].interactionKind, .none)
     }
 
     // MARK: - Copilot Adapter
@@ -736,6 +825,12 @@ final class AgentEventBridgeTests: XCTestCase {
     private func codexEnvironment(pid: String? = nil) -> [String: String] {
         var env = defaultEnvironment
         if let pid { env["ZENTTY_CODEX_PID"] = pid }
+        return env
+    }
+
+    private func kimiEnvironment(pid: String? = nil) -> [String: String] {
+        var env = defaultEnvironment
+        if let pid { env["ZENTTY_KIMI_PID"] = pid }
         return env
     }
 

--- a/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
+++ b/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
@@ -135,4 +135,33 @@ final class AgentResumeCommandBuilderTests: XCTestCase {
 
         XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
     }
+
+    func test_builder_returns_kimi_resume_command_for_uuid_session_id() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "0cb916db-26aa-40f2-86b5-1ba81b225fd2",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            "kimi -r 0cb916db-26aa-40f2-86b5-1ba81b225fd2"
+        )
+    }
+
+    func test_builder_returns_nil_for_kimi_non_uuid_session_id() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "resume-this-session",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
+    }
 }

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -74,6 +74,12 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(AgentTool.resolveKnown(named: "Gemini"), .gemini)
     }
 
+    func test_agent_tool_recognizes_kimi_for_explicit_and_known_tool_resolution() {
+        XCTAssertEqual(AgentTool.resolve(named: "kimi"), .kimi)
+        XCTAssertEqual(AgentTool.resolve(named: "Kimi CLI"), .kimi)
+        XCTAssertEqual(AgentTool.resolveKnown(named: "Kimi"), .kimi)
+    }
+
     func test_agent_tool_recognizes_cursor() {
         XCTAssertEqual(AgentTool.resolve(named: "cursor"), .cursor)
         XCTAssertEqual(AgentTool.resolve(named: "Cursor Agent"), .cursor)
@@ -146,6 +152,32 @@ final class AgentStatusSupportTests: XCTestCase {
         }
     }
 
+    func test_kimi_passthrough_list_matches_kimi_cli_help_snapshot() throws {
+        // Snapshot of `kimi --help` verified 2026-04-20 against the locally
+        // installed Kimi CLI. These subcommands and early-exit flags should
+        // bypass Zentty's overlay/bootstrap path.
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let launcherPath = repoRoot
+            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
+            .path
+        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
+
+        for subcommand in ["login", "logout", "term", "acp", "info", "export", "mcp", "plugin", "vis", "web"] {
+            XCTAssertTrue(
+                source.contains("\"\(subcommand)\""),
+                "kimiPassthroughSubcommands should contain \(subcommand)"
+            )
+        }
+        for flag in ["--help", "-h", "--version", "-V"] {
+            XCTAssertTrue(
+                source.contains("\"\(flag)\""),
+                "kimiEarlyExitFlags should contain \(flag)"
+            )
+        }
+    }
+
     func test_agent_status_helper_returns_nil_when_resource_directories_are_missing() throws {
         let bundle = try makeTemporaryBundle(named: "MissingResources")
 
@@ -188,7 +220,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         XCTAssertEqual(
             AgentStatusHelper.wrapperDirectoryPaths(in: bundle),
-            ["claude", "codex", "copilot", "cursor", "gemini", "opencode", "pi"].map {
+            ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"].map {
                 binURL.appendingPathComponent($0, isDirectory: true).path
             }
         )
@@ -292,7 +324,7 @@ final class AgentStatusSupportTests: XCTestCase {
         try FileManager.default.createDirectory(at: realBinURL, withIntermediateDirectories: true)
         // Real binaries Zentty's wrappers expect on PATH. Note cursor resolves to `cursor-agent`,
         // not `cursor` (which is the Cursor IDE launcher).
-        for name in ["claude", "cursor-agent", "gemini", "opencode"] {
+        for name in ["claude", "cursor-agent", "gemini", "kimi", "opencode"] {
             let fileURL = realBinURL.appendingPathComponent(name, isDirectory: false)
             try "#!/bin/sh\n".write(to: fileURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
@@ -305,6 +337,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 binURL.appendingPathComponent("copilot", isDirectory: true).path,
                 binURL.appendingPathComponent("cursor", isDirectory: true).path,
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
+                binURL.appendingPathComponent("kimi", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
                 binURL.appendingPathComponent("pi", isDirectory: true).path,
                 sharedURL.path,
@@ -320,6 +353,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 binURL.appendingPathComponent("claude", isDirectory: true).path,
                 binURL.appendingPathComponent("cursor", isDirectory: true).path,
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
+                binURL.appendingPathComponent("kimi", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
             ]
         )
@@ -600,6 +634,21 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertFalse(geminiWrapper.contains("ZENTTY_AGENT_BIN"))
     }
 
+    func test_repository_kimi_wrapper_delegates_to_internal_launch_cli() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let kimiWrapper = try String(contentsOf: repositoryRoot
+            .appendingPathComponent("ZenttyResources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("kimi", isDirectory: true)
+            .appendingPathComponent("kimi", isDirectory: false), encoding: .utf8)
+        XCTAssertTrue(kimiWrapper.contains("ZENTTY_AGENT_TOOL=\"kimi\""))
+        XCTAssertTrue(kimiWrapper.contains("zentty-agent-wrapper"))
+        XCTAssertFalse(kimiWrapper.contains("ZENTTY_AGENT_BIN"))
+    }
+
     func test_repository_cursor_wrapper_exposes_cursor_agent_and_agent() throws {
         let repositoryRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -628,6 +677,17 @@ final class AgentStatusSupportTests: XCTestCase {
 
         XCTAssertTrue(project.contains("-o -path \"*/gemini/gemini\""))
         XCTAssertTrue(project.contains("-o -path \"*/cursor/cursor-agent\""))
+    }
+
+    func test_copy_agent_resources_build_script_marks_kimi_wrapper_executable() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let projectURL = repositoryRoot.appendingPathComponent("project.yml", isDirectory: false)
+        let project = try String(contentsOf: projectURL, encoding: .utf8)
+
+        XCTAssertTrue(project.contains("-o -path \"*/kimi/kimi\""))
+        XCTAssertTrue(project.contains("-o -path \"*/shared/zentty-agent-wrapper\""))
     }
 
     func test_agent_ipc_bridge_converts_agent_signal_message_to_payload() throws {
@@ -1408,6 +1468,370 @@ final class AgentStatusSupportTests: XCTestCase {
             FileManager.default.fileExists(atPath: hooksURL.path),
             "installIfPossible must reject whitespace-only env values"
         )
+    }
+
+    // MARK: - KimiHooksInstaller
+
+    func test_kimi_hooks_installer_appends_managed_block_and_preserves_existing_content() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-append")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-k2"
+
+        [[hooks]]
+        event = "SessionStart"
+        command = "echo user"
+        """
+        try original.write(to: configURL, atomically: true, encoding: .utf8)
+
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let after = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(after.hasPrefix(original))
+        XCTAssertTrue(after.contains("### BEGIN ZENTTY KIMI HOOKS"))
+        XCTAssertTrue(after.contains(#"matcher = "permission_prompt""#))
+        XCTAssertTrue(after.contains(#"matcher = "AskUserQuestion""#))
+        XCTAssertTrue(after.contains(#"event = "SessionStart""#))
+        XCTAssertTrue(after.contains(#"event = "SessionEnd""#))
+        XCTAssertTrue(after.contains(#"event = "UserPromptSubmit""#))
+        XCTAssertTrue(after.contains(#"event = "Stop""#))
+        XCTAssertTrue(after.contains(#"event = "Notification""#))
+        XCTAssertTrue(after.contains(#"event = "PreToolUse""#))
+        XCTAssertTrue(after.contains(#"event = "PostToolUse""#))
+        XCTAssertTrue(after.contains(#"command = "\"/opt/zentty/bin/zentty\" ipc agent-event --adapter=kimi""#))
+        XCTAssertFalse(after.contains(#"command = ""/opt/zentty/bin/zentty""#))
+    }
+
+    func test_kimi_hooks_installer_reinstall_replaces_managed_block_in_place() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-reinstall")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/old/zentty")
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/old/zentty")
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/new/zentty")
+
+        let after = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(after.components(separatedBy: "### BEGIN ZENTTY KIMI HOOKS").count, 2)
+        XCTAssertTrue(after.contains("/opt/new/zentty"))
+        XCTAssertFalse(after.contains("/opt/old/zentty"))
+    }
+
+    func test_kimi_hooks_installer_uninstall_removes_only_managed_block() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-uninstall")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-k2"
+
+        [[hooks]]
+        event = "SessionStart"
+        command = "echo user"
+        """
+        try original.write(to: configURL, atomically: true, encoding: .utf8)
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        try KimiHooksInstaller.uninstall(at: configURL)
+
+        let after = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(after, original)
+    }
+
+    func test_kimi_hooks_installer_uninstall_deletes_file_when_only_managed_block_remains() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-uninstall-empty")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        try KimiHooksInstaller.uninstall(at: configURL)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: configURL.path))
+    }
+
+    func test_kimi_hooks_installer_install_if_possible_treats_whitespace_env_as_blank() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-blank-env")
+        let configURL = directory
+            .appendingPathComponent(".kimi", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+
+        KimiHooksInstaller.installIfPossible(environment: [
+            "HOME": "  ",
+            "ZENTTY_CLI_BIN": "\t",
+        ])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: configURL.path))
+    }
+
+    func test_kimi_hooks_installer_replaces_empty_hooks_placeholder_and_restores_it_on_uninstall() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-placeholder")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-k2"
+        hooks = []
+        """
+        try original.write(to: configURL, atomically: true, encoding: .utf8)
+
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let installed = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertFalse(installed.contains("\nhooks = []\n"))
+        XCTAssertTrue(installed.contains(#"hooks = ["#))
+        XCTAssertTrue(installed.contains(#"{ event = "Notification", matcher = "permission_prompt""#))
+        XCTAssertFalse(installed.contains(#"[[hooks]]"#))
+
+        try KimiHooksInstaller.uninstall(at: configURL)
+
+        let uninstalled = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(uninstalled, original)
+    }
+
+    func test_kimi_hooks_installer_merges_nonempty_inline_hooks_array_and_restores_original_on_uninstall() throws {
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-inline-array")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-k2"
+        hooks = [{ event = "SessionStart", command = "echo user" }]
+        """
+        try original.write(to: configURL, atomically: true, encoding: .utf8)
+
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let installed = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(installed.components(separatedBy: "hooks = [").count, 2)
+        XCTAssertTrue(installed.contains(#"command = "echo user""#))
+        XCTAssertTrue(installed.contains(#"{ event = "Notification", matcher = "permission_prompt""#))
+        XCTAssertFalse(installed.contains("[[hooks]]"))
+
+        try KimiHooksInstaller.uninstall(at: configURL)
+
+        let uninstalled = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(uninstalled, original)
+    }
+
+    func test_agent_launch_bootstrap_builds_kimi_overlay_from_default_user_config() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-runtime")
+        let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-home")
+        let userConfigURL = homeDirectory
+            .appendingPathComponent(".kimi", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: userConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let original = """
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = []
+        """
+        try original.write(to: userConfigURL, atomically: true, encoding: .utf8)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": homeDirectory.path,
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/kimi")
+        XCTAssertEqual(plan.setEnvironment["ZENTTY_AGENT_TOOL"], "kimi")
+        XCTAssertEqual(plan.unsetEnvironment, [])
+        XCTAssertEqual(plan.preLaunchActions, [])
+        XCTAssertEqual(plan.arguments.count, 4)
+        XCTAssertEqual(plan.arguments[0], "--config-file")
+        XCTAssertEqual(Array(plan.arguments.suffix(2)), ["chat", "hello"])
+
+        let overlayConfigURL = URL(fileURLWithPath: plan.arguments[1], isDirectory: false)
+        XCTAssertTrue(overlayConfigURL.path.hasPrefix(runtimeDirectory.path))
+
+        let overlayConfig = try String(contentsOf: overlayConfigURL, encoding: .utf8)
+        XCTAssertTrue(overlayConfig.contains(#"default_model = "kimi-code/kimi-for-coding""#))
+        XCTAssertTrue(overlayConfig.contains(#"hooks = ["#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+        XCTAssertTrue(overlayConfig.contains(#"{ event = "Notification", matcher = "permission_prompt""#))
+        XCTAssertFalse(overlayConfig.contains(#"command = ""/tmp/zentty""#))
+
+        let sourceConfig = try String(contentsOf: userConfigURL, encoding: .utf8)
+        XCTAssertEqual(sourceConfig, original)
+    }
+
+    func test_agent_launch_bootstrap_builds_kimi_overlay_from_explicit_config_file() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-explicit-runtime")
+        let sourceDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-explicit-source")
+        let sourceConfigURL = sourceDirectory.appendingPathComponent("kimi.toml", isDirectory: false)
+        let sourceConfig = """
+        default_model = "kimi-k2"
+
+        [[hooks]]
+        event = "SessionStart"
+        command = "echo existing"
+        """
+        try sourceConfig.write(to: sourceConfigURL, atomically: true, encoding: .utf8)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--config-file", sourceConfigURL.path, "chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": NSHomeDirectory(),
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/kimi")
+        XCTAssertEqual(plan.setEnvironment["ZENTTY_AGENT_TOOL"], "kimi")
+        XCTAssertEqual(plan.arguments.count, 4)
+        XCTAssertEqual(plan.arguments[0], "--config-file")
+        XCTAssertEqual(Array(plan.arguments.suffix(2)), ["chat", "hello"])
+        XCTAssertNotEqual(plan.arguments[1], sourceConfigURL.path)
+
+        let overlayConfig = try String(
+            contentsOf: URL(fileURLWithPath: plan.arguments[1], isDirectory: false),
+            encoding: .utf8
+        )
+        XCTAssertTrue(overlayConfig.contains(#"command = "echo existing""#))
+        XCTAssertTrue(overlayConfig.contains(#"event = "SessionEnd""#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+    }
+
+    func test_agent_launch_bootstrap_builds_kimi_overlay_from_inline_config_argument() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-inline-runtime")
+        let inlineConfig = """
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = []
+        """
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--config", inlineConfig, "chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": NSHomeDirectory(),
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.arguments.count, 4)
+        XCTAssertEqual(plan.arguments[0], "--config-file")
+        XCTAssertEqual(Array(plan.arguments.suffix(2)), ["chat", "hello"])
+
+        let overlayConfig = try String(
+            contentsOf: URL(fileURLWithPath: plan.arguments[1], isDirectory: false),
+            encoding: .utf8
+        )
+        XCTAssertTrue(overlayConfig.contains(#"default_model = "kimi-code/kimi-for-coding""#))
+        XCTAssertTrue(overlayConfig.contains(#"hooks = ["#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+    }
+
+    func test_agent_launch_bootstrap_merges_kimi_overlay_into_existing_nonempty_inline_hooks_array() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-inline-hooks-runtime")
+        let inlineConfig = """
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = [{ event = "SessionStart", command = "echo user" }]
+        """
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--config", inlineConfig, "chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": NSHomeDirectory(),
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        let overlayConfig = try String(
+            contentsOf: URL(fileURLWithPath: plan.arguments[1], isDirectory: false),
+            encoding: .utf8
+        )
+        XCTAssertEqual(overlayConfig.components(separatedBy: "hooks = [").count, 2)
+        XCTAssertTrue(overlayConfig.contains(#"command = "echo user""#))
+        XCTAssertTrue(overlayConfig.contains(#"{ event = "SessionEnd", command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+        XCTAssertFalse(overlayConfig.contains("[[hooks]]"))
+    }
+
+    func test_agent_launch_bootstrap_throws_for_missing_explicit_kimi_config_file() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-missing-runtime")
+        let missingConfigURL = runtimeDirectory.appendingPathComponent("missing.toml", isDirectory: false)
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--config-file", missingConfigURL.path, "chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": NSHomeDirectory(),
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        XCTAssertThrowsError(
+            try AgentLaunchBootstrap.makePlan(
+                request: request,
+                target: AgentIPCTarget(
+                    windowID: WindowID("window-main"),
+                    worklaneID: WorklaneID("worklane-main"),
+                    paneID: PaneID("pane-main")
+                ),
+                runtimeDirectoryURL: runtimeDirectory
+            )
+        ) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
+            XCTAssertEqual(nsError.code, CocoaError.fileNoSuchFile.rawValue)
+        }
     }
 
     func test_agent_launch_bootstrap_builds_gemini_system_settings_overlay_and_forces_notifications() throws {
@@ -4797,6 +5221,7 @@ final class AgentStatusSupportTests: XCTestCase {
             ("copilot", "copilot"),
             ("cursor", "cursor-agent"),
             ("gemini", "gemini"),
+            ("kimi", "kimi"),
             ("opencode", "opencode"),
             ("pi", "pi"),
         ]

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -1605,6 +1605,34 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(uninstalled, original)
     }
 
+    func test_kimi_hooks_installer_ignores_markers_embedded_in_toml_string_values() throws {
+        // Regression guard: marker detection is line-anchored. A BEGIN/END
+        // marker smuggled into a TOML string value on a line with other content
+        // must not be treated as a managed block; install should append a fresh
+        // block, and uninstall should leave the string value intact.
+        let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-embedded-marker")
+        let configURL = directory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-k2"
+        quirky = "prefix ### BEGIN ZENTTY KIMI HOOKS suffix ### END ZENTTY KIMI HOOKS tail"
+        """
+        try original.write(to: configURL, atomically: true, encoding: .utf8)
+
+        try KimiHooksInstaller.install(at: configURL, cliPath: "/opt/zentty/bin/zentty")
+
+        let installed = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertTrue(installed.contains(original), "embedded-marker line should be preserved verbatim")
+        XCTAssertEqual(
+            installed.components(separatedBy: "\n### BEGIN ZENTTY KIMI HOOKS\n").count, 2,
+            "install should add exactly one managed block"
+        )
+
+        try KimiHooksInstaller.uninstall(at: configURL)
+
+        let uninstalled = try String(contentsOf: configURL, encoding: .utf8)
+        XCTAssertEqual(uninstalled, original)
+    }
+
     func test_agent_launch_bootstrap_builds_kimi_overlay_from_default_user_config() throws {
         let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-runtime")
         let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-home")

--- a/ZenttyLogicTests/LibghosttyAdapterTests.swift
+++ b/ZenttyLogicTests/LibghosttyAdapterTests.swift
@@ -328,6 +328,52 @@ final class LibghosttyAdapterTests: AppKitTestCase {
         XCTAssertFalse(receivedEvents.contains(.userSubmittedInput))
     }
 
+    func test_control_c_emits_user_interrupt_event() throws {
+        let runtime = LibghosttyRuntimeProviderSpy()
+        let adapter = LibghosttyAdapter(runtime: runtime)
+        var receivedEvents: [TerminalEvent] = []
+
+        adapter.eventDidOccur = { receivedEvents.append($0) }
+
+        _ = adapter.makeTerminalView()
+        try adapter.startSession(using: TerminalSessionRequest())
+
+        let hostView = try XCTUnwrap(runtime.lastHostView)
+        hostView.keyDown(
+            with: try makeKeyEvent(
+                characters: "\u{3}",
+                charactersIgnoringModifiers: "c",
+                keyCode: UInt16(kVK_ANSI_C),
+                modifierFlags: [.control]
+            )
+        )
+
+        XCTAssertTrue(receivedEvents.contains(.userInterrupted))
+        XCTAssertFalse(receivedEvents.contains(.userSubmittedInput))
+    }
+
+    func test_escape_emits_user_interrupt_event() throws {
+        let runtime = LibghosttyRuntimeProviderSpy()
+        let adapter = LibghosttyAdapter(runtime: runtime)
+        var receivedEvents: [TerminalEvent] = []
+
+        adapter.eventDidOccur = { receivedEvents.append($0) }
+
+        _ = adapter.makeTerminalView()
+        try adapter.startSession(using: TerminalSessionRequest())
+
+        let hostView = try XCTUnwrap(runtime.lastHostView)
+        hostView.keyDown(
+            with: try makeKeyEvent(
+                characters: "\u{1B}",
+                keyCode: UInt16(kVK_Escape)
+            )
+        )
+
+        XCTAssertTrue(receivedEvents.contains(.userInterrupted))
+        XCTAssertFalse(receivedEvents.contains(.userSubmittedInput))
+    }
+
     func test_fn_control_left_arrow_bypasses_terminal_surface_input() throws {
         let runtime = LibghosttyRuntimeProviderSpy()
         let adapter = LibghosttyAdapter(runtime: runtime)
@@ -868,6 +914,7 @@ private final class LibghosttySurfaceControllerSpy: LibghosttySurfaceControlling
 
 private func makeKeyEvent(
     characters: String,
+    charactersIgnoringModifiers: String? = nil,
     keyCode: UInt16,
     modifierFlags: NSEvent.ModifierFlags = []
 ) throws -> NSEvent {
@@ -880,7 +927,7 @@ private func makeKeyEvent(
             windowNumber: 0,
             context: nil,
             characters: characters,
-            charactersIgnoringModifiers: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers ?? characters,
             isARepeat: false,
             keyCode: keyCode
         )

--- a/ZenttyLogicTests/LibghosttyAdapterTests.swift
+++ b/ZenttyLogicTests/LibghosttyAdapterTests.swift
@@ -352,7 +352,10 @@ final class LibghosttyAdapterTests: AppKitTestCase {
         XCTAssertFalse(receivedEvents.contains(.userSubmittedInput))
     }
 
-    func test_escape_emits_user_interrupt_event() throws {
+    func test_escape_does_not_emit_user_interrupt_through_generic_terminal_path() throws {
+        // Escape is too broadly used in TUIs (vim, fzf, lazygit, …) to classify
+        // as a universal interrupt. The Kimi-scoped path handles Escape via
+        // FocusedTerminalInterruptBridge; the generic terminal stream stays quiet.
         let runtime = LibghosttyRuntimeProviderSpy()
         let adapter = LibghosttyAdapter(runtime: runtime)
         var receivedEvents: [TerminalEvent] = []
@@ -370,7 +373,7 @@ final class LibghosttyAdapterTests: AppKitTestCase {
             )
         )
 
-        XCTAssertTrue(receivedEvents.contains(.userInterrupted))
+        XCTAssertFalse(receivedEvents.contains(.userInterrupted))
         XCTAssertFalse(receivedEvents.contains(.userSubmittedInput))
     }
 

--- a/ZenttyLogicTests/PaneStripStoreTests.swift
+++ b/ZenttyLogicTests/PaneStripStoreTests.swift
@@ -4583,6 +4583,40 @@ final class PaneStripStoreTests: XCTestCase {
         )
     }
 
+    func test_kimi_control_c_interrupt_transitions_running_session_to_idle_without_ready() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+
+        store.applyAgentStatusPayload(
+            AgentStatusPayload(
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: paneID,
+                signalKind: .lifecycle,
+                state: .running,
+                origin: .explicitHook,
+                toolName: "Kimi",
+                text: nil,
+                confidence: .explicit,
+                sessionID: "kimi-session",
+                artifactKind: nil,
+                artifactLabel: nil,
+                artifactURL: nil
+            )
+        )
+
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .running)
+
+        store.handleTerminalEvent(
+            paneID: paneID,
+            event: .userInterrupted
+        )
+
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .idle)
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.presentation.statusText, "Idle")
+        XCTAssertFalse(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.presentation.isReady == true)
+        XCTAssertFalse(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.raw.showsReadyStatus == true)
+    }
+
     func test_waiting_codex_title_preserves_specific_blocked_prompt_copy() throws {
         let store = WorklaneStore(readyStatusDebounceInterval: 0)
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)

--- a/ZenttyLogicTests/RootViewCompositionTests.swift
+++ b/ZenttyLogicTests/RootViewCompositionTests.swift
@@ -3,6 +3,54 @@ import XCTest
 
 @MainActor
 final class RootViewCompositionTests: AppKitTestCase {
+    private func makeInterruptBridgeWorklane(
+        tool: AgentTool = .kimi,
+        state: PaneAgentState = .running,
+        source: PaneAgentStatusSource = .explicit
+    ) -> (worklane: WorklaneState, paneID: PaneID) {
+        let paneID = PaneID("pn-kimi")
+        let pane = PaneState(id: paneID, title: "pane")
+        let status = PaneAgentStatus(
+            tool: tool,
+            state: state,
+            text: "Running",
+            artifactLink: nil,
+            updatedAt: Date(),
+            source: source,
+            origin: .explicitHook
+        )
+        let worklane = WorklaneState(
+            id: WorklaneID("wl-kimi"),
+            title: "",
+            paneStripState: PaneStripState(panes: [pane], focusedPaneID: paneID),
+            auxiliaryStateByPaneID: [
+                paneID: PaneAuxiliaryState(agentStatus: status)
+            ]
+        )
+
+        return (worklane, paneID)
+    }
+
+    private func makeKeyEvent(
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags = [],
+        characters: String,
+        charactersIgnoringModifiers: String? = nil
+    ) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers ?? characters,
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+    }
+
     override func tearDown() {
         SidebarWidthPreference.reset()
         SidebarVisibilityPreference.reset()
@@ -104,6 +152,48 @@ final class RootViewCompositionTests: AppKitTestCase {
             appCanvasView.frame.minX,
             ShellMetrics.outerInset,
             accuracy: 0.5
+        )
+    }
+
+    func test_focused_terminal_interrupt_bridge_matches_running_kimi_session() throws {
+        let (worklane, paneID) = makeInterruptBridgeWorklane()
+        let event = makeKeyEvent(
+            keyCode: 8,
+            modifierFlags: [.control],
+            characters: "\u{3}",
+            charactersIgnoringModifiers: "c"
+        )
+
+        let bridgedPaneID = FocusedTerminalInterruptBridge.paneIDForUserInterrupt(
+            event: event,
+            activeWorklane: worklane,
+            isFocusedPaneTerminalFocused: true
+        )
+
+        XCTAssertEqual(bridgedPaneID, paneID)
+    }
+
+    func test_focused_terminal_interrupt_bridge_ignores_non_terminal_focus_and_non_kimi_sessions() throws {
+        let (worklane, _) = makeInterruptBridgeWorklane(tool: .codex)
+        let event = makeKeyEvent(
+            keyCode: 53,
+            characters: String(UnicodeScalar(0x1B)!),
+            charactersIgnoringModifiers: String(UnicodeScalar(0x1B)!)
+        )
+
+        XCTAssertNil(
+            FocusedTerminalInterruptBridge.paneIDForUserInterrupt(
+                event: event,
+                activeWorklane: worklane,
+                isFocusedPaneTerminalFocused: false
+            )
+        )
+        XCTAssertNil(
+            FocusedTerminalInterruptBridge.paneIDForUserInterrupt(
+                event: event,
+                activeWorklane: worklane,
+                isFocusedPaneTerminalFocused: true
+            )
         )
     }
 

--- a/ZenttyLogicTests/RootViewCompositionTests.swift
+++ b/ZenttyLogicTests/RootViewCompositionTests.swift
@@ -173,6 +173,23 @@ final class RootViewCompositionTests: AppKitTestCase {
         XCTAssertEqual(bridgedPaneID, paneID)
     }
 
+    func test_focused_terminal_interrupt_bridge_matches_escape_for_running_kimi_session() throws {
+        let (worklane, paneID) = makeInterruptBridgeWorklane()
+        let event = makeKeyEvent(
+            keyCode: 53,
+            characters: String(UnicodeScalar(0x1B)!),
+            charactersIgnoringModifiers: String(UnicodeScalar(0x1B)!)
+        )
+
+        let bridgedPaneID = FocusedTerminalInterruptBridge.paneIDForUserInterrupt(
+            event: event,
+            activeWorklane: worklane,
+            isFocusedPaneTerminalFocused: true
+        )
+
+        XCTAssertEqual(bridgedPaneID, paneID)
+    }
+
     func test_focused_terminal_interrupt_bridge_ignores_non_terminal_focus_and_non_kimi_sessions() throws {
         let (worklane, _) = makeInterruptBridgeWorklane(tool: .codex)
         let event = makeKeyEvent(

--- a/ZenttyResources/bin/kimi/kimi
+++ b/ZenttyResources/bin/kimi/kimi
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export ZENTTY_AGENT_TOOL="kimi"
+exec "$(cd "$(dirname "$0")" && pwd)/../shared/zentty-agent-wrapper" "$@"

--- a/ZenttyResources/bin/shared/zentty-agent-wrapper
+++ b/ZenttyResources/bin/shared/zentty-agent-wrapper
@@ -4,6 +4,43 @@ set -euo pipefail
 
 tool_basename="${ZENTTY_AGENT_TOOL:-$(basename "$0")}"
 
+kimi_passthrough_subcommand() {
+    case "${1:-}" in
+        login|logout|term|acp|info|export|mcp|plugin|vis|web)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+kimi_early_exit_flag_present() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --help|-h|--version|-V)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+should_passthrough_to_real_binary() {
+    case "$tool_basename" in
+        kimi)
+            [[ "${ZENTTY_KIMI_HOOKS_DISABLED:-}" == "1" ]] && return 0
+            kimi_passthrough_subcommand "${1:-}" && return 0
+            kimi_early_exit_flag_present "$@" && return 0
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 # Tools whose wrapper directory name differs from the real CLI binary name.
 # cursor's CLI ships as `cursor-agent` (`cursor` itself is the IDE launcher).
 real_binary_candidates() {
@@ -43,6 +80,13 @@ zentty_cli_bin() {
 }
 
 if cli_bin="$(zentty_cli_bin 2>/dev/null)"; then
+    if should_passthrough_to_real_binary "$@"; then
+        real_binary="$(find_real_binary)" || {
+            echo "Error: $tool_basename not found in PATH" >&2
+            exit 127
+        }
+        exec "$real_binary" "$@"
+    fi
     exec "$cli_bin" launch "$tool_basename" "$@"
 fi
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -225,6 +225,51 @@ Gemini's built-in terminal notifications still matter for wrapped sessions. Zent
 
 This gives Gemini first-class sidebar and notification behavior even when the hook payload is minimal.
 
+## Kimi CLI
+
+Wrapped `kimi` launches use a per-launch overlay config under Zentty's runtime directory. Zentty reads the active Kimi config source, merges in its hook block for that session, and launches Kimi with `--config-file <overlay>`. The user's `~/.kimi/config.toml` is left untouched during normal wrapped launches.
+
+Kimi's own setup commands are stricter than normal chat turns:
+
+- `kimi login` must run against Kimi's default config location. Zentty now passthroughs `kimi login` and the other Kimi management commands directly to the real Kimi binary so they keep using the default config.
+- `/login` and `/model` inside a wrapped `kimi` session are not reliable because Kimi rejects those flows when launched with `--config` or `--config-file`.
+- For model selection in wrapped sessions, prefer `kimi --model <model-id>` or update `~/.kimi/config.toml` directly.
+
+Manual fallback commands:
+
+```sh
+zentty install kimi-hooks
+zentty uninstall kimi-hooks
+```
+
+`zentty install kimi-hooks` remains available if you explicitly want a persistent global hook install for debugging or recovery. Set `ZENTTY_KIMI_HOOKS_DISABLED=1` to bypass Zentty's Kimi hook overlay and launch Kimi directly.
+
+Zentty registers these Kimi hooks:
+
+- `SessionStart`
+- `SessionEnd`
+- `UserPromptSubmit`
+- `Stop`
+- `Notification` with `matcher = "permission_prompt"`
+- `PreToolUse` with `matcher = "AskUserQuestion"`
+- `PostToolUse` with `matcher = "AskUserQuestion"`
+
+Each hook calls:
+
+```sh
+"$ZENTTY_CLI_BIN" ipc agent-event --adapter=kimi
+```
+
+### Current mapping
+
+- `SessionStart` -> PID attach + `starting`
+- `UserPromptSubmit` -> `running`
+- `Stop` -> `idle`
+- `SessionEnd` -> clear session + PID mapping
+- `Notification(permission_prompt)` -> `needs-input` with `approval`
+- `PreToolUse(AskUserQuestion)` -> `needs-input` with `question`
+- `PostToolUse(AskUserQuestion)` -> `running`
+
 ## OpenCode
 
 Zentty injects a local OpenCode plugin overlay via the shared agent wrapper. The plugin forwards `session.status`, `session.idle`, permission/question events, and `todo.updated`.

--- a/project.yml
+++ b/project.yml
@@ -52,6 +52,7 @@ targets:
       - path: ZenttyCLI
       - path: Zentty/AppState/Agent/AgentIPCProtocol.swift
       - path: Zentty/AppState/Agent/CursorHooksInstaller.swift
+      - path: Zentty/AppState/Agent/KimiHooksInstaller.swift
       - path: Zentty/AppState/Agent/JSONCRelaxedParse.swift
     dependencies:
       - package: ArgumentParser
@@ -121,7 +122,7 @@ targets:
           mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
           rsync -a --delete "${RESOURCES_SRC}/bin/" "${RESOURCES_DST}/bin/"
           install -m 755 "${BUILT_PRODUCTS_DIR}/zentty" "${RESOURCES_DST}/bin/shared/zentty"
-          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/gemini/gemini" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
+          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/gemini/gemini" -o -path "*/kimi/kimi" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
           rsync -a --delete "${RESOURCES_SRC}/shell-integration/" "${RESOURCES_DST}/shell-integration/"
           rsync -a --delete "${RESOURCES_SRC}/opencode/" "${RESOURCES_DST}/opencode/"
           rsync -a --delete "${RESOURCES_SRC}/pi/" "${RESOURCES_DST}/pi/"


### PR DESCRIPTION
- add first-class Kimi CLI support across launch, status mapping, restore, wrappers, and docs
- use a per-launch Kimi config overlay instead of mutating ~/.kimi/config.toml, with passthrough for login/logout and other management commands
- handle Kimi user interrupts so Ctrl-C/Escape clear stale running state, and add regression coverage for the new Kimi flows