### PR TITLE
feat: add droid agent status integration

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		D6A5B756DD47B6E634574F47 /* CommandPaletteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C966AC83B20D437AA8281B3 /* CommandPaletteController.swift */; };
 		D90B030DC3BB4F5D7E28FBAF /* ThemeCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB7FE3B87F05DE3D6B4426 /* ThemeCatalogService.swift */; };
 		DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0057216F25AA9654E5BDB87 /* ErrorReporting.swift */; };
+		DB99D15DBBA9E04854EE979F /* DroidHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */; };
 		DC139F18052FBD8126678D7F /* TerminalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7FF718B0E0C3314C57BFC5 /* TerminalAdapter.swift */; };
 		DC6594609ADC8C26340A0B8A /* SidebarWorklaneRowButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4225E34022CEC2DFB9C70338 /* SidebarWorklaneRowButtonTests.swift */; };
 		DE22542885A2BE164FE9090E /* KeyboardShortcutPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF1AD0DA5648D1E48300407 /* KeyboardShortcutPreview.swift */; };
@@ -258,6 +259,7 @@
 		E6DB3D37929BDB0F6583E0E5 /* OpenWithCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19801FEA1E31AE1665776372 /* OpenWithCatalog.swift */; };
 		E9BF42DC69D4CF63845BCBE2 /* SidebarWorklaneRowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BC50CDB5D0B82695D9A2D4 /* SidebarWorklaneRowLayoutTests.swift */; };
 		EA6847AAD0A938767899B578 /* VendoredGhosttyResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E1E9FF5B98D7124B6E65AC /* VendoredGhosttyResourcesTests.swift */; };
+		EAC39845FAE3EF9784F2F17C /* DroidTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCA77C435DCC7E4F338789C /* DroidTaskStore.swift */; };
 		EBA82B93B865F768A59C3FB5 /* CommandPaletteItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1927429EEB90A74961D30D /* CommandPaletteItemBuilderTests.swift */; };
 		ED27476E195CD5905EA8FE99 /* CleanCopyPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9147BE310A4C4D3D61638835 /* CleanCopyPipeline.swift */; };
 		ED97F9FB42E05ECE3179E60D /* PaneStripState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D36706DB3DF677FA13DC722 /* PaneStripState.swift */; };
@@ -280,6 +282,7 @@
 		F5A26C1A6A89ED60FFF6F341 /* AgentToolLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7790121822A61AC4121DF708 /* AgentToolLauncher.swift */; };
 		F75C8D5EDC0772F56DE54C52 /* PaneStripStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB4690A6E06FB3FC4C1909E /* PaneStripStoreTests.swift */; };
 		F79914E37499F5FE7297C009 /* PresentationPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB40B6883D6232A52132FA30 /* PresentationPipeline.swift */; };
+		F97846ECF2EADD4484996415 /* DroidHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */; };
 		F9C6AC77A6FB6F8DE3D4A6DB /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 7D52A635E3B0AD7FA3A4255D /* ArgumentParser */; };
 		FA750A3CFFC86E664AAA4A00 /* NotificationInboxButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 896298593071A80E3E914866 /* NotificationInboxButton.swift */; };
 		FA751D5D7BCE3C7048198953 /* CopilotOSCProgressReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8650021838A0AF48775312 /* CopilotOSCProgressReducer.swift */; };
@@ -347,6 +350,7 @@
 		19801FEA1E31AE1665776372 /* OpenWithCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenWithCatalog.swift; sourceTree = "<group>"; };
 		1AE59622A5FC54739F5CC7AA /* ZenttyCLIDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenttyCLIDiscoveryTests.swift; sourceTree = "<group>"; };
 		1B5FBD6A49E1AC7F9DB7BB3C /* LicensesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesWindowController.swift; sourceTree = "<group>"; };
+		1BCA77C435DCC7E4F338789C /* DroidTaskStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidTaskStore.swift; sourceTree = "<group>"; };
 		1CF5DDE2F06EB5CBE4C2E0B9 /* WorklaneState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneState+Testing.swift"; sourceTree = "<group>"; };
 		1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDropPlaceholderView.swift; sourceTree = "<group>"; };
 		20147088C6EEA07145EA0961 /* ShellEscaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEscaping.swift; sourceTree = "<group>"; };
@@ -431,6 +435,7 @@
 		677818B56188202E6289EC96 /* WorklaneColorMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorMenuItemView.swift; sourceTree = "<group>"; };
 		6BC138BE273ED92291124633 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		6D46D74C2BFDAC52C678BDB1 /* TerminalMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMetadata.swift; sourceTree = "<group>"; };
+		6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidHooksInstaller.swift; sourceTree = "<group>"; };
 		7017B142217423B1126B8E2A /* WindowChromeRowLayoutPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeRowLayoutPlanner.swift; sourceTree = "<group>"; };
 		70234FD008E68026E8248FF5 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		7120EEE7A0C06BD8315283B9 /* MainWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowControllerTests.swift; sourceTree = "<group>"; };
@@ -839,6 +844,8 @@
 				C344F4EE24498B605D2794B3 /* ClaudeHookSessionStore.swift */,
 				D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */,
 				8E60EACABB7717596CA70DEE /* DiscoveryIPCHandler.swift */,
+				6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */,
+				1BCA77C435DCC7E4F338789C /* DroidTaskStore.swift */,
 				24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */,
 				1703E7CBF1D46D10D30281FC /* KimiHooksInstaller.swift */,
 				898B152AC508F23715DB2518 /* OpenCodeLiveThemeSync.swift */,
@@ -1376,7 +1383,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/gemini/gemini\" -o -path \"*/kimi/kimi\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
+			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/droid/droid\" -o -path \"*/gemini/gemini\" -o -path \"*/kimi/kimi\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
 		};
 		C7055FCE2E5119172F74E931 /* Verify GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1533,6 +1540,8 @@
 				4CCDF0D69B99D52B07074B08 /* CopilotTitleNeedsInputReducer.swift in Sources */,
 				C6FC32D748BD8642629B7321 /* CursorHooksInstaller.swift in Sources */,
 				63889DD70BDB3D367FE16B16 /* DiscoveryIPCHandler.swift in Sources */,
+				F97846ECF2EADD4484996415 /* DroidHooksInstaller.swift in Sources */,
+				EAC39845FAE3EF9784F2F17C /* DroidTaskStore.swift in Sources */,
 				DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */,
 				257E380BBDC29CDFE3389A48 /* ExplicitAgentStateReducer.swift in Sources */,
 				260AB2147508C0997EDC89BC /* FallbackTitleHeuristicReducer.swift in Sources */,
@@ -1701,6 +1710,7 @@
 				880EF4CC0E61299FC43869BC /* AgentIPCProtocol.swift in Sources */,
 				F5A26C1A6A89ED60FFF6F341 /* AgentToolLauncher.swift in Sources */,
 				BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */,
+				DB99D15DBBA9E04854EE979F /* DroidHooksInstaller.swift in Sources */,
 				99451BC2B09FAA072A3B3A88 /* JSONCRelaxedParse.swift in Sources */,
 				B32F85F567CD87464A187C57 /* KimiHooksInstaller.swift in Sources */,
 				0353FE3D437A0B9370A6261B /* TopologyCLI.swift in Sources */,

--- a/Zentty/AppState/Agent/AgentEventAdapters.swift
+++ b/Zentty/AppState/Agent/AgentEventAdapters.swift
@@ -2,6 +2,328 @@ import Foundation
 import os
 
 private let cursorAdapterLogger = Logger(subsystem: "be.zenjoy.zentty", category: "CursorAdapter")
+private let droidAdapterLogger = Logger(subsystem: "be.zenjoy.zentty", category: "DroidAdapter")
+
+// MARK: - Droid Adapter
+
+extension AgentEventBridge {
+    static func droidAdapter(
+        data: Data,
+        environment: [String: String],
+        taskStore: DroidTaskStore = DroidTaskStore()
+    ) throws -> [AgentStatusPayload] {
+        let jsonObject = data.isEmpty ? [:] : (try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:])
+        guard let hookEventName = firstString(in: jsonObject, keys: ["hook_event_name", "hookEventName"]) else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+
+        guard currentTargetIfAvailable(from: environment) != nil else {
+            return []
+        }
+
+        let target = try currentTarget(from: environment)
+        let toolName = AgentTool.droid.displayName
+        let sessionID = firstString(in: jsonObject, keys: ["session_id", "sessionId"])
+        let cwd = firstString(in: jsonObject, keys: ["cwd", "working_directory", "workingDirectory", "project_dir", "projectDir"])
+        let message = firstString(in: jsonObject, keys: ["message", "body", "text", "prompt", "description"])
+        let hookToolName = firstString(in: jsonObject, keys: ["tool_name", "toolName"])
+        let permissionMode = firstString(in: jsonObject, keys: ["permission_mode", "permissionMode"])
+        let toolInput = (jsonObject["tool_input"] as? [String: Any])
+            ?? (jsonObject["toolInput"] as? [String: Any])
+        let pid = parseAgentPID(from: environment, key: "ZENTTY_DROID_PID")
+
+        switch hookEventName {
+        case "SessionStart":
+            var payloads: [AgentStatusPayload] = []
+            if let pid {
+                payloads.append(pidPayload(target: target, toolName: toolName, pid: pid, event: .attach, sessionID: sessionID))
+            }
+            payloads.append(lifecyclePayload(target: target, toolName: toolName, state: .starting, sessionID: sessionID, cwd: cwd))
+            return payloads
+
+        case "PreToolUse":
+            if hookToolName == "TodoWrite",
+               let sessionID,
+               let todoProgress = droidTodoProgress(toolInput: toolInput) {
+                let taskProgress = try taskStore.updateProgress(
+                    sessionID: sessionID,
+                    doneCount: todoProgress.doneCount,
+                    totalCount: todoProgress.totalCount
+                )
+                return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+            }
+            if hookToolName == "Task", let sessionID {
+                let taskProgress = try taskStore.taskCreated(sessionID: sessionID)
+                return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+            }
+            if hookToolName == "AskUser" {
+                let askUserInteraction = droidAskUserInteraction(toolInput: toolInput)
+                let interactionText = askUserInteraction.text ?? message ?? "Droid needs your input"
+                let interactionKind = askUserInteraction.kind
+                    ?? AgentInteractionClassifier.interactionKind(forWaitingMessage: interactionText)
+                    ?? .question
+                return [AgentStatusPayload(
+                    windowID: target.windowID,
+                    worklaneID: target.worklaneID,
+                    paneID: target.paneID,
+                    state: .needsInput,
+                    origin: .explicitHook,
+                    toolName: toolName,
+                    text: interactionText,
+                    lifecycleEvent: .update,
+                    interactionKind: interactionKind,
+                    confidence: .explicit,
+                    sessionID: sessionID,
+                    taskProgress: try taskStore.taskProgress(sessionID: sessionID),
+                    artifactKind: nil,
+                    artifactLabel: nil,
+                    artifactURL: nil,
+                    agentWorkingDirectory: cwd
+                )]
+            }
+            if droidManualModeRequiresApproval(permissionMode: permissionMode, toolName: hookToolName) {
+                let interactionText = droidApprovalText(toolName: hookToolName, toolInput: toolInput)
+                return [AgentStatusPayload(
+                    windowID: target.windowID,
+                    worklaneID: target.worklaneID,
+                    paneID: target.paneID,
+                    state: .needsInput,
+                    origin: .explicitHook,
+                    toolName: toolName,
+                    text: interactionText,
+                    lifecycleEvent: .update,
+                    interactionKind: .approval,
+                    confidence: .explicit,
+                    sessionID: sessionID,
+                    taskProgress: try taskStore.taskProgress(sessionID: sessionID),
+                    artifactKind: nil,
+                    artifactLabel: nil,
+                    artifactURL: nil,
+                    agentWorkingDirectory: cwd
+                )]
+            }
+            let taskProgress = try taskStore.taskProgress(sessionID: sessionID)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+
+        case "PostToolUse":
+            if hookToolName == "TodoWrite",
+               let sessionID,
+               let todoProgress = droidTodoProgress(toolInput: toolInput) {
+                let taskProgress = try taskStore.updateProgress(
+                    sessionID: sessionID,
+                    doneCount: todoProgress.doneCount,
+                    totalCount: todoProgress.totalCount
+                )
+                return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+            }
+            let taskProgress = try taskStore.taskProgress(sessionID: sessionID)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+
+        case "UserPromptSubmit":
+            let taskProgress = try taskStore.taskProgress(sessionID: sessionID)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+
+        case "Notification":
+            let interactionText = message ?? "Droid needs your input"
+            let interactionKind: PaneAgentInteractionKind
+            let normalized = interactionText.lowercased()
+            if normalized.contains("permission") || normalized.contains("approval") || normalized.contains("approve") {
+                interactionKind = .approval
+            } else if normalized.contains("?") {
+                interactionKind = .question
+            } else {
+                interactionKind = .genericInput
+            }
+            return [AgentStatusPayload(
+                windowID: target.windowID,
+                worklaneID: target.worklaneID,
+                paneID: target.paneID,
+                state: .needsInput,
+                origin: .explicitHook,
+                toolName: toolName,
+                text: interactionText,
+                lifecycleEvent: .update,
+                interactionKind: interactionKind,
+                confidence: .explicit,
+                sessionID: sessionID,
+                taskProgress: try taskStore.taskProgress(sessionID: sessionID),
+                artifactKind: nil,
+                artifactLabel: nil,
+                artifactURL: nil,
+                agentWorkingDirectory: cwd
+            )]
+
+        case "SubagentStop":
+            if let sessionID {
+                let taskProgress = try taskStore.taskCompleted(sessionID: sessionID)
+                return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+            }
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd)]
+
+        case "Stop":
+            let taskProgress = try taskStore.taskProgress(sessionID: sessionID)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .idle, sessionID: sessionID, cwd: cwd, taskProgress: taskProgress)]
+
+        case "SessionEnd":
+            try taskStore.clearSession(sessionID: sessionID)
+            return [
+                AgentStatusPayload(
+                    windowID: target.windowID,
+                    worklaneID: target.worklaneID,
+                    paneID: target.paneID,
+                    signalKind: .lifecycle,
+                    state: nil,
+                    origin: .explicitHook,
+                    toolName: toolName,
+                    text: nil,
+                    sessionID: sessionID,
+                    artifactKind: nil,
+                    artifactLabel: nil,
+                    artifactURL: nil
+                ),
+                pidPayload(target: target, toolName: toolName, pid: nil, event: .clear, sessionID: sessionID),
+            ]
+
+        default:
+            droidAdapterLogger.debug("Unhandled droid hook event: \(hookEventName, privacy: .public)")
+            return []
+        }
+    }
+
+    private static func droidManualModeRequiresApproval(permissionMode: String?, toolName: String?) -> Bool {
+        guard permissionMode?.caseInsensitiveCompare("off") == .orderedSame,
+              let toolName else {
+            return false
+        }
+
+        let approvalTools: Set<String> = [
+            "Create",
+            "Edit",
+            "Execute",
+            "MultiEdit",
+            "NotebookEdit",
+            "Write",
+        ]
+        return approvalTools.contains(toolName)
+    }
+
+    private static func droidAskUserInteraction(toolInput: [String: Any]?) -> (
+        text: String?,
+        kind: PaneAgentInteractionKind?
+    ) {
+        let text = firstString(in: toolInput, keys: ["question", "prompt", "message", "text"])
+        let options = droidStringArray(in: toolInput, keys: ["options", "choices"])
+        guard let text, !options.isEmpty else {
+            return (text, nil)
+        }
+
+        return (([text] + options.map { "- \($0)" }).joined(separator: "\n"), .decision)
+    }
+
+    private static func droidApprovalText(toolName: String?, toolInput: [String: Any]?) -> String {
+        let tool = toolName ?? "tool"
+        if let command = firstString(in: toolInput, keys: ["command"]) {
+            return "Allow \(tool): \(command)"
+        }
+        if let path = firstString(in: toolInput, keys: ["file_path", "filePath", "path"]) {
+            return "Allow \(tool) on \(path)?"
+        }
+        return "Droid needs your permission to use \(tool)"
+    }
+
+    private static func droidStringArray(in object: [String: Any]?, keys: [String]) -> [String] {
+        guard let object else { return [] }
+        for key in keys {
+            if let values = object[key] as? [String] {
+                return values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+            }
+            if let values = object[key] as? [[String: Any]] {
+                return values.compactMap { firstString(in: $0, keys: ["label", "text", "value", "name"]) }
+            }
+        }
+        return []
+    }
+
+    private struct DroidTodoProgressSnapshot {
+        let doneCount: Int
+        let totalCount: Int
+    }
+
+    private static func droidTodoProgress(toolInput: [String: Any]?) -> DroidTodoProgressSnapshot? {
+        guard let toolInput, let todos = toolInput["todos"] else {
+            return nil
+        }
+
+        if let todoObjects = todos as? [[String: Any]] {
+            return droidTodoProgress(todoObjects: todoObjects)
+        }
+
+        if let todoLines = todos as? [String] {
+            return droidTodoProgress(todoText: todoLines.joined(separator: "\n"))
+        }
+
+        if let todoText = todos as? String {
+            return droidTodoProgress(todoText: todoText)
+        }
+
+        return nil
+    }
+
+    private static func droidTodoProgress(todoObjects: [[String: Any]]) -> DroidTodoProgressSnapshot? {
+        guard !todoObjects.isEmpty else {
+            return DroidTodoProgressSnapshot(doneCount: 0, totalCount: 0)
+        }
+
+        let statuses = todoObjects.compactMap { todo in
+            firstString(in: todo, keys: ["status", "state"])
+        }
+        guard !statuses.isEmpty else { return nil }
+
+        let doneCount = statuses.filter { droidTodoStatusIsComplete($0) }.count
+        return DroidTodoProgressSnapshot(doneCount: doneCount, totalCount: statuses.count)
+    }
+
+    private static func droidTodoProgress(todoText: String) -> DroidTodoProgressSnapshot? {
+        var totalCount = 0
+        var doneCount = 0
+        var sawTodoLine = false
+
+        for rawLine in todoText.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !line.isEmpty else { continue }
+            sawTodoLine = true
+
+            if line.contains("[completed]") || line.contains("[done]") {
+                totalCount += 1
+                doneCount += 1
+            } else if line.contains("[in_progress]")
+                || line.contains("[in-progress]")
+                || line.contains("[pending]") {
+                totalCount += 1
+            } else if line.contains("[x]") {
+                totalCount += 1
+                doneCount += 1
+            } else if line.contains("[ ]") {
+                totalCount += 1
+            }
+        }
+
+        guard totalCount > 0 || !sawTodoLine else {
+            return nil
+        }
+        return DroidTodoProgressSnapshot(doneCount: doneCount, totalCount: totalCount)
+    }
+
+    private static func droidTodoStatusIsComplete(_ status: String) -> Bool {
+        switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "completed", "complete", "done":
+            return true
+        default:
+            return false
+        }
+    }
+}
 
 // MARK: - Gemini Adapter
 
@@ -1212,7 +1534,8 @@ extension AgentEventBridge {
         state: PaneAgentState,
         lifecycleEvent: AgentLifecycleEvent = .update,
         sessionID: String? = nil,
-        cwd: String? = nil
+        cwd: String? = nil,
+        taskProgress: PaneAgentTaskProgress? = nil
     ) -> AgentStatusPayload {
         AgentStatusPayload(
             windowID: target.windowID,
@@ -1225,6 +1548,7 @@ extension AgentEventBridge {
             lifecycleEvent: lifecycleEvent,
             confidence: .explicit,
             sessionID: sessionID,
+            taskProgress: taskProgress,
             artifactKind: nil,
             artifactLabel: nil,
             artifactURL: nil,

--- a/Zentty/AppState/Agent/AgentEventBridge.swift
+++ b/Zentty/AppState/Agent/AgentEventBridge.swift
@@ -63,6 +63,8 @@ enum AgentEventBridge {
                 payloads = try codexAdapter(data: inputData, defaultEventName: eventName, environment: environment)
             case "codex-notify":
                 payloads = try codexNotifyAdapter(data: inputData, environment: environment)
+            case "droid":
+                payloads = try droidAdapter(data: inputData, environment: environment)
             case "gemini":
                 payloads = try geminiAdapter(data: inputData, environment: environment)
             case "cursor":

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -17,6 +17,7 @@ enum AgentBootstrapTool: String, Codable, Equatable {
     case codex
     case copilot
     case cursor
+    case droid
     case gemini
     case kimi
     case opencode
@@ -29,7 +30,7 @@ enum AgentBootstrapTool: String, Codable, Equatable {
         switch self {
         case .cursor:
             return ["cursor-agent"]
-        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi:
+        case .claude, .codex, .copilot, .droid, .gemini, .kimi, .opencode, .pi:
             return [rawValue]
         }
     }

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -60,6 +60,13 @@ enum AgentLaunchBootstrap {
                 environment: environment,
                 fileManager: fileManager
             )
+        case .droid:
+            return try droidPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                environment: environment,
+                fileManager: fileManager
+            )
         case .gemini:
             return try geminiPlan(
                 executablePath: executablePath,
@@ -119,6 +126,29 @@ enum AgentLaunchBootstrap {
             arguments: arguments,
             setEnvironment: [
                 "ZENTTY_AGENT_TOOL": "cursor",
+            ],
+            unsetEnvironment: [],
+            preLaunchActions: []
+        )
+    }
+
+    private static func droidPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        fileManager: FileManager
+    ) throws -> AgentLaunchPlan {
+        if environment["ZENTTY_DROID_HOOKS_DISABLED"] == "1" {
+            return directPlan(executablePath: executablePath, arguments: arguments)
+        }
+
+        DroidHooksInstaller.installIfPossible(environment: environment, fileManager: fileManager)
+
+        return AgentLaunchPlan(
+            executablePath: executablePath,
+            arguments: arguments,
+            setEnvironment: [
+                "ZENTTY_AGENT_TOOL": "droid",
             ],
             unsetEnvironment: [],
             preLaunchActions: []

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -5,6 +5,7 @@ enum AgentTool: Equatable, Sendable {
     case codex
     case copilot
     case cursor
+    case droid
     case gemini
     case kimi
     case openCode
@@ -21,6 +22,8 @@ enum AgentTool: Equatable, Sendable {
             return "Copilot"
         case .cursor:
             return "Cursor"
+        case .droid:
+            return "Droid"
         case .gemini:
             return "Gemini"
         case .kimi:
@@ -50,6 +53,9 @@ enum AgentTool: Equatable, Sendable {
         }
         if normalized.contains("cursor") {
             return .cursor
+        }
+        if normalized.contains("droid") {
+            return .droid
         }
         if normalized.contains("gemini") {
             return .gemini
@@ -81,6 +87,9 @@ enum AgentTool: Equatable, Sendable {
         }
         if normalized.contains("codex") {
             return .codex
+        }
+        if normalized.contains("droid") {
+            return .droid
         }
         if normalized.contains("gemini") {
             return .gemini

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -42,32 +42,8 @@ enum AgentTool: Equatable, Sendable {
             return nil
         }
 
-        if normalized.contains("claude") {
-            return .claudeCode
-        }
-        if normalized.contains("codex") {
-            return .codex
-        }
-        if normalized.contains("copilot") {
-            return .copilot
-        }
-        if normalized.contains("cursor") {
-            return .cursor
-        }
-        if normalized.contains("droid") {
-            return .droid
-        }
-        if normalized.contains("gemini") {
-            return .gemini
-        }
-        if normalized.contains("kimi") {
-            return .kimi
-        }
-        if normalized.contains("opencode") || normalized.contains("open code") {
-            return .openCode
-        }
-        if matchesPi(normalized) {
-            return .pi
+        if let tool = resolveKnownTool(named: normalized, includeHookDrivenOnly: true) {
+            return tool
         }
 
         guard let rawName = rawName?.trimmingCharacters(in: .whitespacesAndNewlines), !rawName.isEmpty else {
@@ -82,32 +58,55 @@ enum AgentTool: Equatable, Sendable {
             return nil
         }
 
-        if normalized.contains("claude") {
-            return .claudeCode
-        }
-        if normalized.contains("codex") {
-            return .codex
-        }
-        if normalized.contains("droid") {
-            return .droid
-        }
-        if normalized.contains("gemini") {
-            return .gemini
-        }
-        if normalized.contains("kimi") {
-            return .kimi
-        }
-        if normalized.contains("opencode") || normalized.contains("open code") {
-            return .openCode
-        }
-        if matchesPi(normalized) {
-            return .pi
-        }
+        return resolveKnownTool(named: normalized, includeHookDrivenOnly: false)
+    }
 
-        // Keep Copilot hook-driven only for metadata recognition so generic
-        // terminal-progress fallback still shows Running when hooks are absent.
+    private static func resolveKnownTool(named normalized: String, includeHookDrivenOnly: Bool) -> AgentTool? {
+        for matcher in knownToolMatchers {
+            guard includeHookDrivenOnly || !matcher.isHookDrivenOnly else { continue }
+            if matcher.matches(normalized) {
+                return matcher.tool
+            }
+        }
         return nil
     }
+
+    private struct ToolNameMatcher: Sendable {
+        let tool: AgentTool
+        let isHookDrivenOnly: Bool
+        let match: Match
+
+        func matches(_ normalized: String) -> Bool {
+            switch match {
+            case .contains(let needle):
+                return normalized.contains(needle)
+            case .containsAny(let needles):
+                return needles.contains { normalized.contains($0) }
+            case .pi:
+                return matchesPi(normalized)
+            }
+        }
+    }
+
+    private enum Match: Sendable {
+        case contains(String)
+        case containsAny([String])
+        case pi
+    }
+
+    private static let knownToolMatchers: [ToolNameMatcher] = [
+        ToolNameMatcher(tool: .claudeCode, isHookDrivenOnly: false, match: .contains("claude")),
+        ToolNameMatcher(tool: .codex, isHookDrivenOnly: false, match: .contains("codex")),
+        // Keep hook-driven-only tools out of metadata recognition so generic
+        // terminal-progress fallback still shows Running when hooks are absent.
+        ToolNameMatcher(tool: .copilot, isHookDrivenOnly: true, match: .contains("copilot")),
+        ToolNameMatcher(tool: .cursor, isHookDrivenOnly: true, match: .contains("cursor")),
+        ToolNameMatcher(tool: .droid, isHookDrivenOnly: false, match: .contains("droid")),
+        ToolNameMatcher(tool: .gemini, isHookDrivenOnly: false, match: .contains("gemini")),
+        ToolNameMatcher(tool: .kimi, isHookDrivenOnly: false, match: .contains("kimi")),
+        ToolNameMatcher(tool: .openCode, isHookDrivenOnly: false, match: .containsAny(["opencode", "open code"])),
+        ToolNameMatcher(tool: .pi, isHookDrivenOnly: false, match: .pi),
+    ]
 
     private static func matchesPi(_ normalized: String) -> Bool {
         // Pi's binary name is short ("pi") and its titlebar extension uses

--- a/Zentty/AppState/Agent/AgentStatusHelper.swift
+++ b/Zentty/AppState/Agent/AgentStatusHelper.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 enum AgentStatusHelper {
-    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"]
+    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"]
     private static let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
     static func runIfNeeded(arguments: [String], environment: [String: String]) -> Int32? {
@@ -55,6 +55,7 @@ enum AgentStatusHelper {
                     "codex/codex",
                     "copilot/copilot",
                     "cursor/cursor-agent",
+                    "droid/droid",
                     "gemini/gemini",
                     "kimi/kimi",
                     "opencode/opencode",
@@ -66,6 +67,7 @@ enum AgentStatusHelper {
                     "codex/codex",
                     "copilot/copilot",
                     "cursor/cursor-agent",
+                    "droid/droid",
                     "gemini/gemini",
                     "kimi/kimi",
                     "opencode/opencode",

--- a/Zentty/AppState/Agent/DroidHooksInstaller.swift
+++ b/Zentty/AppState/Agent/DroidHooksInstaller.swift
@@ -1,0 +1,299 @@
+import Foundation
+import os
+
+private let installerLogger = Logger(subsystem: "be.zenjoy.zentty", category: "DroidHookInstall")
+
+/// Installs and removes Zentty hook entries in Droid's user-level settings.local.json file.
+///
+/// Droid (`droid`) merges hooks from `~/.factory/settings.local.json` on top of
+/// `~/.factory/settings.json`. The installer mutates `settings.local.json` in place:
+/// Zentty's managed entries are marked by the presence of `hookMarker` in the command
+/// string, so uninstall (and re-install) can find and rewrite them without touching
+/// entries owned by the user or other tools in either file.
+enum DroidHooksInstaller {
+    static let managedEvents: [String] = [
+        "SessionStart",
+        "SessionEnd",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Notification",
+        "Stop",
+        "SubagentStop",
+    ]
+
+    /// Substring present in every Zentty-managed hook command. Used to locate
+    /// and remove our entries without affecting entries the user added by hand
+    /// or via another tool.
+    static let hookMarker: String = "ipc agent-event --adapter=droid"
+
+    static func defaultUserSettingsURL(
+        home: String = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+    ) -> URL {
+        URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".factory", isDirectory: true)
+            .appendingPathComponent("settings.local.json", isDirectory: false)
+    }
+
+    /// Write (or refresh) Zentty's hook entries in the given file. Safe to call
+    /// repeatedly; stale entries are replaced in place.
+    ///
+    /// Throws only on unrecoverable I/O failures. A malformed existing file is
+    /// surfaced as a thrown error so the caller can log an actionable message
+    /// rather than destroying user data.
+    static func install(
+        at settingsURL: URL,
+        cliPath: String,
+        fileManager: FileManager = .default
+    ) throws {
+        let command = hookCommand(cliPath: cliPath)
+        try fileManager.createDirectory(
+            at: settingsURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        var jsonObject: [String: Any] = [:]
+        if fileManager.isReadableFile(atPath: settingsURL.path) {
+            let data = try Data(contentsOf: settingsURL)
+            if !data.isEmpty {
+                guard let parsed = parsePermissive(data) else {
+                    throw CocoaError(
+                        .propertyListReadCorrupt,
+                        userInfo: [NSLocalizedDescriptionKey:
+                            "\(settingsURL.path) is not valid JSON; move it aside or fix it and relaunch"]
+                    )
+                }
+                jsonObject = parsed
+            }
+        }
+
+        var hooks = jsonObject["hooks"] as? [String: Any] ?? [:]
+        for event in managedEvents {
+            var entries = hooks[event] as? [[String: Any]] ?? []
+            entries.removeAll { entry in
+                guard let nestedHooks = entry["hooks"] as? [[String: Any]] else { return false }
+                return nestedHooks.contains { hook in
+                    guard let existing = hook["command"] as? String else { return false }
+                    return existing.contains(hookMarker)
+                }
+            }
+            entries.append([
+                "hooks": [
+                    [
+                        "type": "command",
+                        "command": command,
+                        "timeout": 10,
+                    ],
+                ],
+            ])
+            hooks[event] = entries
+        }
+        jsonObject["hooks"] = hooks
+
+        let newData = try JSONSerialization.data(
+            withJSONObject: jsonObject,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+
+        if fileManager.isReadableFile(atPath: settingsURL.path),
+           let existing = try? Data(contentsOf: settingsURL),
+           existing == newData {
+            return
+        }
+
+        try newData.write(to: settingsURL, options: .atomic)
+    }
+
+    /// Remove any Zentty-managed entries from the given file. If removal
+    /// leaves the file with no hooks and no other top-level keys, the file is
+    /// deleted entirely. Files that never contained a Zentty entry are left
+    /// exactly as-is (including any JSON-with-Comments formatting the user may
+    /// have).
+    static func uninstall(
+        at settingsURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.isReadableFile(atPath: settingsURL.path) else {
+            return
+        }
+        let data = try Data(contentsOf: settingsURL)
+        guard !data.isEmpty, var jsonObject = parsePermissive(data) else {
+            return
+        }
+
+        guard var hooks = jsonObject["hooks"] as? [String: Any] else {
+            return
+        }
+
+        var didRemoveAny = false
+        for event in managedEvents {
+            guard var entries = hooks[event] as? [[String: Any]] else { continue }
+            let before = entries.count
+            entries.removeAll { entry in
+                guard let nestedHooks = entry["hooks"] as? [[String: Any]] else { return false }
+                return nestedHooks.contains { hook in
+                    guard let existing = hook["command"] as? String else { return false }
+                    return existing.contains(hookMarker)
+                }
+            }
+            if entries.count != before {
+                didRemoveAny = true
+            }
+            if entries.isEmpty {
+                if hooks[event] != nil {
+                    hooks.removeValue(forKey: event)
+                }
+            } else {
+                hooks[event] = entries
+            }
+        }
+
+        guard didRemoveAny else {
+            return
+        }
+
+        if hooks.isEmpty {
+            jsonObject.removeValue(forKey: "hooks")
+        } else {
+            jsonObject["hooks"] = hooks
+        }
+
+        if jsonObject.isEmpty {
+            try fileManager.removeItem(at: settingsURL)
+            return
+        }
+
+        let newData = try JSONSerialization.data(
+            withJSONObject: jsonObject,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        if data == newData {
+            return
+        }
+        try newData.write(to: settingsURL, options: .atomic)
+    }
+
+    /// URL for `~/.factory/hooks/hooks.json` where Droid persists hook-level
+    /// settings like `showHookOutput`.
+    static func defaultHooksConfigURL(
+        home: String = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+    ) -> URL {
+        URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".factory", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+            .appendingPathComponent("hooks.json", isDirectory: false)
+    }
+
+    /// Ensure `showHookOutput` is set to `false` in Droid's hooks config.
+    ///
+    /// Zentty hooks are invisible plumbing that should not clutter the Droid
+    /// chat view with purple HOOKS output boxes. This sets the flag only if
+    /// it has not already been explicitly set by the user.
+    static func suppressHookOutput(
+        at hooksConfigURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(
+            at: hooksConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        var jsonObject: [String: Any] = [:]
+        if fileManager.isReadableFile(atPath: hooksConfigURL.path) {
+            let data = try Data(contentsOf: hooksConfigURL)
+            if !data.isEmpty {
+                guard let parsed = parsePermissive(data) else {
+                    // File is corrupt — don't risk overwriting user data.
+                    return
+                }
+                jsonObject = parsed
+            }
+        }
+
+        // Only set the default if the key is absent — respect the user's
+        // explicit choice if they've already toggled it.
+        guard jsonObject["showHookOutput"] == nil else {
+            return
+        }
+
+        jsonObject["showHookOutput"] = false
+
+        let newData = try JSONSerialization.data(
+            withJSONObject: jsonObject,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try newData.write(to: hooksConfigURL, options: .atomic)
+    }
+
+    /// Run `install` with environment-derived paths, logging the outcome.
+    /// Used by the auto-install path during `zentty launch droid`.
+    static func installIfPossible(
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) {
+        guard let cliPath = environment["ZENTTY_CLI_BIN"]?.nonBlank else {
+            installerLogger.debug("Skipping droid hook install: ZENTTY_CLI_BIN is not set")
+            return
+        }
+        guard let home = environment["HOME"]?.nonBlank else {
+            installerLogger.debug("Skipping droid hook install: HOME is not set")
+            return
+        }
+        let settingsURL = defaultUserSettingsURL(home: home)
+        do {
+            try install(at: settingsURL, cliPath: cliPath, fileManager: fileManager)
+            installerLogger.info("Installed Zentty hook entries in \(settingsURL.path, privacy: .public)")
+        } catch {
+            installerLogger.error(
+                "Failed to install droid hooks at \(settingsURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+
+        let hooksConfigURL = defaultHooksConfigURL(home: home)
+        do {
+            try suppressHookOutput(at: hooksConfigURL, fileManager: fileManager)
+        } catch {
+            installerLogger.warning(
+                "Failed to suppress droid hook output at \(hooksConfigURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Internals
+
+    static func hookCommand(cliPath: String) -> String {
+        "\"\(shellEscapeDoubleQuoted(cliPath))\" ipc agent-event --adapter=droid"
+    }
+
+    /// Try strict JSON first; on failure, retry after stripping `//` / `/* */`
+    /// comments and trailing commas (JSON-with-Comments forms some users edit
+    /// by hand). Returns `nil` only when the content can't be recovered.
+    private static func parsePermissive(_ data: Data) -> [String: Any]? {
+        if let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return parsed
+        }
+        guard let stripped = JSONCRelaxedParse.stripComments(in: data),
+              let cleaned = JSONCRelaxedParse.stripTrailingCommas(in: stripped),
+              let parsed = try? JSONSerialization.jsonObject(with: cleaned) as? [String: Any] else {
+            return nil
+        }
+        return parsed
+    }
+
+    private static func shellEscapeDoubleQuoted(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
+    }
+}
+
+private extension String {
+    /// Returns `self` when it has at least one non-whitespace character; `nil`
+    /// otherwise. Mirrors the trimming behaviour the pre-extraction helpers
+    /// relied on to filter out env vars set to whitespace-only strings.
+    var nonBlank: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
+}

--- a/Zentty/AppState/Agent/DroidTaskStore.swift
+++ b/Zentty/AppState/Agent/DroidTaskStore.swift
@@ -1,0 +1,200 @@
+import Darwin
+import Foundation
+
+/// Lightweight file-based task counter for Droid sessions.
+///
+/// Droid does not expose dedicated ``TaskCreated`` / ``TaskCompleted`` hooks
+/// like Claude Code. Zentty tracks the exact visible to-do list when Droid
+/// calls ``TodoWrite`` and falls back to sub-droid ``Task`` / ``SubagentStop``
+/// events when no to-do list is available. This store persists per-session
+/// counts across short-lived hook-bridge invocations.
+final class DroidTaskStore {
+    private let stateURL: URL
+    private let lockURL: URL
+    private let fileManager: FileManager
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(
+        stateURL: URL,
+        fileManager: FileManager = .default
+    ) {
+        self.stateURL = stateURL
+        self.lockURL = stateURL.appendingPathExtension("lock")
+        self.fileManager = fileManager
+        self.encoder.outputFormatting = [.sortedKeys]
+    }
+
+    convenience init(
+        processInfo: ProcessInfo = .processInfo,
+        fileManager: FileManager = .default
+    ) {
+        let env = processInfo.environment
+        if let overridePath = env["ZENTTY_DROID_TASK_STATE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridePath.isEmpty {
+            self.init(stateURL: URL(fileURLWithPath: NSString(string: overridePath).expandingTildeInPath), fileManager: fileManager)
+            return
+        }
+
+        let stateURL: URL
+        if let appSupportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            stateURL = appSupportDirectory
+                .appendingPathComponent("Zentty", isDirectory: true)
+                .appendingPathComponent("droid-task-sessions.json", isDirectory: false)
+        } else {
+            stateURL = fileManager.temporaryDirectory.appendingPathComponent("zentty-droid-task-sessions.json")
+        }
+        self.init(stateURL: stateURL, fileManager: fileManager)
+    }
+
+    /// Record a new sub-droid task being created. Returns the updated progress.
+    func taskCreated(sessionID: String) throws -> PaneAgentTaskProgress? {
+        try withLockedState { state in
+            let key = normalized(sessionID)
+            guard !key.isEmpty else { return nil }
+            var entry = state.sessions[key] ?? SessionEntry()
+            guard entry.source != .todo else {
+                return entry.progress
+            }
+            entry.source = .subagent
+            entry.totalCount += 1
+            entry.updatedAt = Date().timeIntervalSince1970
+            state.sessions[key] = entry
+            return entry.progress
+        }
+    }
+
+    /// Record a sub-droid task completing. Returns the updated progress.
+    func taskCompleted(sessionID: String) throws -> PaneAgentTaskProgress? {
+        try withLockedState { state in
+            let key = normalized(sessionID)
+            guard !key.isEmpty else { return nil }
+            var entry = state.sessions[key] ?? SessionEntry()
+            guard entry.source != .todo else {
+                return entry.progress
+            }
+            entry.source = .subagent
+            entry.doneCount = min(entry.doneCount + 1, entry.totalCount)
+            entry.updatedAt = Date().timeIntervalSince1970
+            state.sessions[key] = entry
+            return entry.progress
+        }
+    }
+
+    /// Replace progress with an exact to-do snapshot.
+    func updateProgress(sessionID: String, doneCount: Int, totalCount: Int) throws -> PaneAgentTaskProgress? {
+        try withLockedState { state in
+            let key = normalized(sessionID)
+            guard !key.isEmpty else { return nil }
+            guard totalCount > 0 else {
+                state.sessions.removeValue(forKey: key)
+                // Optional taskProgress cannot distinguish "clear" from "unchanged";
+                // a complete sentinel overwrites and hides stale visible counts.
+                return PaneAgentTaskProgress(doneCount: 1, totalCount: 1)
+            }
+
+            var entry = state.sessions[key] ?? SessionEntry()
+            entry.source = .todo
+            entry.totalCount = totalCount
+            entry.doneCount = min(max(doneCount, 0), totalCount)
+            entry.updatedAt = Date().timeIntervalSince1970
+            state.sessions[key] = entry
+            return entry.progress
+        }
+    }
+
+    /// Retrieve current task progress for a session.
+    func taskProgress(sessionID: String?) throws -> PaneAgentTaskProgress? {
+        guard let key = normalizedOptional(sessionID) else { return nil }
+        return try withLockedState { state in
+            state.sessions[key]?.progress
+        }
+    }
+
+    /// Remove tracking data for a session.
+    func clearSession(sessionID: String?) throws {
+        guard let key = normalizedOptional(sessionID) else { return }
+        try withLockedState { state in
+            state.sessions.removeValue(forKey: key)
+        }
+    }
+
+    // MARK: - Internals
+
+    private struct StoreFile: Codable {
+        var sessions: [String: SessionEntry] = [:]
+    }
+
+    struct SessionEntry: Codable {
+        var source: ProgressSource = .subagent
+        var totalCount: Int = 0
+        var doneCount: Int = 0
+        var updatedAt: TimeInterval = 0
+
+        var progress: PaneAgentTaskProgress? {
+            PaneAgentTaskProgress(doneCount: doneCount, totalCount: totalCount)
+        }
+
+        init() {}
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            source = (try? container.decodeIfPresent(ProgressSource.self, forKey: .source)) ?? .subagent
+            totalCount = try container.decodeIfPresent(Int.self, forKey: .totalCount) ?? 0
+            doneCount = try container.decodeIfPresent(Int.self, forKey: .doneCount) ?? 0
+            updatedAt = try container.decodeIfPresent(TimeInterval.self, forKey: .updatedAt) ?? 0
+        }
+    }
+
+    enum ProgressSource: String, Codable {
+        case subagent
+        case todo
+    }
+
+    @discardableResult
+    private func withLockedState<T>(_ body: (inout StoreFile) throws -> T) throws -> T {
+        try fileManager.createDirectory(at: stateURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if !fileManager.fileExists(atPath: lockURL.path) {
+            fileManager.createFile(atPath: lockURL.path, contents: Data())
+        }
+
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
+        guard descriptor >= 0 else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+        defer { close(descriptor) }
+
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+        defer { flock(descriptor, LOCK_UN) }
+
+        var state = loadState()
+        let result = try body(&state)
+        try saveState(state)
+        return result
+    }
+
+    private func loadState() -> StoreFile {
+        guard let data = try? Data(contentsOf: stateURL) else {
+            return StoreFile()
+        }
+        return (try? decoder.decode(StoreFile.self, from: data)) ?? StoreFile()
+    }
+
+    private func saveState(_ state: StoreFile) throws {
+        let data = try encoder.encode(state)
+        try data.write(to: stateURL, options: .atomic)
+    }
+
+    private func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -754,6 +754,8 @@ enum PanePresentationNormalizer {
             return ["copilot"].contains(normalized)
         case .cursor:
             return ["cursor"].contains(normalized)
+        case .droid:
+            return ["droid"].contains(normalized)
         case .gemini:
             return ["gemini", "gemini cli"].contains(normalized)
         case .kimi:

--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -577,6 +577,7 @@ extension WorklaneStore {
             case .codex: return "codex"
             case .copilot: return "gh copilot"
             case .cursor: return "cursor"
+            case .droid: return "droid"
             case .gemini: return "gemini"
             case .kimi: return "kimi"
             case .openCode: return "opencode"

--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -377,6 +377,12 @@ enum AgentResumeCommandBuilder {
             return "kimi -r \(sessionID)"
         case .cursor:
             return nil
+        case .droid:
+            guard let sessionID = validatedDroidSessionID(from: draft.sessionID) else {
+                logRejectedSessionID(for: draft)
+                return nil
+            }
+            return "droid exec -s \(sessionID)"
         case .pi:
             // Pi resumes per-project via `-c` (continue last session). Since pi stores
             // sessions under ~/.pi/agent/sessions/<project>/, we don't need to pass a
@@ -428,6 +434,17 @@ enum AgentResumeCommandBuilder {
             return nil
         }
         return uuid.uuidString.lowercased()
+    }
+
+    private static func validatedDroidSessionID(from sessionID: String) -> String? {
+        // Droid session IDs are opaque strings; validate only that they are
+        // non-empty and contain no shell metacharacters or whitespace so the
+        // restore command remains a single safe argument.
+        let pattern = "^[A-Za-z0-9_.:-]+$"
+        guard sessionID.range(of: pattern, options: .regularExpression) != nil else {
+            return nil
+        }
+        return sessionID
     }
 
     private static func logRejectedSessionID(for draft: PaneRestoreDraft) {

--- a/Zentty/Terminal/TerminalMetadata.swift
+++ b/Zentty/Terminal/TerminalMetadata.swift
@@ -939,6 +939,8 @@ final class TerminalDiagnostics: @unchecked Sendable {
             return "copilot"
         case .cursor:
             return "cursor"
+        case .droid:
+            return "droid"
         case .gemini:
             return "gemini"
         case .kimi:

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -53,6 +53,8 @@ struct AgentToolLauncher {
             return environment["ZENTTY_COPILOT_HOOKS_DISABLED"] != "1"
         case .cursor:
             return environment["ZENTTY_CURSOR_HOOKS_DISABLED"] != "1"
+        case .droid:
+            return environment["ZENTTY_DROID_HOOKS_DISABLED"] != "1"
         case .kimi:
             if environment["ZENTTY_KIMI_HOOKS_DISABLED"] == "1" {
                 return false
@@ -149,6 +151,7 @@ struct AgentToolLauncher {
             "ZENTTY_COPILOT_HOOKS_DISABLED",
             "ZENTTY_CURSOR_HOOKS_DISABLED",
             "ZENTTY_CURSOR_VERBOSE_HOOKS",
+            "ZENTTY_DROID_HOOKS_DISABLED",
             "ZENTTY_KIMI_HOOKS_DISABLED",
             "ZENTTY_CODEX_NOTIFY_DISABLED",
             "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
@@ -172,7 +175,7 @@ struct AgentToolLauncher {
         switch tool {
         case .claude:
             return EnvironmentPatch(set: [:], unset: ["CLAUDECODE"])
-        case .codex, .copilot, .cursor, .gemini, .kimi, .opencode, .pi:
+        case .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi:
             return EnvironmentPatch()
         }
     }
@@ -194,6 +197,8 @@ struct AgentToolLauncher {
             environmentPatch.set["ZENTTY_GEMINI_PID"] = "\(getpid())"
         case .cursor:
             environmentPatch.set["ZENTTY_CURSOR_PID"] = "\(getpid())"
+        case .droid:
+            environmentPatch.set["ZENTTY_DROID_PID"] = "\(getpid())"
         case .kimi:
             environmentPatch.set["ZENTTY_KIMI_PID"] = "\(getpid())"
         case .opencode, .pi:
@@ -241,6 +246,7 @@ struct AgentToolLauncher {
             "ZENTTY_COPILOT_PID",
             "ZENTTY_GEMINI_PID",
             "ZENTTY_CURSOR_PID",
+            "ZENTTY_DROID_PID",
             "ZENTTY_KIMI_PID",
         ]
         return Dictionary(uniqueKeysWithValues: keys.compactMap { key in

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -529,6 +529,7 @@ struct IPCCommand: ParsableCommand {
         "ZENTTY_COPILOT_PID",
         "ZENTTY_GEMINI_PID",
         "ZENTTY_CURSOR_PID",
+        "ZENTTY_DROID_PID",
         "ZENTTY_KIMI_PID",
     ]
 

--- a/ZenttyIntegrationTests/AgentWrapperTests.swift
+++ b/ZenttyIntegrationTests/AgentWrapperTests.swift
@@ -198,6 +198,40 @@ final class AgentWrapperTests: XCTestCase {
         XCTAssertEqual(request.environment["ZENTTY_PANE_ID"], "pane-main")
     }
 
+    func test_real_cli_ipc_forwards_droid_pid_to_adapter() throws {
+        let server = try IPCRequestCaptureServer()
+        defer { server.invalidate() }
+
+        let payload = #"{"hook_event_name":"SessionStart","session_id":"session-droid"}"#
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try builtCLIPath())
+        process.arguments = ["ipc", "agent-event", "--adapter=droid"]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["ZENTTY_INSTANCE_SOCKET"] = server.socketPath
+        environment["ZENTTY_PANE_TOKEN"] = "pane-token-under-test"
+        environment["ZENTTY_WORKLANE_ID"] = "worklane-main"
+        environment["ZENTTY_PANE_ID"] = "pane-main"
+        environment["ZENTTY_DROID_PID"] = "4242"
+        process.environment = environment
+        process.standardError = Pipe()
+        process.standardOutput = Pipe()
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+
+        try process.run()
+        stdinPipe.fileHandleForWriting.write(Data(payload.utf8))
+        try? stdinPipe.fileHandleForWriting.close()
+        let request = try server.receiveOneRequest()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(request.subcommand, "agent-event")
+        XCTAssertEqual(request.arguments, ["--adapter=droid"])
+        XCTAssertEqual(request.standardInput, payload)
+        XCTAssertEqual(request.environment["ZENTTY_DROID_PID"], "4242")
+    }
+
     func test_real_cli_codex_notify_reads_payload_from_standard_input_when_argument_is_omitted() throws {
         let server = try IPCRequestCaptureServer()
         defer { server.invalidate() }
@@ -354,7 +388,7 @@ final class AgentWrapperTests: XCTestCase {
     }
 
     func test_tool_wrappers_delegate_to_launch_command_when_cli_is_available() throws {
-        for tool in ["claude", "codex", "copilot", "cursor-agent", "gemini", "kimi", "opencode", "pi"] {
+        for tool in ["claude", "codex", "copilot", "cursor-agent", "droid", "gemini", "kimi", "opencode", "pi"] {
             let harness = try WrapperHarness(copyingScriptsNamed: [tool, "zentty-agent-wrapper"])
             try harness.installRealBinary(
                 named: tool,
@@ -764,7 +798,7 @@ private struct WrapperHarness {
     }
 
     private var publicWrapperDirectories: [URL] {
-        ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"]
+        ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"]
             .map { wrapperBinURL.appendingPathComponent($0, isDirectory: true) }
             .filter { FileManager.default.fileExists(atPath: $0.path) }
     }
@@ -783,6 +817,8 @@ private struct WrapperHarness {
             return "copilot/copilot"
         case "cursor-agent":
             return "cursor/cursor-agent"
+        case "droid":
+            return "droid/droid"
         case "gemini":
             return "gemini/gemini"
         case "kimi":

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -871,4 +871,246 @@ final class AgentEventBridgeTests: XCTestCase {
         if let pid { env["ZENTTY_CLAUDE_PID"] = pid }
         return env
     }
+
+    private func droidEnvironment(pid: String? = nil) -> [String: String] {
+        var env = defaultEnvironment
+        if let pid { env["ZENTTY_DROID_PID"] = pid }
+        return env
+    }
+
+    private func makeDroidTaskStore() throws -> DroidTaskStore {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directoryURL) }
+        return DroidTaskStore(stateURL: directoryURL.appendingPathComponent("droid-task-sessions.json"))
+    }
+
+    // MARK: - Droid Task Progress
+
+    func test_droid_preToolUse_Task_increments_total() throws {
+        let store = try makeDroidTaskStore()
+        let json = #"{"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Task","cwd":"/tmp"}"#
+        let payloads = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 0, totalCount: 1))
+    }
+
+    func test_droid_preToolUse_nonTask_preserves_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        let json = #"{"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Edit","cwd":"/tmp"}"#
+        let payloads = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 0, totalCount: 1))
+    }
+
+    func test_droid_preToolUse_todoWrite_string_reports_exact_progress() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"TodoWrite","cwd":"/tmp","tool_input":{"todos":"1. [completed] Review logs\\n2. [in_progress] Patch adapter\\n3. [pending] Run tests"}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 3))
+    }
+
+    func test_droid_preToolUse_todoWrite_array_reports_exact_progress() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"TodoWrite","cwd":"/tmp","tool_input":{"todos":[{"content":"Review logs","status":"completed"},{"content":"Patch adapter","status":"in_progress"},{"content":"Run tests","status":"pending"}]}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 3))
+    }
+
+    func test_droid_preToolUse_todoWrite_accepts_camel_case_tool_input() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"TodoWrite","cwd":"/tmp","toolInput":{"todos":"- [x] Review logs\\n- [ ] Run tests"}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 2))
+    }
+
+    func test_droid_preToolUse_todoWrite_unrecognized_string_preserves_existing_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"TodoWrite","cwd":"/tmp","tool_input":{"todos":"Review logs\\nRun tests"}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 0, totalCount: 1))
+    }
+
+    func test_droid_preToolUse_todoWrite_empty_list_hides_stale_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.updateProgress(sessionID: "sess-1", doneCount: 1, totalCount: 3)
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"TodoWrite","cwd":"/tmp","tool_input":{"todos":[]}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 1))
+        XCTAssertNil(try store.taskProgress(sessionID: "sess-1"))
+    }
+
+    func test_droid_subagent_events_do_not_mutate_todo_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.updateProgress(sessionID: "sess-1", doneCount: 1, totalCount: 3)
+
+        let taskJSON = #"{"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Task","cwd":"/tmp"}"#
+        let taskPayloads = try AgentEventBridge.droidAdapter(data: Data(taskJSON.utf8), environment: droidEnvironment(), taskStore: store)
+        XCTAssertEqual(try XCTUnwrap(taskPayloads.first).taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 3))
+
+        let stopJSON = #"{"hook_event_name":"SubagentStop","session_id":"sess-1","cwd":"/tmp"}"#
+        let stopPayloads = try AgentEventBridge.droidAdapter(data: Data(stopJSON.utf8), environment: droidEnvironment(), taskStore: store)
+        XCTAssertEqual(try XCTUnwrap(stopPayloads.first).taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 3))
+    }
+
+    func test_droid_preToolUse_askUser_reports_question() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"AskUser","cwd":"/tmp","tool_input":{"question":"Choose a target?","options":["Staging","Production"]}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .needsInput)
+        XCTAssertEqual(payload.interactionKind, .decision)
+        XCTAssertEqual(payload.text, "Choose a target?\n- Staging\n- Production")
+    }
+
+    func test_droid_preToolUse_manual_execute_reports_approval() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Execute","permission_mode":"off","cwd":"/tmp","tool_input":{"command":"xcodebuild test"}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .needsInput)
+        XCTAssertEqual(payload.interactionKind, .approval)
+        XCTAssertEqual(payload.text, "Allow Execute: xcodebuild test")
+    }
+
+    func test_droid_preToolUse_auto_execute_stays_running() throws {
+        let store = try makeDroidTaskStore()
+        let json = """
+        {"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Execute","permission_mode":"auto-low","cwd":"/tmp","tool_input":{"command":"ls"}}
+        """
+        let payloads = try AgentEventBridge.droidAdapter(data: Data(json.utf8), environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertNil(payload.interactionKind)
+    }
+
+    func test_droid_subagentStop_increments_done() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        _ = try store.taskCreated(sessionID: "sess-1")
+        let json = #"{"hook_event_name":"SubagentStop","session_id":"sess-1","cwd":"/tmp"}"#
+        let payloads = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 2))
+    }
+
+    func test_droid_task_full_lifecycle() throws {
+        let store = try makeDroidTaskStore()
+        let env = droidEnvironment()
+
+        // Create 3 tasks
+        for _ in 1...3 {
+            let json = #"{"hook_event_name":"PreToolUse","session_id":"sess-1","tool_name":"Task","cwd":"/tmp"}"#
+            _ = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: env, taskStore: store)
+        }
+
+        let progress1 = try store.taskProgress(sessionID: "sess-1")
+        XCTAssertEqual(progress1, PaneAgentTaskProgress(doneCount: 0, totalCount: 3))
+
+        // Complete 2 tasks
+        for _ in 1...2 {
+            let json = #"{"hook_event_name":"SubagentStop","session_id":"sess-1","cwd":"/tmp"}"#
+            _ = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: env, taskStore: store)
+        }
+
+        let progress2 = try store.taskProgress(sessionID: "sess-1")
+        XCTAssertEqual(progress2, PaneAgentTaskProgress(doneCount: 2, totalCount: 3))
+
+        // Complete last task
+        let json = #"{"hook_event_name":"SubagentStop","session_id":"sess-1","cwd":"/tmp"}"#
+        _ = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: env, taskStore: store)
+
+        let progress3 = try store.taskProgress(sessionID: "sess-1")
+        XCTAssertEqual(progress3, PaneAgentTaskProgress(doneCount: 3, totalCount: 3))
+    }
+
+    func test_droid_sessionEnd_clears_task_progress() throws {
+        let store = try makeDroidTaskStore()
+        let env = droidEnvironment()
+
+        _ = try store.taskCreated(sessionID: "sess-1")
+        _ = try store.taskCreated(sessionID: "sess-1")
+
+        let json = #"{"hook_event_name":"SessionEnd","session_id":"sess-1"}"#
+        _ = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: env, taskStore: store)
+
+        let progress = try store.taskProgress(sessionID: "sess-1")
+        XCTAssertNil(progress)
+    }
+
+    func test_droid_task_store_reads_entries_without_source() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let stateURL = directoryURL.appendingPathComponent("droid-task-sessions.json")
+        let stateJSON = #"{"sessions":{"sess-1":{"doneCount":1,"totalCount":3,"updatedAt":123}}}"#
+        try Data(stateJSON.utf8).write(to: stateURL)
+
+        let store = DroidTaskStore(stateURL: stateURL)
+        XCTAssertEqual(try store.taskProgress(sessionID: "sess-1"), PaneAgentTaskProgress(doneCount: 1, totalCount: 3))
+    }
+
+    func test_droid_stop_carries_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        let json = #"{"hook_event_name":"Stop","session_id":"sess-1","cwd":"/tmp"}"#
+        let payloads = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .idle)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 0, totalCount: 1))
+    }
+
+    func test_droid_notification_carries_progress() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        _ = try store.taskCompleted(sessionID: "sess-1")
+        _ = try store.taskCreated(sessionID: "sess-1")
+        let json = #"{"hook_event_name":"Notification","session_id":"sess-1","message":"Droid needs permission","cwd":"/tmp"}"#
+        let payloads = try AgentEventBridge.droidAdapter(data: json.data(using: .utf8)!, environment: droidEnvironment(), taskStore: store)
+        let payload = try XCTUnwrap(payloads.first)
+        XCTAssertEqual(payload.state, .needsInput)
+        XCTAssertEqual(payload.taskProgress, PaneAgentTaskProgress(doneCount: 1, totalCount: 2))
+    }
+
+    func test_droid_doneCount_clamps_to_totalCount() throws {
+        let store = try makeDroidTaskStore()
+        _ = try store.taskCreated(sessionID: "sess-1")
+        _ = try store.taskCompleted(sessionID: "sess-1")
+        // Extra SubagentStop beyond total should not exceed totalCount
+        _ = try store.taskCompleted(sessionID: "sess-1")
+        let progress = try store.taskProgress(sessionID: "sess-1")
+        XCTAssertEqual(progress, PaneAgentTaskProgress(doneCount: 1, totalCount: 1))
+    }
 }

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -83,6 +83,13 @@ final class AgentStatusSupportTests: XCTestCase {
     func test_agent_tool_recognizes_cursor() {
         XCTAssertEqual(AgentTool.resolve(named: "cursor"), .cursor)
         XCTAssertEqual(AgentTool.resolve(named: "Cursor Agent"), .cursor)
+        XCTAssertNil(AgentTool.resolveKnown(named: "Cursor Agent"))
+    }
+
+    func test_agent_tool_recognizes_droid_for_explicit_and_known_tool_resolution() {
+        XCTAssertEqual(AgentTool.resolve(named: "droid"), .droid)
+        XCTAssertEqual(AgentTool.resolve(named: "Droid CLI"), .droid)
+        XCTAssertEqual(AgentTool.resolveKnown(named: "Droid"), .droid)
     }
 
     func test_agent_tool_recognizes_pi_and_its_titlebar_variants() {

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -220,7 +220,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         XCTAssertEqual(
             AgentStatusHelper.wrapperDirectoryPaths(in: bundle),
-            ["claude", "codex", "copilot", "cursor", "gemini", "kimi", "opencode", "pi"].map {
+            ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"].map {
                 binURL.appendingPathComponent($0, isDirectory: true).path
             }
         )
@@ -1468,6 +1468,68 @@ final class AgentStatusSupportTests: XCTestCase {
             FileManager.default.fileExists(atPath: hooksURL.path),
             "installIfPossible must reject whitespace-only env values"
         )
+    }
+
+    // MARK: - DroidHooksInstaller — suppressHookOutput
+
+    func test_droid_suppress_hook_output_sets_false_on_fresh_file() throws {
+        let directory = try makeTemporaryDirectory(named: "droid-suppress-fresh")
+        let hooksConfigURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+
+        try DroidHooksInstaller.suppressHookOutput(at: hooksConfigURL)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try Data(contentsOf: hooksConfigURL)) as? [String: Any]
+        )
+        XCTAssertEqual(object["showHookOutput"] as? Bool, false)
+    }
+
+    func test_droid_suppress_hook_output_preserves_existing_entries() throws {
+        let directory = try makeTemporaryDirectory(named: "droid-suppress-existing")
+        let hooksConfigURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try #"{"Stop":[{"hooks":[{"type":"command","command":"echo hi"}]}]}"#
+            .write(to: hooksConfigURL, atomically: true, encoding: .utf8)
+
+        try DroidHooksInstaller.suppressHookOutput(at: hooksConfigURL)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try Data(contentsOf: hooksConfigURL)) as? [String: Any]
+        )
+        XCTAssertEqual(object["showHookOutput"] as? Bool, false)
+        XCTAssertNotNil(object["Stop"], "existing hook entries must be preserved")
+    }
+
+    func test_droid_suppress_hook_output_respects_user_true() throws {
+        let directory = try makeTemporaryDirectory(named: "droid-suppress-user-true")
+        let hooksConfigURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try #"{"showHookOutput":true}"#
+            .write(to: hooksConfigURL, atomically: true, encoding: .utf8)
+
+        try DroidHooksInstaller.suppressHookOutput(at: hooksConfigURL)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try Data(contentsOf: hooksConfigURL)) as? [String: Any]
+        )
+        XCTAssertEqual(object["showHookOutput"] as? Bool, true, "user's explicit true must not be overwritten")
+    }
+
+    func test_droid_suppress_hook_output_respects_user_false() throws {
+        let directory = try makeTemporaryDirectory(named: "droid-suppress-user-false")
+        let hooksConfigURL = directory.appendingPathComponent("hooks.json", isDirectory: false)
+        try #"{"showHookOutput":false}"#
+            .write(to: hooksConfigURL, atomically: true, encoding: .utf8)
+
+        let mtimeBefore = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: hooksConfigURL.path)[.modificationDate] as? Date
+        )
+        Thread.sleep(forTimeInterval: 1.1)
+
+        try DroidHooksInstaller.suppressHookOutput(at: hooksConfigURL)
+
+        let mtimeAfter = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: hooksConfigURL.path)[.modificationDate] as? Date
+        )
+        XCTAssertEqual(mtimeBefore, mtimeAfter, "file should not be rewritten when key already exists")
     }
 
     // MARK: - KimiHooksInstaller
@@ -5248,6 +5310,7 @@ final class AgentStatusSupportTests: XCTestCase {
             ("codex", "codex"),
             ("copilot", "copilot"),
             ("cursor", "cursor-agent"),
+            ("droid", "droid"),
             ("gemini", "gemini"),
             ("kimi", "kimi"),
             ("opencode", "opencode"),

--- a/ZenttyResources/bin/droid/droid
+++ b/ZenttyResources/bin/droid/droid
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export ZENTTY_AGENT_TOOL="droid"
+exec "$(cd "$(dirname "$0")" && pwd)/../shared/zentty-agent-wrapper" "$@"

--- a/project.yml
+++ b/project.yml
@@ -52,6 +52,7 @@ targets:
       - path: ZenttyCLI
       - path: Zentty/AppState/Agent/AgentIPCProtocol.swift
       - path: Zentty/AppState/Agent/CursorHooksInstaller.swift
+      - path: Zentty/AppState/Agent/DroidHooksInstaller.swift
       - path: Zentty/AppState/Agent/KimiHooksInstaller.swift
       - path: Zentty/AppState/Agent/JSONCRelaxedParse.swift
       - path: Zentty/UI/Theme/WorklaneColor.swift
@@ -123,7 +124,7 @@ targets:
           mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
           rsync -a --delete "${RESOURCES_SRC}/bin/" "${RESOURCES_DST}/bin/"
           install -m 755 "${BUILT_PRODUCTS_DIR}/zentty" "${RESOURCES_DST}/bin/shared/zentty"
-          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/gemini/gemini" -o -path "*/kimi/kimi" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
+          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/droid/droid" -o -path "*/gemini/gemini" -o -path "*/kimi/kimi" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" \) -exec chmod 755 {} +
           rsync -a --delete "${RESOURCES_SRC}/shell-integration/" "${RESOURCES_DST}/shell-integration/"
           rsync -a --delete "${RESOURCES_SRC}/opencode/" "${RESOURCES_DST}/opencode/"
           rsync -a --delete "${RESOURCES_SRC}/pi/" "${RESOURCES_DST}/pi/"


### PR DESCRIPTION
## Summary
- Add Droid as an agent tool with wrapper/resource wiring and hook installation support.
- Add Droid hook adapter coverage for lifecycle, PID attach/clear, permission/input notifications, and task progress.
- Track Droid task counts from TodoWrite snapshots with a fallback subagent task store, including stale-count clearing and persisted state compatibility.