### PR TITLE
Fix shell integration startup output

### DIFF
--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -442,6 +442,20 @@ final class AgentStatusSupportTests: XCTestCase {
         }
     }
 
+    func test_zsh_shell_integration_does_not_write_terminal_sequences_to_stdout_or_stderr_when_loaded() throws {
+        let result = try runShellIntegrationCommand(shell: .zsh, command: ":", extraEnvironment: ["TTY": "/dev/null"])
+
+        XCTAssertEqual(result.stdout, "")
+        XCTAssertEqual(result.stderr, "")
+    }
+
+    func test_bash_shell_integration_does_not_write_terminal_sequences_to_stdout_or_stderr_when_loaded() throws {
+        let result = try runShellIntegrationCommand(shell: .bash, command: ":", extraEnvironment: ["TTY": "/dev/null"])
+
+        XCTAssertEqual(result.stdout, "")
+        XCTAssertEqual(result.stderr, "")
+    }
+
     func test_zsh_shell_integration_emits_updated_pane_context_before_next_command_after_cd() throws {
         let targetDirectory = try makeTemporaryDirectory(named: "shell-zsh-target")
 

--- a/ZenttyResources/shell-integration/zentty-bash-integration.bash
+++ b/ZenttyResources/shell-integration/zentty-bash-integration.bash
@@ -6,6 +6,16 @@ fi
 export ZENTTY_BASH_INTEGRATION_LOADED=1
 _zentty_shell_activity_last=""
 
+_zentty_print_tty() {
+    local sequence="$1"
+    local tty_path="${TTY:-}"
+    if [[ -z "$tty_path" || ! -w "$tty_path" ]]; then
+        tty_path="/dev/tty"
+    fi
+    [[ -w "$tty_path" ]] || return 0
+    { printf '%s' "$sequence" > "$tty_path"; } 2>/dev/null || true
+}
+
 _zentty_ensure_wrapper_path() {
     local wrapper_dirs="${ZENTTY_ALL_WRAPPER_BIN_DIRS:-${ZENTTY_WRAPPER_BIN_DIRS:-${ZENTTY_WRAPPER_BIN_DIR:-}}}"
     [[ -n "$wrapper_dirs" ]] || return 0
@@ -108,7 +118,7 @@ _zentty_local_git_branch() {
 }
 
 _zentty_reset_title_to_cwd() {
-    printf '\e]2;%s\a' "${PWD/#$HOME/\~}"
+    _zentty_print_tty $'\e]2;'"${PWD/#$HOME/\~}"$'\a'
 }
 
 _zentty_emit_pane_context() {
@@ -151,7 +161,7 @@ _zentty_bash_prompt_hook() {
     # without disabling it (e.g., Ctrl+C killing an agent). Pop up to 99
     # entries to clear multi-level stacks (e.g., Ink/React TUI layers).
     # Extra pops beyond the stack depth are harmless no-ops.
-    printf '\e[<99u'
+    _zentty_print_tty $'\e[<99u'
     _zentty_report_shell_activity prompt
     _zentty_emit_pane_context
     if [[ -n "$_zentty_bash_original_prompt_command" ]]; then
@@ -166,7 +176,7 @@ _zentty_bash_preexec_hook() {
     [[ "$_zentty_bash_in_prompt" == "1" ]] && return 0
     _zentty_report_shell_activity running
     # Set terminal title to the running command (first line only)
-    printf '\e]2;%s\a' "${BASH_COMMAND%%$'\n'*}"
+    _zentty_print_tty $'\e]2;'"${BASH_COMMAND%%$'\n'*}"$'\a'
 }
 
 cd() {

--- a/ZenttyResources/shell-integration/zentty-zsh-integration.zsh
+++ b/ZenttyResources/shell-integration/zentty-zsh-integration.zsh
@@ -3,6 +3,23 @@
 [[ "${ZENTTY_ZSH_INTEGRATION_LOADED:-0}" == "1" ]] && return 0
 typeset -g ZENTTY_ZSH_INTEGRATION_LOADED=1
 typeset -g _zentty_shell_activity_last=""
+typeset -gi _zentty_tty_fd=0
+
+_zentty_open_tty_fd() {
+    (( _zentty_tty_fd > 0 )) && return 0
+    {
+        builtin zmodload zsh/system && (( $+builtins[sysopen] )) && {
+            { [[ -n "${TTY:-}" && -w "$TTY" ]] && builtin sysopen -o cloexec -wu _zentty_tty_fd -- "$TTY" } ||
+            { [[ -w /dev/tty ]] && builtin sysopen -o cloexec -wu _zentty_tty_fd -- /dev/tty }
+        }
+    } 2>/dev/null || return 1
+    (( _zentty_tty_fd > 0 ))
+}
+
+_zentty_print_tty() {
+    _zentty_open_tty_fd || return 0
+    builtin print -rn -u "$_zentty_tty_fd" -- "$1"
+}
 
 _zentty_ensure_wrapper_path() {
     local wrapper_dirs="${ZENTTY_ALL_WRAPPER_BIN_DIRS:-${ZENTTY_WRAPPER_BIN_DIRS:-${ZENTTY_WRAPPER_BIN_DIR:-}}}"
@@ -85,7 +102,7 @@ _zentty_local_git_branch() {
 }
 
 _zentty_reset_title_to_cwd() {
-    builtin printf '\e]2;%s\a' "${PWD/#$HOME/~}"
+    _zentty_print_tty $'\e]2;'"${PWD/#$HOME/~}"$'\a'
 }
 
 _zentty_emit_pane_context() {
@@ -124,7 +141,7 @@ _zentty_precmd() {
     # without disabling it (e.g., Ctrl+C killing an agent). Pop up to 99
     # entries to clear multi-level stacks (e.g., Ink/React TUI layers).
     # Extra pops beyond the stack depth are harmless no-ops.
-    builtin printf '\e[<99u'
+    _zentty_print_tty $'\e[<99u'
     _zentty_report_shell_activity prompt
     _zentty_emit_pane_context
     _zentty_reset_title_to_cwd
@@ -152,7 +169,7 @@ _zentty_preexec() {
     local cmd="${1%%[[:space:]]*}"
     _zentty_is_navigation_command "$cmd" || _zentty_report_shell_activity running
     # Set terminal title to the running command (first line only)
-    builtin printf '\e]2;%s\a' "${1%%$'\n'*}"
+    _zentty_print_tty $'\e]2;'"${1%%$'\n'*}"$'\a'
 }
 
 autoload -Uz add-zsh-hook 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add regression tests that catch shell integration escape sequences leaking to stdout/stderr on startup
- route zsh and bash terminal-control sequences to the controlling TTY instead
- keep prompt title updates and keyboard protocol reset behavior intact

Fixes #7

## Verification
- TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test -scheme Zentty -destination 'platform=macOS'