### PR TITLE
feat(agent): support Amp integration

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		2A08D5A8D71D847DA5EBB8FC /* DiscoveryIPCHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8132E7564D882D85A155D2B5 /* DiscoveryIPCHandlerTests.swift */; };
 		2A64F29063B13F85F622F207 /* SidebarBookmarkRowAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D603FA3B4BCDFE0AC7C4342 /* SidebarBookmarkRowAction.swift */; };
 		2BC7421FF9D00CF7851A5E32 /* JSONCRelaxedParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */; };
+		2C6C6FCC081720E010745882 /* AmpResumeArgumentSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */; };
 		2E7726CCE8D1D2DC6D44DB22 /* ClosedPaneStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8626016D68E310751E9D7E91 /* ClosedPaneStack.swift */; };
 		2F03F61669A9A0D783BB8009 /* WorklanePeekSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBFAD0E8B72C30571FCAD0A /* WorklanePeekSelectionState.swift */; };
 		2F54A7D7AD63E93CC841317F /* GlobalSearchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4483B8E7BA05745883A993C0 /* GlobalSearchCoordinatorTests.swift */; };
@@ -280,6 +281,7 @@
 		BB1BCADC002057CB2A8211ED /* PaneContainerViewWorklaneBorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D468A4AAC25D668673CC51CE /* PaneContainerViewWorklaneBorderTests.swift */; };
 		BB5B3519D7A006621A08A991 /* AppUpdateStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BF48FCF3548F4ABF45950F /* AppUpdateStateStore.swift */; };
 		BC0AC74F991917A3539038CB /* LeadingChromeControlsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A236782CF61D4D5B4FC361 /* LeadingChromeControlsBar.swift */; };
+		BD7EA4AEE8EB280F5A855B2C /* AmpPluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */; };
 		BE30B813EC32158B648F52B1 /* SidebarShimmerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE256725D568E7583890592B /* SidebarShimmerCoordinatorTests.swift */; };
 		BE5DF3CB1463B823867F64C8 /* WorklanePeekKeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F238040A6D3B645944F5AB0 /* WorklanePeekKeyMonitor.swift */; };
 		BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
@@ -543,6 +545,7 @@
 		48846247312C42A929369E20 /* AppKitTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitTestCase.swift; sourceTree = "<group>"; };
 		48BB45FB1B15B96A8C195343 /* PaneSearchHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSearchHUDView.swift; sourceTree = "<group>"; };
 		48F435FA119C97C5F497FBD9 /* PaneLayoutSettingsWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutSettingsWindowControllerTests.swift; sourceTree = "<group>"; };
+		4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpResumeArgumentSanitizer.swift; sourceTree = "<group>"; };
 		4AB3C0ACB087A96811645CE3 /* AppMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMenuBuilder.swift; sourceTree = "<group>"; };
 		4ABED86877FD29F83E4196E0 /* TmuxCompatCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatCommand.swift; sourceTree = "<group>"; };
 		4B409385EC57C8C7A65441BD /* TmuxFormatRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxFormatRenderer.swift; sourceTree = "<group>"; };
@@ -777,6 +780,7 @@
 		E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAuxiliaryState.swift; sourceTree = "<group>"; };
 		E1A2BC275D0F7E90ACD593C6 /* PaneDragSplitOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragSplitOverlayView.swift; sourceTree = "<group>"; };
 		E1C2498C39738D7E5DBC5BBC /* AgentIPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIPCClient.swift; sourceTree = "<group>"; };
+		E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpPluginInstaller.swift; sourceTree = "<group>"; };
 		E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStripStateTests.swift; sourceTree = "<group>"; };
 		E4C05F7BE9ED093DD4CC4CA4 /* SidebarActiveWorklaneAutoScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarActiveWorklaneAutoScrollerTests.swift; sourceTree = "<group>"; };
 		E58967CFFAB97F7D24A62733 /* WorklaneContextFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneContextFormatterTests.swift; sourceTree = "<group>"; };
@@ -1099,6 +1103,8 @@
 				D1DB0F3E90C5CCF115A2E27B /* AgentStatusCommand.swift */,
 				10C70E68528914C7BDC3B755 /* AgentStatusHelper.swift */,
 				B79972CCAB3361277D4E949C /* AgentStatusPayload.swift */,
+				E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */,
+				4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */,
 				C344F4EE24498B605D2794B3 /* ClaudeHookSessionStore.swift */,
 				9108D5844FE620ED92B7B5BC /* CodexTranscriptQuestionExtractor.swift */,
 				D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */,
@@ -1731,7 +1737,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/droid/droid\" -o -path \"*/gemini/gemini\" -o -path \"*/kimi/kimi\" -o -path \"*/kimi/kimi-cli\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" -o -path \"*/tmux-shim/tmux\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
+			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/amp/plugins\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/amp/amp\" -o -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/droid/droid\" -o -path \"*/gemini/gemini\" -o -path \"*/kimi/kimi\" -o -path \"*/kimi/kimi-cli\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" -o -path \"*/tmux-shim/tmux\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/amp/\" \"${RESOURCES_DST}/amp/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
 		};
 		C7055FCE2E5119172F74E931 /* Verify GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1898,6 +1904,8 @@
 				6BDA3DD6058C31E9C1635868 /* AgentStatusCommand.swift in Sources */,
 				7564C7F11282A9CD3B3D0CC0 /* AgentStatusHelper.swift in Sources */,
 				04F27F3F3AE18FF0B4F78B44 /* AgentStatusPayload.swift in Sources */,
+				BD7EA4AEE8EB280F5A855B2C /* AmpPluginInstaller.swift in Sources */,
+				2C6C6FCC081720E010745882 /* AmpResumeArgumentSanitizer.swift in Sources */,
 				166BEE11322EC8809FACB201 /* AppCanvasView.swift in Sources */,
 				D59DA89E6E0CE0E9766052F0 /* AppConfig.swift in Sources */,
 				21E006D9ECF19B42A661D6C1 /* AppConfigStore.swift in Sources */,

--- a/Zentty/AppState/Agent/AgentEventBridge.swift
+++ b/Zentty/AppState/Agent/AgentEventBridge.swift
@@ -19,6 +19,7 @@ struct AgentEventInput {
     let artifactLabel: String?
     let artifactURL: String?
     let workingDirectory: String?
+    let agentLaunchSnapshot: AgentLaunchSnapshot?
 }
 
 enum AgentEventBridge {
@@ -125,6 +126,7 @@ enum AgentEventBridge {
         let progress = json["progress"] as? [String: Any]
         let artifact = json["artifact"] as? [String: Any]
         let context = json["context"] as? [String: Any]
+        let launch = context?["launch"] as? [String: Any]
 
         return AgentEventInput(
             event: event,
@@ -141,7 +143,8 @@ enum AgentEventBridge {
             artifactKind: firstString(in: artifact, keys: ["kind"]),
             artifactLabel: firstString(in: artifact, keys: ["label"]),
             artifactURL: firstString(in: artifact, keys: ["url"]),
-            workingDirectory: firstString(in: context, keys: ["workingDirectory"])
+            workingDirectory: firstString(in: context, keys: ["workingDirectory"]),
+            agentLaunchSnapshot: firstStringArray(in: launch, keys: ["arguments"]).map(AgentLaunchSnapshot.init(arguments:))
         )
     }
 
@@ -201,7 +204,8 @@ enum AgentEventBridge {
                 artifactKind: nil,
                 artifactLabel: nil,
                 artifactURL: nil,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             ))
             return payloads
 
@@ -259,7 +263,8 @@ enum AgentEventBridge {
                 artifactKind: input.artifactKind.flatMap(WorklaneArtifactKind.init(rawValue:)),
                 artifactLabel: input.artifactLabel,
                 artifactURL: artifactURL,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             )]
 
         case "agent.idle":
@@ -281,7 +286,8 @@ enum AgentEventBridge {
                 artifactKind: input.artifactKind.flatMap(WorklaneArtifactKind.init(rawValue:)),
                 artifactLabel: input.artifactLabel,
                 artifactURL: artifactURL,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             )]
 
         case "agent.needs-input":
@@ -305,7 +311,8 @@ enum AgentEventBridge {
                 artifactKind: nil,
                 artifactLabel: nil,
                 artifactURL: nil,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             )]
 
         case "agent.input-resolved":
@@ -325,7 +332,8 @@ enum AgentEventBridge {
                 artifactKind: nil,
                 artifactLabel: nil,
                 artifactURL: nil,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             )]
 
         case "task.progress":
@@ -344,7 +352,8 @@ enum AgentEventBridge {
                 artifactKind: nil,
                 artifactLabel: nil,
                 artifactURL: nil,
-                agentWorkingDirectory: input.workingDirectory
+                agentWorkingDirectory: input.workingDirectory,
+                agentLaunchSnapshot: input.agentLaunchSnapshot
             )]
 
         default:
@@ -377,6 +386,31 @@ enum AgentEventBridge {
                 let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
                     return trimmed
+                }
+            }
+        }
+        return nil
+    }
+
+    static func firstStringArray(in object: [String: Any]?, keys: [String]) -> [String]? {
+        guard let object else { return nil }
+        for key in keys {
+            if let values = object[key] as? [String] {
+                let trimmedValues = values.map {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                }.filter { !$0.isEmpty }
+                if !trimmedValues.isEmpty {
+                    return trimmedValues
+                }
+            }
+            if let values = object[key] as? [Any] {
+                let trimmedValues = values.compactMap { value -> String? in
+                    guard let string = value as? String else { return nil }
+                    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                if !trimmedValues.isEmpty {
+                    return trimmedValues
                 }
             }
         }

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -14,6 +14,7 @@ enum AgentIPCRequestKind: String, Codable, Equatable {
 }
 
 enum AgentBootstrapTool: String, Codable, Equatable {
+    case amp
     case claude
     case codex
     case copilot
@@ -31,7 +32,7 @@ enum AgentBootstrapTool: String, Codable, Equatable {
         switch self {
         case .cursor:
             return ["cursor-agent"]
-        case .claude, .codex, .copilot, .droid, .gemini, .opencode, .pi:
+        case .amp, .claude, .codex, .copilot, .droid, .gemini, .opencode, .pi:
             return [rawValue]
         case .kimi:
             return [rawValue, "kimi-cli"]

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -30,6 +30,14 @@ enum AgentLaunchBootstrap {
         }
 
         switch tool {
+        case .amp:
+            return try ampPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                environment: environment,
+                bundle: bundle,
+                fileManager: fileManager
+            )
         case .claude:
             return try claudePlan(
                 executablePath: executablePath,
@@ -108,6 +116,60 @@ enum AgentLaunchBootstrap {
                 fileManager: fileManager
             )
         }
+    }
+
+    private static func ampPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        bundle: Bundle,
+        fileManager: FileManager
+    ) throws -> AgentLaunchPlan {
+        if environment["ZENTTY_AMP_HOOKS_DISABLED"] == "1" {
+            return directPlan(executablePath: executablePath, arguments: arguments)
+        }
+
+        var setEnvironment = ["ZENTTY_AGENT_TOOL": "amp"]
+        let configHomeURL = AmpPluginInstaller.defaultUserConfigHomeURL(environment: environment)
+        if AmpPluginInstaller.installBundledPluginIfPossible(
+            destinationConfigHomeURL: configHomeURL,
+            bundle: bundle,
+            fileManager: fileManager
+        ) {
+            setEnvironment["PLUGINS"] = "all"
+        }
+
+        if let sanitizedArguments = AmpResumeArgumentSanitizer.sanitizedAmpResumeArguments(from: arguments),
+           !sanitizedArguments.isEmpty,
+           let data = try? JSONSerialization.data(withJSONObject: sanitizedArguments),
+           let json = String(data: data, encoding: .utf8) {
+            setEnvironment["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"] = json
+        }
+
+        let sessionStartJSON = """
+        {"version":1,"event":"session.start","agent":{"name":"Amp","pid":\(AgentIPCProtocol.selfPIDPlaceholder)},"context":{"launch":{"arguments":\(setEnvironment["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"] ?? "[]")}}}
+        """
+        let agentRunningJSON = """
+        {"version":1,"event":"agent.running","agent":{"name":"Amp","pid":\(AgentIPCProtocol.selfPIDPlaceholder)},"context":{"launch":{"arguments":\(setEnvironment["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"] ?? "[]")}}}
+        """
+        return AgentLaunchPlan(
+            executablePath: executablePath,
+            arguments: arguments,
+            setEnvironment: setEnvironment,
+            unsetEnvironment: [],
+            preLaunchActions: [
+                AgentLaunchAction(
+                    subcommand: "agent-event",
+                    arguments: [],
+                    standardInput: sessionStartJSON
+                ),
+                AgentLaunchAction(
+                    subcommand: "agent-event",
+                    arguments: [],
+                    standardInput: agentRunningJSON
+                ),
+            ]
+        )
     }
 
     private static func cursorPlan(

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum AgentTool: Equatable, Sendable {
     case zentty
+    case amp
     case claudeCode
     case codex
     case copilot
@@ -17,6 +18,8 @@ enum AgentTool: Equatable, Sendable {
         switch self {
         case .zentty:
             return "Zentty"
+        case .amp:
+            return "Amp"
         case .claudeCode:
             return "Claude Code"
         case .codex:
@@ -85,6 +88,8 @@ enum AgentTool: Equatable, Sendable {
                 return normalized.contains(needle)
             case .containsAny(let needles):
                 return needles.contains { normalized.contains($0) }
+            case .leadingToken(let tokens):
+                return matchesLeadingToken(normalized, tokens: tokens)
             case .pi:
                 return matchesPi(normalized)
             }
@@ -94,10 +99,12 @@ enum AgentTool: Equatable, Sendable {
     private enum Match: Sendable {
         case contains(String)
         case containsAny([String])
+        case leadingToken([String])
         case pi
     }
 
     private static let knownToolMatchers: [ToolNameMatcher] = [
+        ToolNameMatcher(tool: .amp, isHookDrivenOnly: false, match: .leadingToken(["amp"])),
         ToolNameMatcher(tool: .claudeCode, isHookDrivenOnly: false, match: .contains("claude")),
         ToolNameMatcher(tool: .codex, isHookDrivenOnly: false, match: .contains("codex")),
         // Keep hook-driven-only tools out of metadata recognition so generic
@@ -121,6 +128,13 @@ enum AgentTool: Equatable, Sendable {
             if token == "pi" || token == "π" { return true }
         }
         return false
+    }
+
+    private static func matchesLeadingToken(_ normalized: String, tokens expectedTokens: [String]) -> Bool {
+        guard let token = normalized.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).first else {
+            return false
+        }
+        return expectedTokens.contains(String(token))
     }
 
     private static func normalized(_ value: String?) -> String? {
@@ -363,6 +377,7 @@ struct PaneAgentStatus: Equatable, Sendable {
     var hasObservedRunning: Bool
     var sessionID: String?
     var parentSessionID: String?
+    var agentLaunchSnapshot: AgentLaunchSnapshot?
     var taskProgress: PaneAgentTaskProgress?
 
     init(
@@ -382,6 +397,7 @@ struct PaneAgentStatus: Equatable, Sendable {
         hasObservedRunning: Bool? = nil,
         sessionID: String? = nil,
         parentSessionID: String? = nil,
+        agentLaunchSnapshot: AgentLaunchSnapshot? = nil,
         taskProgress: PaneAgentTaskProgress? = nil
     ) {
         self.tool = tool
@@ -401,6 +417,7 @@ struct PaneAgentStatus: Equatable, Sendable {
         self.hasObservedRunning = hasObservedRunning ?? Self.defaultHasObservedRunning(for: state)
         self.sessionID = sessionID
         self.parentSessionID = parentSessionID
+        self.agentLaunchSnapshot = agentLaunchSnapshot
         self.taskProgress = taskProgress
     }
 

--- a/Zentty/AppState/Agent/AgentStatusHelper.swift
+++ b/Zentty/AppState/Agent/AgentStatusHelper.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 enum AgentStatusHelper {
-    private static let wrappedToolNames = ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"]
+    private static let wrappedToolNames = ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"]
     private static let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
     static func runIfNeeded(arguments: [String], environment: [String: String]) -> Int32? {
@@ -51,6 +51,7 @@ enum AgentStatusHelper {
             if let path = validatedDirectoryPath(
                 candidateBundle.resourceURL?.appendingPathComponent("bin", isDirectory: true),
                 requiredRelativePaths: [
+                    "amp/amp",
                     "claude/claude",
                     "codex/codex",
                     "copilot/copilot",
@@ -64,6 +65,7 @@ enum AgentStatusHelper {
                     "shared/zentty-agent-wrapper",
                 ],
                 executableRelativePaths: [
+                    "amp/amp",
                     "claude/claude",
                     "codex/codex",
                     "copilot/copilot",

--- a/Zentty/AppState/Agent/AgentStatusPayload.swift
+++ b/Zentty/AppState/Agent/AgentStatusPayload.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+struct AgentLaunchSnapshot: Codable, Equatable, Sendable {
+    var arguments: [String]
+
+    init(arguments: [String]) {
+        self.arguments = arguments
+    }
+}
+
 enum AgentStatusPayloadError: Error {
     case missingPaneID
     case missingPID
@@ -49,6 +57,7 @@ struct AgentStatusPayload: Equatable, Sendable {
     let artifactURL: URL?
     let agentWorkingDirectory: String?
     let agentTranscriptPath: String?
+    let agentLaunchSnapshot: AgentLaunchSnapshot?
 
     var clearsStatus: Bool {
         signalKind == .lifecycle && state == nil
@@ -141,6 +150,11 @@ struct AgentStatusPayload: Equatable, Sendable {
         if let agentTranscriptPath {
             userInfo["agentTranscriptPath"] = agentTranscriptPath
         }
+        if let agentLaunchSnapshot,
+           let data = try? JSONEncoder().encode(agentLaunchSnapshot),
+           let json = String(data: data, encoding: .utf8) {
+            userInfo["agentLaunchSnapshot"] = json
+        }
         return userInfo
     }
 
@@ -168,7 +182,8 @@ struct AgentStatusPayload: Equatable, Sendable {
         artifactLabel: String?,
         artifactURL: URL?,
         agentWorkingDirectory: String? = nil,
-        agentTranscriptPath: String? = nil
+        agentTranscriptPath: String? = nil,
+        agentLaunchSnapshot: AgentLaunchSnapshot? = nil
     ) {
         self.windowID = windowID
         self.worklaneID = worklaneID
@@ -194,6 +209,7 @@ struct AgentStatusPayload: Equatable, Sendable {
         self.artifactURL = artifactURL
         self.agentWorkingDirectory = agentWorkingDirectory
         self.agentTranscriptPath = agentTranscriptPath
+        self.agentLaunchSnapshot = agentLaunchSnapshot
     }
 
     init(userInfo: [AnyHashable: Any]) throws {
@@ -228,6 +244,9 @@ struct AgentStatusPayload: Equatable, Sendable {
             doneCount: (userInfo["taskProgressDoneCount"] as? NSNumber)?.intValue ?? 0,
             totalCount: (userInfo["taskProgressTotalCount"] as? NSNumber)?.intValue ?? 0
         )
+        let agentLaunchSnapshot = (userInfo["agentLaunchSnapshot"] as? String)
+            .flatMap { $0.data(using: .utf8) }
+            .flatMap { try? JSONDecoder().decode(AgentLaunchSnapshot.self, from: $0) }
 
         self.init(
             windowID: (userInfo["windowID"] as? String).map(WindowID.init),
@@ -253,7 +272,8 @@ struct AgentStatusPayload: Equatable, Sendable {
             artifactLabel: userInfo["artifactLabel"] as? String,
             artifactURL: artifactURL,
             agentWorkingDirectory: userInfo["agentWorkingDirectory"] as? String,
-            agentTranscriptPath: userInfo["agentTranscriptPath"] as? String
+            agentTranscriptPath: userInfo["agentTranscriptPath"] as? String,
+            agentLaunchSnapshot: agentLaunchSnapshot
         )
     }
 }

--- a/Zentty/AppState/Agent/AmpPluginInstaller.swift
+++ b/Zentty/AppState/Agent/AmpPluginInstaller.swift
@@ -1,0 +1,90 @@
+import Foundation
+import os
+
+private let ampPluginInstallerLogger = Logger(
+    subsystem: "be.zenjoy.zentty",
+    category: "AmpPluginInstaller"
+)
+
+enum AmpPluginInstaller {
+    static let pluginFileName = "zentty-amp-zentty.ts"
+    static let ownershipMarker = "zentty-amp-plugin-v1"
+
+    static func installBundledPluginIfPossible(
+        destinationConfigHomeURL: URL,
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let sourceURL = bundledPluginURL(bundle: bundle, fileManager: fileManager) else {
+            ampPluginInstallerLogger.warning("AMP plugin resource missing; agent status will not be tracked")
+            return false
+        }
+
+        do {
+            return try install(
+                sourceURL: sourceURL,
+                destinationURL: bundledPluginDestinationURL(destinationConfigHomeURL: destinationConfigHomeURL),
+                fileManager: fileManager
+            )
+        } catch {
+            ampPluginInstallerLogger.error("Failed to install AMP plugin: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    static func install(
+        sourceURL: URL,
+        destinationURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            let existing = (try? String(contentsOf: destinationURL, encoding: .utf8)) ?? ""
+            guard existing.contains(ownershipMarker) else {
+                ampPluginInstallerLogger.warning("Refusing to overwrite unmarked AMP plugin at \(destinationURL.path, privacy: .public)")
+                return false
+            }
+        }
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try source.write(to: destinationURL, atomically: true, encoding: .utf8)
+        return true
+    }
+
+    static func defaultUserConfigHomeURL(environment: [String: String]) -> URL {
+        if let configRoot = nonBlank(environment["XDG_CONFIG_HOME"]) {
+            return URL(fileURLWithPath: configRoot, isDirectory: true)
+        }
+        return URL(fileURLWithPath: nonBlank(environment["HOME"]) ?? NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".config", isDirectory: true)
+    }
+
+    private static func bundledPluginDestinationURL(destinationConfigHomeURL: URL) -> URL {
+        destinationConfigHomeURL
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(pluginFileName, isDirectory: false)
+    }
+
+    private static func bundledPluginURL(bundle: Bundle, fileManager: FileManager) -> URL? {
+        guard let url = bundle.resourceURL?
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(pluginFileName, isDirectory: false),
+              fileManager.isReadableFile(atPath: url.path)
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func nonBlank(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Zentty/AppState/Agent/AmpResumeArgumentSanitizer.swift
+++ b/Zentty/AppState/Agent/AmpResumeArgumentSanitizer.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+enum AmpResumeArgumentSanitizer {
+    private static let safeValueOptions: Set<String> = [
+        "--mode", "-m", "--effort", "--settings-file", "--log-level",
+        "--log-file", "--mcp-config", "--visibility",
+    ]
+    private static let droppedValueOptions: Set<String> = ["--label", "-l"]
+    private static let droppedFlags: Set<String> = [
+        "--archive", "--stream-json", "--stream-json-input", "--stream-json-thinking",
+        "--json", "--output-format",
+    ]
+    private static let rejectedFlags: Set<String> = [
+        "--execute", "--print", "-x", "--help", "-h", "--version", "-V", "--jetbrains",
+    ]
+    private static let rejectedSubcommands: Set<String> = [
+        "login", "logout", "mcp", "permission", "permissions", "review",
+        "skill", "skills", "tool", "tools", "update", "up", "usage", "version",
+    ]
+
+    static func sanitizedAmpResumeArguments(from arguments: [String]) -> [String]? {
+        var remaining = Array(arguments.dropFirstIfExecutableName("amp"))
+        if let first = remaining.first, rejectedSubcommands.contains(first) {
+            return nil
+        }
+        if remaining.contains(where: { isRejectedFlag($0) }) {
+            return nil
+        }
+        stripResumePreamble(from: &remaining)
+
+        var sanitized: [String] = []
+        var index = 0
+        while index < remaining.count {
+            let argument = remaining[index]
+            if argument.hasPrefix("--") {
+                let optionName = argument.split(separator: "=", maxSplits: 1).first.map(String.init) ?? argument
+                if safeValueOptions.contains(optionName) {
+                    if argument.contains("=") {
+                        sanitized.append(argument)
+                    } else if remaining.indices.contains(index + 1), !remaining[index + 1].hasPrefix("-") {
+                        sanitized.append(argument)
+                        sanitized.append(remaining[index + 1])
+                        index += 1
+                    }
+                } else if droppedValueOptions.contains(optionName) {
+                    if !argument.contains("="), remaining.indices.contains(index + 1), !remaining[index + 1].hasPrefix("-") {
+                        index += 1
+                    }
+                } else if droppedFlags.contains(optionName) {
+                    if optionName == "--output-format",
+                       !argument.contains("="),
+                       remaining.indices.contains(index + 1),
+                       !remaining[index + 1].hasPrefix("-") {
+                        index += 1
+                    }
+                }
+            } else if argument == "-m" {
+                if remaining.indices.contains(index + 1), !remaining[index + 1].hasPrefix("-") {
+                    sanitized.append(argument)
+                    sanitized.append(remaining[index + 1])
+                    index += 1
+                }
+            } else if argument == "-l" {
+                if remaining.indices.contains(index + 1), !remaining[index + 1].hasPrefix("-") {
+                    index += 1
+                }
+            } else if argument.hasPrefix("-") {
+                if isRejectedFlag(argument) { return nil }
+            } else {
+                break
+            }
+            index += 1
+        }
+        return sanitized
+    }
+
+    private static func stripResumePreamble(from arguments: inout [String]) {
+        guard arguments.count >= 2 else { return }
+        let threadSubcommands: Set<String> = ["threads", "thread", "t"]
+        let continueSubcommands: Set<String> = ["continue", "c"]
+        guard threadSubcommands.contains(arguments[0]),
+              continueSubcommands.contains(arguments[1]) else {
+            return
+        }
+        arguments.removeFirst(2)
+        if let first = arguments.first, first.range(of: #"^T-[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil {
+            arguments.removeFirst()
+        }
+    }
+
+    private static func isRejectedFlag(_ argument: String) -> Bool {
+        let optionName = argument.hasPrefix("--")
+            ? (argument.split(separator: "=", maxSplits: 1).first.map(String.init) ?? argument)
+            : argument
+        return rejectedFlags.contains(optionName)
+    }
+}
+
+private extension Array where Element == String {
+    func dropFirstIfExecutableName(_ executableName: String) -> ArraySlice<String> {
+        guard first == executableName else {
+            return self[...]
+        }
+        return dropFirst()
+    }
+}

--- a/Zentty/AppState/Agent/PaneAgentReducer.swift
+++ b/Zentty/AppState/Agent/PaneAgentReducer.swift
@@ -6,6 +6,7 @@ private let stopSignalLogger = Logger(subsystem: "be.zenjoy.zentty", category: "
 struct PaneAgentSessionState: Equatable, Sendable {
     var sessionID: String
     var parentSessionID: String?
+    var agentLaunchSnapshot: AgentLaunchSnapshot? = nil
     var tool: AgentTool
     var state: PaneAgentState
     var text: String?
@@ -421,6 +422,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             hasObservedRunning: session.hasObservedRunning,
             sessionID: session.sessionID,
             parentSessionID: session.parentSessionID,
+            agentLaunchSnapshot: session.agentLaunchSnapshot,
             taskProgress: session.taskProgress
         )
     }
@@ -452,6 +454,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
         var session = sessionsByID[sessionID] ?? PaneAgentSessionState(
             sessionID: sessionID,
             parentSessionID: normalized(payload.parentSessionID),
+            agentLaunchSnapshot: payload.agentLaunchSnapshot,
             tool: tool,
             state: .starting,
             text: nil,
@@ -490,6 +493,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
         let previousOrigin = session.origin
 
         session.parentSessionID = normalized(payload.parentSessionID) ?? session.parentSessionID
+        session.agentLaunchSnapshot = payload.agentLaunchSnapshot ?? session.agentLaunchSnapshot
         session.tool = tool
         session.source = statusSource(for: payload.origin)
         session.origin = payload.origin
@@ -599,6 +603,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             session.artifactLink = session.artifactLink ?? inferredSession.artifactLink
             session.text = session.text ?? inferredSession.text
             session.taskProgress = session.taskProgress ?? inferredSession.taskProgress
+            session.agentLaunchSnapshot = session.agentLaunchSnapshot ?? inferredSession.agentLaunchSnapshot
             if inferredSession.updatedAt > session.updatedAt {
                 session.updatedAt = inferredSession.updatedAt
             }
@@ -624,6 +629,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
         session.text = session.text ?? fallbackSession.text
         session.trackedPID = session.trackedPID ?? fallbackSession.trackedPID
         session.taskProgress = session.taskProgress ?? fallbackSession.taskProgress
+        session.agentLaunchSnapshot = session.agentLaunchSnapshot ?? fallbackSession.agentLaunchSnapshot
         if session.shellActivityState == .unknown {
             session.shellActivityState = fallbackSession.shellActivityState
         }
@@ -644,6 +650,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             var session = sessionsByID[sessionID] ?? PaneAgentSessionState(
                 sessionID: sessionID,
                 parentSessionID: normalized(payload.parentSessionID),
+                agentLaunchSnapshot: payload.agentLaunchSnapshot,
                 tool: tool,
                 state: .starting,
                 text: nil,
@@ -671,6 +678,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             session.updatedAt = now
             session.trackedPID = pid
             session.parentSessionID = normalized(payload.parentSessionID) ?? session.parentSessionID
+            session.agentLaunchSnapshot = payload.agentLaunchSnapshot ?? session.agentLaunchSnapshot
             sessionsByID[sessionID] = session
         case .clear:
             if let sessionID = normalized(payload.sessionID), var session = sessionsByID[sessionID] {

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -875,6 +875,8 @@ enum PanePresentationNormalizer {
         switch tool {
         case .zentty:
             return normalized == "zentty"
+        case .amp:
+            return normalized == "amp"
         case .claudeCode:
             return ["claude", "claude code"].contains(normalized)
         case .codex:

--- a/Zentty/AppState/WorklaneStore+AgentStatus.swift
+++ b/Zentty/AppState/WorklaneStore+AgentStatus.swift
@@ -183,6 +183,10 @@ extension WorklaneStore {
                Self.isProcessAlive(pid: trackedPID) {
                 break
             }
+            if shouldPromoteIdleStatusToReadyOnCommandFinished(existingStatus) {
+                requestReadyStatusIfNeeded(for: paneID, in: &worklane)
+                break
+            }
             if shouldClearWeakCodexStatusOnCommandFinished(existingStatus) {
                 clearTransientCodexState(
                     paneID: paneID,
@@ -194,6 +198,7 @@ extension WorklaneStore {
             if existingStatus?.state != .idle,
                existingStatus?.state != .needsInput,
                existingStatus?.state != .starting,
+               existingStatus?.state != .unresolvedStop,
                existingStatus?.source == .explicit {
                 var auxiliaryState = worklane.auxiliaryStateByPaneID[paneID, default: PaneAuxiliaryState()]
                 auxiliaryState.agentReducerState = Self.seededReducerState(
@@ -494,7 +499,8 @@ extension WorklaneStore {
                     artifactLabel: payload.artifactLabel,
                     artifactURL: payload.artifactURL,
                     agentWorkingDirectory: payload.agentWorkingDirectory,
-                    agentTranscriptPath: payload.agentTranscriptPath
+                    agentTranscriptPath: payload.agentTranscriptPath,
+                    agentLaunchSnapshot: payload.agentLaunchSnapshot
                 )
             )
             auxiliaryState.agentStatus = Self.hydratedStatus(
@@ -531,6 +537,23 @@ extension WorklaneStore {
                 } else {
                     auxiliaryState.raw.restoredAgentAutoResumePending = false
                 }
+            }
+
+            if shouldClearAmpStatusForNonAgentCommand(existingStatus, payload: payload) {
+                auxiliaryState.agentStatus = nil
+                auxiliaryState.agentReducerState = PaneAgentReducerState()
+                auxiliaryState.terminalProgress = nil
+                auxiliaryState.raw.wantsReadyStatus = false
+                auxiliaryState.raw.showsReadyStatus = false
+                worklane.auxiliaryStateByPaneID[payload.paneID] = auxiliaryState
+                cancelPendingReadyStatus(for: PaneReference(worklaneID: worklane.id, paneID: payload.paneID))
+                recomputePresentation(for: payload.paneID, in: &worklane)
+                worklanes[worklaneIndex] = worklane
+                let impacts = auxiliaryInvalidation(for: payload.paneID, previousWorklane: previousWorklane, nextWorklane: worklane)
+                if !impacts.isEmpty {
+                    notify(.auxiliaryStateUpdated(worklane.id, payload.paneID, impacts))
+                }
+                return
             }
 
             if var existingStatus {
@@ -605,7 +628,8 @@ extension WorklaneStore {
                         artifactLabel: nil,
                         artifactURL: nil,
                         agentWorkingDirectory: payload.agentWorkingDirectory,
-                        agentTranscriptPath: payload.agentTranscriptPath
+                        agentTranscriptPath: payload.agentTranscriptPath,
+                        agentLaunchSnapshot: payload.agentLaunchSnapshot
                     )
                 )
                 var status = Self.hydratedStatus(
@@ -1016,6 +1040,42 @@ extension WorklaneStore {
         return nextStatus.state != .idle
     }
 
+    private func shouldPromoteIdleStatusToReadyOnCommandFinished(_ status: PaneAgentStatus?) -> Bool {
+        guard let status,
+              status.tool == .amp,
+              status.state == .idle,
+              status.hasObservedRunning,
+              status.origin != .shell,
+              status.source == .explicit else {
+            return false
+        }
+
+        return true
+    }
+
+    private func shouldClearAmpStatusForNonAgentCommand(
+        _ status: PaneAgentStatus?,
+        payload: AgentStatusPayload
+    ) -> Bool {
+        guard payload.signalKind == .shellState,
+              payload.shellActivityState == .commandRunning,
+              let status,
+              status.tool == .amp,
+              status.source == .explicit,
+              status.origin != .shell,
+              status.state == .idle || status.state == .unresolvedStop else {
+            return false
+        }
+
+        if AgentTool.resolveKnown(named: payload.toolName) == .amp {
+            return false
+        }
+        if AgentTool.resolveKnown(named: payload.shellCommand) == .amp {
+            return false
+        }
+        return true
+    }
+
     private func shouldClearReadyStatusForProgressReport(
         existingStatus: PaneAgentStatus?,
         showsReadyStatus: Bool
@@ -1189,6 +1249,7 @@ extension WorklaneStore {
         seededReducerState.sessionsByID[sessionID] = PaneAgentSessionState(
             sessionID: sessionID,
             parentSessionID: existingStatus.parentSessionID,
+            agentLaunchSnapshot: existingStatus.agentLaunchSnapshot,
             tool: existingStatus.tool,
             state: existingStatus.state,
             text: existingStatus.text,
@@ -1224,6 +1285,7 @@ extension WorklaneStore {
 
         status.workingDirectory = WorklaneContextFormatter.trimmed(payloadWorkingDirectory)
             ?? existingStatus?.workingDirectory
+        status.agentLaunchSnapshot = status.agentLaunchSnapshot ?? existingStatus?.agentLaunchSnapshot
         return status
     }
 

--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -980,6 +980,7 @@ extension WorklaneStore {
         if let tool = recognizedTool {
             switch tool {
             case .zentty: return nil
+            case .amp: return "amp"
             case .claudeCode: return "claude"
             case .codex: return "codex"
             case .copilot: return "gh copilot"

--- a/Zentty/AppState/WorklaneStore+Restore.swift
+++ b/Zentty/AppState/WorklaneStore+Restore.swift
@@ -34,7 +34,8 @@ extension WorklaneStore {
                 tool: status.tool,
                 toolDisplayName: status.tool.displayName,
                 sessionID: status.sessionID,
-                workingDirectory: status.workingDirectory ?? auxiliary?.presentation.cwd
+                workingDirectory: status.workingDirectory ?? auxiliary?.presentation.cwd,
+                agentLaunchSnapshot: status.agentLaunchSnapshot
             )
         }
 

--- a/Zentty/Restore/ClosedPaneEntry.swift
+++ b/Zentty/Restore/ClosedPaneEntry.swift
@@ -12,6 +12,21 @@ struct ClosedPaneAgentSnapshot: Equatable, Sendable {
     let toolDisplayName: String
     let sessionID: String?
     let workingDirectory: String?
+    let agentLaunchSnapshot: AgentLaunchSnapshot?
+
+    init(
+        tool: AgentTool,
+        toolDisplayName: String,
+        sessionID: String?,
+        workingDirectory: String?,
+        agentLaunchSnapshot: AgentLaunchSnapshot? = nil
+    ) {
+        self.tool = tool
+        self.toolDisplayName = toolDisplayName
+        self.sessionID = sessionID
+        self.workingDirectory = workingDirectory
+        self.agentLaunchSnapshot = agentLaunchSnapshot
+    }
 }
 
 struct ClosedPaneEntry: Identifiable, Equatable, Sendable {

--- a/Zentty/Restore/ClosedPaneRestoreHelpers.swift
+++ b/Zentty/Restore/ClosedPaneRestoreHelpers.swift
@@ -119,7 +119,8 @@ enum ClosedPaneRestoreCommandResolver {
                 toolName: snapshot.toolDisplayName,
                 sessionID: snapshot.sessionID ?? "",
                 workingDirectory: snapshot.workingDirectory ?? entry.workingDirectory,
-                trackedPID: 0
+                trackedPID: 0,
+                agentLaunchSnapshot: snapshot.agentLaunchSnapshot
             )
 
             if let resumeCommand = AgentResumeCommandBuilder.command(for: draft) {

--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -250,6 +250,7 @@ struct PaneRestoreDraft: Codable, Equatable, Sendable {
     var sessionID: String
     var workingDirectory: String?
     var trackedPID: Int32
+    var agentLaunchSnapshot: AgentLaunchSnapshot? = nil
 }
 
 enum SessionRestoreDraftExporter {
@@ -336,7 +337,8 @@ enum SessionRestoreDraftExporter {
                 tool: agentStatus.tool,
                 sessionID: agentStatus.sessionID,
                 workingDirectory: resolvedWorkingDirectory,
-                trackedPID: trackedPID
+                trackedPID: trackedPID,
+                agentLaunchSnapshot: agentStatus.agentLaunchSnapshot
             )
         }
 
@@ -357,7 +359,8 @@ enum SessionRestoreDraftExporter {
             tool: session.tool,
             sessionID: session.sessionID,
             workingDirectory: resolvedWorkingDirectory,
-            trackedPID: trackedPID
+            trackedPID: trackedPID,
+            agentLaunchSnapshot: session.agentLaunchSnapshot
         )
     }
 
@@ -408,7 +411,8 @@ enum SessionRestoreDraftExporter {
         tool: AgentTool,
         sessionID rawSessionID: String?,
         workingDirectory rawWorkingDirectory: String?,
-        trackedPID: Int32
+        trackedPID: Int32,
+        agentLaunchSnapshot: AgentLaunchSnapshot? = nil
     ) -> PaneRestoreDraft? {
         let workingDirectory = trimmed(rawWorkingDirectory)
         let sessionID: String
@@ -434,7 +438,8 @@ enum SessionRestoreDraftExporter {
             toolName: tool.displayName,
             sessionID: sessionID,
             workingDirectory: workingDirectory,
-            trackedPID: trackedPID
+            trackedPID: trackedPID,
+            agentLaunchSnapshot: agentLaunchSnapshot
         )
 
         guard AgentResumeCommandBuilder.command(for: draft) != nil else {
@@ -446,7 +451,7 @@ enum SessionRestoreDraftExporter {
 
     private static func restoreIdentityRequirement(for tool: AgentTool) -> RestoreIdentityRequirement {
         switch tool {
-        case .claudeCode, .codex, .copilot, .droid, .kimi, .openCode:
+        case .amp, .claudeCode, .codex, .copilot, .droid, .kimi, .openCode:
             return .sessionID
         case .gemini, .pi:
             return .workingDirectory
@@ -519,6 +524,18 @@ enum AgentResumeCommandBuilder {
         }
 
         switch AgentTool.resolve(named: draft.toolName) {
+        case .amp:
+            guard let sessionID = validatedAmpThreadID(from: draft.sessionID) else {
+                logRejectedSessionID(for: draft)
+                return nil
+            }
+            guard let resumeArguments = AmpResumeArgumentSanitizer.sanitizedAmpResumeArguments(
+                from: draft.agentLaunchSnapshot?.arguments ?? []
+            ) else {
+                return nil
+            }
+            let commandArguments = ["amp", "threads", "continue"] + resumeArguments + [sessionID]
+            return commandArguments.map(shellQuotedArgument(_:)).joined(separator: " ")
         case .claudeCode:
             guard let sessionID = validatedClaudeSessionID(from: draft.sessionID) else {
                 logRejectedSessionID(for: draft)
@@ -629,6 +646,21 @@ enum AgentResumeCommandBuilder {
             return nil
         }
         return sessionID
+    }
+
+    private static func validatedAmpThreadID(from sessionID: String) -> String? {
+        let pattern = #"^T-[A-Za-z0-9_-]+$"#
+        guard sessionID.range(of: pattern, options: .regularExpression) != nil else {
+            return nil
+        }
+        return sessionID
+    }
+
+    private static func shellQuotedArgument(_ argument: String) -> String {
+        if argument.range(of: #"^[A-Za-z0-9_./:=+-]+$"#, options: .regularExpression) != nil {
+            return argument
+        }
+        return "'" + argument.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     private static func hasWorkingDirectory(_ draft: PaneRestoreDraft) -> Bool {

--- a/Zentty/Terminal/TerminalMetadata.swift
+++ b/Zentty/Terminal/TerminalMetadata.swift
@@ -1277,6 +1277,8 @@ final class TerminalDiagnostics: @unchecked Sendable {
         switch tool {
         case .zentty:
             return "zentty"
+        case .amp:
+            return "amp"
         case .claudeCode:
             return "claude"
         case .codex:

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -52,6 +52,17 @@ struct AgentToolLauncher {
         }
 
         switch tool {
+        case .amp:
+            if environment["ZENTTY_AMP_HOOKS_DISABLED"] == "1" {
+                return false
+            }
+            if Self.ampPassthroughSubcommands.contains(arguments.first ?? "") {
+                return false
+            }
+            if arguments.contains(where: Self.isAmpEarlyExitFlag) {
+                return false
+            }
+            return true
         case .claude:
             if environment["ZENTTY_CLAUDE_HOOKS_DISABLED"] == "1" {
                 return false
@@ -107,6 +118,22 @@ struct AgentToolLauncher {
     static let piEarlyExitFlags: Set<String> = [
         "--help", "-h", "--version", "-v", "--list-models", "--export",
     ]
+
+    static let ampPassthroughSubcommands: Set<String> = [
+        "login", "logout", "mcp", "permission", "permissions", "review",
+        "skill", "skills", "tool", "tools", "update", "up", "usage", "version",
+    ]
+
+    static let ampEarlyExitFlags: Set<String> = [
+        "--help", "-h", "--version", "-V", "--jetbrains",
+    ]
+
+    private static func isAmpEarlyExitFlag(_ argument: String) -> Bool {
+        let optionName = argument.hasPrefix("--")
+            ? (argument.split(separator: "=", maxSplits: 1).first.map(String.init) ?? argument)
+            : argument
+        return ampEarlyExitFlags.contains(optionName)
+    }
 
     static let kimiPassthroughSubcommands: Set<String> = [
         "login", "logout", "term", "acp", "info", "export", "mcp", "plugin", "vis", "web",
@@ -242,6 +269,8 @@ struct AgentToolLauncher {
 
     private var toolDisplayName: String {
         switch tool {
+        case .amp:
+            return "Amp"
         case .claude:
             return "Claude"
         case .codex:
@@ -267,6 +296,7 @@ struct AgentToolLauncher {
         let forwardedKeys = [
             "HOME",
             "PATH",
+            "AMP_SETTINGS_FILE",
             "ZENTTY_CLI_BIN",
             "ZENTTY_INSTANCE_SOCKET",
             "ZENTTY_WINDOW_ID",
@@ -274,6 +304,7 @@ struct AgentToolLauncher {
             "ZENTTY_PANE_ID",
             "ZENTTY_PANE_TOKEN",
             "ZENTTY_INSTANCE_ID",
+            "ZENTTY_AMP_HOOKS_DISABLED",
             "ZENTTY_CLAUDE_HOOKS_DISABLED",
             "ZENTTY_COPILOT_HOOKS_DISABLED",
             "ZENTTY_CURSOR_HOOKS_DISABLED",
@@ -336,7 +367,7 @@ struct AgentToolLauncher {
         switch tool {
         case .claude:
             return EnvironmentPatch(set: [:], unset: ["CLAUDECODE"])
-        case .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi:
+        case .amp, .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi:
             return EnvironmentPatch()
         }
     }
@@ -348,6 +379,8 @@ struct AgentToolLauncher {
         )
 
         switch tool {
+        case .amp:
+            environmentPatch.set["ZENTTY_AMP_PID"] = "\(getpid())"
         case .claude:
             environmentPatch.set["ZENTTY_CLAUDE_PID"] = "\(getpid())"
         case .codex:
@@ -402,6 +435,7 @@ struct AgentToolLauncher {
             "ZENTTY_WORKLANE_ID",
             "ZENTTY_PANE_ID",
             "ZENTTY_PANE_TOKEN",
+            "ZENTTY_AMP_PID",
             "ZENTTY_CLAUDE_PID",
             "ZENTTY_CODEX_PID",
             "ZENTTY_COPILOT_PID",

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -877,6 +877,7 @@ struct IPCCommand: ParsableCommand {
         "ZENTTY_PANE_ID",
         "ZENTTY_PANE_TOKEN",
         "ZENTTY_INSTANCE_ID",
+        "ZENTTY_AMP_PID",
         "ZENTTY_CLAUDE_PID",
         "ZENTTY_CODEX_PID",
         "ZENTTY_COPILOT_PID",
@@ -973,7 +974,7 @@ struct LaunchCommand: ParsableCommand {
         shouldDisplay: false
     )
 
-    @Argument(help: "Supported values: claude, codex, copilot, cursor, gemini, kimi, opencode, pi")
+    @Argument(help: "Supported values: amp, claude, codex, copilot, cursor, droid, gemini, kimi, opencode, pi")
     var tool: String
 
     @Argument(parsing: .captureForPassthrough, help: "Arguments forwarded to the real tool.")

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -40,7 +40,12 @@ final class AgentEventBridgeTests: XCTestCase {
           },
           "progress": { "done": 3, "total": 7 },
           "artifact": { "kind": "pull-request", "label": "PR #42", "url": "https://github.com/org/repo/pull/42" },
-          "context": { "workingDirectory": "/tmp/project" }
+          "context": {
+            "workingDirectory": "/tmp/project",
+            "launch": {
+              "arguments": ["--mode", "smart"]
+            }
+          }
         }
         """
         let input = try AgentEventBridge.parseInput(json.data(using: .utf8)!)
@@ -60,6 +65,7 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertEqual(input.artifactLabel, "PR #42")
         XCTAssertEqual(input.artifactURL, "https://github.com/org/repo/pull/42")
         XCTAssertEqual(input.workingDirectory, "/tmp/project")
+        XCTAssertEqual(input.agentLaunchSnapshot, AgentLaunchSnapshot(arguments: ["--mode", "smart"]))
     }
 
     func test_parseInput_handles_minimal_payload() throws {

--- a/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
+++ b/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
@@ -2,6 +2,68 @@ import XCTest
 @testable import Zentty
 
 final class AgentResumeCommandBuilderTests: XCTestCase {
+    func test_builder_returns_amp_thread_continue_command_for_valid_thread_id() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-amp",
+            kind: .agentResume,
+            toolName: "Amp",
+            sessionID: "T-ZenttyBenchRestore",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            "amp threads continue T-ZenttyBenchRestore"
+        )
+    }
+
+    func test_builder_preserves_sanitized_amp_resume_arguments() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-amp",
+            kind: .agentResume,
+            toolName: "Amp",
+            sessionID: "T-ZenttyBenchRestore",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242,
+            agentLaunchSnapshot: AgentLaunchSnapshot(
+                arguments: ["--mode", "smart", "--effort", "high", "--settings-file", "/tmp/amp settings.json"]
+            )
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            #"amp threads continue --mode smart --effort high --settings-file '/tmp/amp settings.json' T-ZenttyBenchRestore"#
+        )
+    }
+
+    func test_builder_returns_nil_for_unsafe_amp_thread_id() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-amp",
+            kind: .agentResume,
+            toolName: "Amp",
+            sessionID: "T-safe; rm -rf /",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
+    }
+
+    func test_builder_returns_nil_for_amp_execute_resume_argument_with_value() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-amp",
+            kind: .agentResume,
+            toolName: "Amp",
+            sessionID: "T-ZenttyBenchRestore",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242,
+            agentLaunchSnapshot: AgentLaunchSnapshot(arguments: ["--execute=echo hi"])
+        )
+
+        XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
+    }
+
     func test_builder_returns_claude_resume_command_for_uuid_session_id() {
         let draft = PaneRestoreDraft(
             paneID: "pane-claude",

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -68,6 +68,14 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertNil(AgentTool.resolveKnown(named: "copilot"))
     }
 
+    func test_agent_tool_recognizes_amp_only_as_leading_token() {
+        XCTAssertEqual(AgentTool.resolve(named: "amp"), .amp)
+        XCTAssertEqual(AgentTool.resolve(named: "amp - Greeting"), .amp)
+        XCTAssertEqual(AgentTool.resolveKnown(named: "amp - Greeting"), .amp)
+        XCTAssertEqual(AgentTool.resolve(named: "feature/amp"), .custom("feature/amp"))
+        XCTAssertNil(AgentTool.resolveKnown(named: "/Users/peter/Development/worktrees/feature/amp"))
+    }
+
     func test_agent_tool_recognizes_gemini_for_explicit_and_known_tool_resolution() {
         XCTAssertEqual(AgentTool.resolve(named: "gemini"), .gemini)
         XCTAssertEqual(AgentTool.resolve(named: "Gemini CLI"), .gemini)
@@ -206,6 +214,29 @@ final class AgentStatusSupportTests: XCTestCase {
         }
     }
 
+    func test_amp_passthrough_list_matches_management_commands_snapshot() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let launcherPath = repoRoot
+            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
+            .path
+        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
+
+        for subcommand in ["login", "logout", "mcp", "permission", "permissions", "review", "skill", "skills", "tool", "tools", "update", "up", "usage", "version"] {
+            XCTAssertTrue(
+                source.contains("\"\(subcommand)\""),
+                "ampPassthroughSubcommands should contain \(subcommand)"
+            )
+        }
+        for flag in ["--help", "-h", "--version", "-V", "--jetbrains"] {
+            XCTAssertTrue(
+                source.contains("\"\(flag)\""),
+                "ampEarlyExitFlags should contain \(flag)"
+            )
+        }
+    }
+
     func test_agent_tool_launcher_forwards_opencode_tui_and_xdg_environment() throws {
         // AgentToolLauncher lives in the ZenttyCLI target which tests don't
         // import, so read the source file directly to protect the bootstrap
@@ -222,6 +253,23 @@ final class AgentStatusSupportTests: XCTestCase {
             XCTAssertTrue(
                 source.contains("\"\(key)\""),
                 "AgentToolLauncher should forward \(key) into the bootstrap request"
+            )
+        }
+    }
+
+    func test_agent_tool_launcher_forwards_amp_routing_environment() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let launcherPath = repoRoot
+            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
+            .path
+        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
+
+        for key in ["AMP_SETTINGS_FILE", "ZENTTY_AMP_HOOKS_DISABLED", "ZENTTY_AMP_PID"] {
+            XCTAssertTrue(
+                source.contains("\"\(key)\""),
+                "AgentToolLauncher should forward \(key) for AMP bootstrap and plugin events"
             )
         }
     }
@@ -268,7 +316,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         XCTAssertEqual(
             AgentStatusHelper.wrapperDirectoryPaths(in: bundle),
-            ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"].map {
+            ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"].map {
                 binURL.appendingPathComponent($0, isDirectory: true).path
             }
         )
@@ -372,7 +420,7 @@ final class AgentStatusSupportTests: XCTestCase {
         try FileManager.default.createDirectory(at: realBinURL, withIntermediateDirectories: true)
         // Real binaries Zentty's wrappers expect on PATH. Note cursor resolves to `cursor-agent`,
         // not `cursor` (which is the Cursor IDE launcher).
-        for name in ["claude", "cursor-agent", "gemini", "kimi", "opencode"] {
+        for name in ["amp", "claude", "cursor-agent", "gemini", "kimi", "opencode"] {
             let fileURL = realBinURL.appendingPathComponent(name, isDirectory: false)
             try "#!/bin/sh\n".write(to: fileURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
@@ -380,6 +428,7 @@ final class AgentStatusSupportTests: XCTestCase {
 
         let environment = [
             "PATH": [
+                binURL.appendingPathComponent("amp", isDirectory: true).path,
                 binURL.appendingPathComponent("claude", isDirectory: true).path,
                 binURL.appendingPathComponent("codex", isDirectory: true).path,
                 binURL.appendingPathComponent("copilot", isDirectory: true).path,
@@ -398,6 +447,7 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(
             AgentStatusHelper.enabledWrapperDirectoryPaths(in: bundle, processEnvironment: environment),
             [
+                binURL.appendingPathComponent("amp", isDirectory: true).path,
                 binURL.appendingPathComponent("claude", isDirectory: true).path,
                 binURL.appendingPathComponent("cursor", isDirectory: true).path,
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
@@ -539,6 +589,22 @@ final class AgentStatusSupportTests: XCTestCase {
         }
     }
 
+    func test_repository_shell_integrations_tag_amp_shell_activity() throws {
+        for shell in [ShellIntegrationTestShell.zsh, .bash] {
+            let signals = try runShellIntegration(
+                shell: shell,
+                command: shell == .zsh
+                    ? #"_zentty_preexec "amp \"summarize this\"""#
+                    : #"amp "summarize this" 2>/dev/null || true"#
+            )
+
+            XCTAssertTrue(
+                signals.contains(where: { $0.contains("shell-state running --tool Amp") }),
+                "Expected \(shell) integration to tag amp shell activity, got: \(signals)"
+            )
+        }
+    }
+
     func test_repository_shell_integrations_include_running_command() throws {
         for shell in [ShellIntegrationTestShell.zsh, .bash] {
             let commandText = "pnpm start:staging -- --host 127.0.0.1"
@@ -665,6 +731,36 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(lastAbsolutePath(in: result.stdout), wrapperURL.path)
     }
 
+    func test_shell_integration_does_not_enable_amp_wrapper_when_wrapper_executable_is_missing() throws {
+        for shell in [ShellIntegrationTestShell.zsh, .bash] {
+            let wrapperRoot = try makeTemporaryDirectory(named: "shell-\(shell)-missing-amp-wrapper-root")
+            let wrapperDir = wrapperRoot.appendingPathComponent("amp", isDirectory: true)
+            try FileManager.default.createDirectory(at: wrapperDir, withIntermediateDirectories: true)
+
+            let realBinDir = try makeTemporaryDirectory(named: "shell-\(shell)-real-amp")
+            let realBinaryURL = realBinDir.appendingPathComponent("amp", isDirectory: false)
+            try "#!/bin/sh\nexit 0\n".write(to: realBinaryURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: realBinaryURL.path)
+
+            let result = try runShellIntegrationCommand(
+                shell: shell,
+                command: """
+                PATH="\(realBinDir.path):/usr/bin:/bin"
+                export PATH
+                _zentty_ensure_wrapper_path
+                printf 'active=<%s>\\n' "${ZENTTY_WRAPPER_BIN_DIRS-}"
+                command -v amp
+                """,
+                extraEnvironment: [
+                    "ZENTTY_ALL_WRAPPER_BIN_DIRS": wrapperDir.path,
+                ]
+            )
+
+            XCTAssertTrue(result.stdout.contains("active=<>"), "\(shell) should not export a missing amp wrapper: \(result.stdout)")
+            XCTAssertEqual(lastAbsolutePath(in: result.stdout), realBinaryURL.path)
+        }
+    }
+
     func test_zsh_shell_integration_prefers_tmux_shim_when_agent_teams_enabled() throws {
         let shimDir = try makeTemporaryDirectory(named: "shell-zsh-tmux-shim")
         let shimURL = shimDir.appendingPathComponent("tmux", isDirectory: false)
@@ -789,6 +885,56 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertTrue(script.contains("ZENTTY_AGENT_TOOL=\"codex\""))
         XCTAssertTrue(script.contains("zentty-agent-wrapper"))
         XCTAssertFalse(script.contains("python3"))
+    }
+
+    func test_repository_amp_wrapper_delegates_to_launch_cli() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let wrapperURL = repositoryRoot
+            .appendingPathComponent("ZenttyResources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: false)
+
+        let wrapper = try String(contentsOf: wrapperURL, encoding: .utf8)
+
+        XCTAssertTrue(wrapper.contains("ZENTTY_AGENT_TOOL=\"amp\""))
+        XCTAssertTrue(wrapper.contains("zentty-agent-wrapper"))
+        XCTAssertFalse(wrapper.contains("ZENTTY_AGENT_BIN"))
+    }
+
+    func test_copy_agent_resources_build_script_syncs_amp_support_directory() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let projectFileURL = repositoryRoot.appendingPathComponent("Zentty.xcodeproj/project.pbxproj", isDirectory: false)
+
+        let project = try String(contentsOf: projectFileURL, encoding: .utf8)
+
+        XCTAssertTrue(project.contains("${RESOURCES_DST}/amp/plugins"))
+        XCTAssertTrue(project.contains("${RESOURCES_SRC}/amp/"))
+        XCTAssertTrue(project.contains("${RESOURCES_DST}/amp/"))
+    }
+
+    func test_repository_amp_plugin_guards_routing_and_sanitizes_ipc_environment() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let pluginURL = repositoryRoot
+            .appendingPathComponent("ZenttyResources", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("zentty-amp-zentty.ts", isDirectory: false)
+
+        let plugin = try String(contentsOf: pluginURL, encoding: .utf8)
+
+        XCTAssertTrue(plugin.contains("ZENTTY_INSTANCE_SOCKET"))
+        XCTAssertTrue(plugin.contains("ZENTTY_WORKLANE_ID"))
+        XCTAssertTrue(plugin.contains("ZENTTY_PANE_ID"))
+        XCTAssertTrue(plugin.contains("if (!hasZenttyRoutingEnvironment()) return"))
+        XCTAssertTrue(plugin.contains("delete env.AMP_API_KEY"))
+        XCTAssertTrue(plugin.contains("ampEvent.status !== 'done'"))
     }
 
     func test_copy_agent_resources_build_script_syncs_opencode_support_directory() throws {
@@ -3093,6 +3239,185 @@ final class AgentStatusSupportTests: XCTestCase {
                     .path
             )
         )
+    }
+
+    func test_agent_launch_bootstrap_builds_amp_plan_with_plugin_and_launch_snapshot() throws {
+        let home = try makeTemporaryDirectory(named: "agent-launch-amp-home")
+        let userPluginURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("user-plugin.ts", isDirectory: false)
+        try FileManager.default.createDirectory(at: userPluginURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "// user plugin\n".write(to: userPluginURL, atomically: true, encoding: .utf8)
+        let userSettingsURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("settings.json", isDirectory: false)
+        try #"{"amp.notifications.enabled":false}"#
+            .write(to: userSettingsURL, atomically: true, encoding: .utf8)
+        let userAgentsURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("AGENTS.md", isDirectory: false)
+        try "personal amp guidance\n".write(to: userAgentsURL, atomically: true, encoding: .utf8)
+        let bundleRoot = try makeTemporaryBundleRoot(named: "agent-launch-amp-bundle")
+        let pluginDirectory = bundleRoot
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDirectory, withIntermediateDirectories: true)
+        let pluginURL = pluginDirectory.appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false)
+        try "// \(AmpPluginInstaller.ownershipMarker)\nexport default function ampPlugin() {}\n"
+            .write(to: pluginURL, atomically: true, encoding: .utf8)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--mode", "smart", "--execute", "ignored"],
+            standardInput: nil,
+            environment: [
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/amp",
+                "HOME": home.path,
+            ],
+            expectsResponse: true,
+            tool: .amp
+        )
+
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-amp-runtime")
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory,
+            bundle: try XCTUnwrap(Bundle(url: bundleRoot))
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/amp")
+        XCTAssertEqual(plan.arguments, ["--mode", "smart", "--execute", "ignored"])
+        XCTAssertEqual(plan.setEnvironment["ZENTTY_AGENT_TOOL"], "amp")
+        XCTAssertEqual(plan.setEnvironment["PLUGINS"], "all")
+        XCTAssertNil(plan.setEnvironment["HOME"])
+        XCTAssertNil(plan.setEnvironment["XDG_CONFIG_HOME"])
+        XCTAssertNil(plan.setEnvironment["AMP_SETTINGS_FILE"])
+        XCTAssertNil(plan.setEnvironment["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"])
+        XCTAssertEqual(plan.preLaunchActions.count, 2)
+        XCTAssertEqual(plan.preLaunchActions.map(\.subcommand), ["agent-event", "agent-event"])
+        XCTAssertTrue(plan.preLaunchActions[0].standardInput?.contains("\"event\":\"session.start\"") == true)
+        XCTAssertTrue(plan.preLaunchActions[1].standardInput?.contains("\"event\":\"agent.running\"") == true)
+        XCTAssertTrue(plan.preLaunchActions[0].standardInput?.contains("\"name\":\"Amp\"") == true)
+        XCTAssertTrue(plan.preLaunchActions[1].standardInput?.contains("\"arguments\":[]") == true)
+
+        let installedPluginURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installedPluginURL.path))
+        XCTAssertTrue(try String(contentsOf: installedPluginURL, encoding: .utf8).contains(AmpPluginInstaller.ownershipMarker))
+        let userPluginStillPresentURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("user-plugin.ts", isDirectory: false)
+        XCTAssertEqual(try String(contentsOf: userPluginStillPresentURL, encoding: .utf8), "// user plugin\n")
+
+        let settingsStillPresentURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("settings.json", isDirectory: false)
+        XCTAssertEqual(try String(contentsOf: settingsStillPresentURL, encoding: .utf8), try String(contentsOf: userSettingsURL, encoding: .utf8))
+
+        let agentsStillPresentURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("AGENTS.md", isDirectory: false)
+        XCTAssertEqual(try String(contentsOf: agentsStillPresentURL, encoding: .utf8), try String(contentsOf: userAgentsURL, encoding: .utf8))
+    }
+
+    func test_agent_launch_bootstrap_amp_refuses_to_overwrite_unmarked_plugin() throws {
+        let home = try makeTemporaryDirectory(named: "agent-launch-amp-conflict-home")
+        let installedPluginURL = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false)
+        try FileManager.default.createDirectory(at: installedPluginURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "// user-owned plugin\n".write(to: installedPluginURL, atomically: true, encoding: .utf8)
+
+        let bundleRoot = try makeTemporaryBundleRoot(named: "agent-launch-amp-conflict-bundle")
+        let pluginDirectory = bundleRoot
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDirectory, withIntermediateDirectories: true)
+        try "// \(AmpPluginInstaller.ownershipMarker)\n"
+            .write(
+                to: pluginDirectory.appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["hello"],
+            standardInput: nil,
+            environment: [
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/amp",
+                "HOME": home.path,
+            ],
+            expectsResponse: true,
+            tool: .amp
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: try makeTemporaryDirectory(named: "agent-launch-amp-conflict-runtime"),
+            bundle: try XCTUnwrap(Bundle(url: bundleRoot))
+        )
+
+        XCTAssertEqual(try String(contentsOf: installedPluginURL, encoding: .utf8), "// user-owned plugin\n")
+        XCTAssertNil(plan.setEnvironment["PLUGINS"])
+        XCTAssertEqual(plan.setEnvironment["ZENTTY_AGENT_TOOL"], "amp")
+    }
+
+    func test_agent_launch_bootstrap_amp_respects_hooks_disabled() throws {
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["--mode", "smart"],
+            standardInput: nil,
+            environment: [
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/amp",
+                "ZENTTY_AMP_HOOKS_DISABLED": "1",
+            ],
+            expectsResponse: true,
+            tool: .amp
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: try makeTemporaryDirectory(named: "agent-launch-amp-disabled-runtime"),
+            bundle: try makeTemporaryBundle(named: "agent-launch-amp-disabled-bundle")
+        )
+
+        XCTAssertEqual(plan.executablePath, "/usr/local/bin/amp")
+        XCTAssertEqual(plan.arguments, ["--mode", "smart"])
+        XCTAssertTrue(plan.setEnvironment.isEmpty)
+        XCTAssertTrue(plan.preLaunchActions.isEmpty)
     }
 
     func test_agent_ipc_authentication_is_pane_scoped() {
@@ -5954,6 +6279,192 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(presentation.statusText, "Needs input")
     }
 
+    func test_amp_running_payload_updates_pane_and_sidebar_status() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        let worklaneID = try XCTUnwrap(store.activeWorklane?.id)
+
+        store.applyAgentStatusPayload(AgentStatusPayload(
+            worklaneID: worklaneID,
+            paneID: paneID,
+            state: .running,
+            origin: .explicitHook,
+            toolName: "Amp",
+            text: nil,
+            sessionID: "amp-session-1",
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        ))
+
+        let worklane = try XCTUnwrap(store.activeWorklane)
+        let presentation = try XCTUnwrap(worklane.auxiliaryStateByPaneID[paneID]?.presentation)
+        XCTAssertEqual(worklane.auxiliaryStateByPaneID[paneID]?.agentStatus?.tool, .amp)
+        XCTAssertEqual(presentation.recognizedTool, .amp)
+        XCTAssertEqual(presentation.runtimePhase, .running)
+        XCTAssertEqual(presentation.statusText, "Running")
+
+        let summary = WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true)
+        let row = try XCTUnwrap(summary.paneRows.first)
+        XCTAssertEqual(row.statusText, "Running")
+        XCTAssertEqual(row.attentionState, .running)
+        XCTAssertTrue(row.isWorking)
+    }
+
+    func test_amp_command_finished_promotes_stale_idle_status_to_ready() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+
+        var worklane = try XCTUnwrap(store.activeWorklane)
+        worklane.auxiliaryStateByPaneID[paneID] = PaneAuxiliaryState(
+            agentStatus: PaneAgentStatus(
+                tool: .amp,
+                state: .idle,
+                text: nil,
+                artifactLink: nil,
+                updatedAt: Date(),
+                source: .explicit,
+                origin: .explicitHook,
+                interactionKind: PaneAgentInteractionKind.none,
+                confidence: .explicit,
+                hasObservedRunning: true,
+                sessionID: "amp-session-1"
+            )
+        )
+        store.activeWorklane = worklane
+
+        store.handleTerminalEvent(
+            paneID: paneID,
+            event: .commandFinished(exitCode: 0, durationNanoseconds: 250_000_000)
+        )
+
+        let presentation = try XCTUnwrap(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.presentation)
+        XCTAssertEqual(presentation.runtimePhase, .idle)
+        XCTAssertEqual(presentation.statusText, "Agent ready")
+        XCTAssertTrue(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.raw.showsReadyStatus == true)
+    }
+
+    func test_amp_idle_status_clears_when_non_agent_command_starts() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        let worklaneID = try XCTUnwrap(store.activeWorklane?.id)
+
+        var worklane = try XCTUnwrap(store.activeWorklane)
+        worklane.auxiliaryStateByPaneID[paneID] = PaneAuxiliaryState(
+            agentStatus: PaneAgentStatus(
+                tool: .amp,
+                state: .idle,
+                text: nil,
+                artifactLink: nil,
+                updatedAt: Date(),
+                source: .explicit,
+                origin: .explicitHook,
+                interactionKind: PaneAgentInteractionKind.none,
+                confidence: .explicit,
+                hasObservedRunning: true,
+                sessionID: "amp-session-1"
+            )
+        )
+        worklane.auxiliaryStateByPaneID[paneID]?.raw.showsReadyStatus = true
+        store.activeWorklane = worklane
+
+        store.applyAgentStatusPayload(AgentStatusPayload(
+            worklaneID: worklaneID,
+            paneID: paneID,
+            signalKind: .shellState,
+            state: nil,
+            shellActivityState: .commandRunning,
+            shellCommand: "pwd",
+            origin: .shell,
+            toolName: nil,
+            text: nil,
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        ))
+
+        let auxiliaryState = try XCTUnwrap(store.activeWorklane?.auxiliaryStateByPaneID[paneID])
+        XCTAssertNil(auxiliaryState.agentStatus)
+        XCTAssertFalse(auxiliaryState.raw.showsReadyStatus)
+        XCTAssertNil(auxiliaryState.presentation.statusText)
+    }
+
+    func test_amp_unresolved_stop_status_clears_when_non_agent_command_starts() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        let worklaneID = try XCTUnwrap(store.activeWorklane?.id)
+
+        var worklane = try XCTUnwrap(store.activeWorklane)
+        worklane.auxiliaryStateByPaneID[paneID] = PaneAuxiliaryState(
+            agentStatus: PaneAgentStatus(
+                tool: .amp,
+                state: .unresolvedStop,
+                text: nil,
+                artifactLink: nil,
+                updatedAt: Date(),
+                source: .explicit,
+                origin: .explicitHook,
+                interactionKind: PaneAgentInteractionKind.none,
+                confidence: .explicit,
+                hasObservedRunning: true,
+                sessionID: "amp-session-1"
+            )
+        )
+        store.activeWorklane = worklane
+
+        store.applyAgentStatusPayload(AgentStatusPayload(
+            worklaneID: worklaneID,
+            paneID: paneID,
+            signalKind: .shellState,
+            state: nil,
+            shellActivityState: .commandRunning,
+            shellCommand: "ls",
+            origin: .shell,
+            toolName: nil,
+            text: nil,
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        ))
+
+        let auxiliaryState = try XCTUnwrap(store.activeWorklane?.auxiliaryStateByPaneID[paneID])
+        XCTAssertNil(auxiliaryState.agentStatus)
+        XCTAssertNil(auxiliaryState.presentation.statusText)
+    }
+
+    func test_amp_unresolved_stop_command_finished_does_not_refresh_status() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        let oldDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+        var worklane = try XCTUnwrap(store.activeWorklane)
+        worklane.auxiliaryStateByPaneID[paneID] = PaneAuxiliaryState(
+            agentStatus: PaneAgentStatus(
+                tool: .amp,
+                state: .unresolvedStop,
+                text: nil,
+                artifactLink: nil,
+                updatedAt: oldDate,
+                source: .explicit,
+                origin: .explicitHook,
+                interactionKind: PaneAgentInteractionKind.none,
+                confidence: .explicit,
+                hasObservedRunning: true,
+                sessionID: "amp-session-1"
+            )
+        )
+        store.activeWorklane = worklane
+
+        store.handleTerminalEvent(
+            paneID: paneID,
+            event: .commandFinished(exitCode: 0, durationNanoseconds: 100_000_000)
+        )
+
+        let status = try XCTUnwrap(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus)
+        XCTAssertEqual(status.state, .unresolvedStop)
+        XCTAssertEqual(status.updatedAt, oldDate)
+    }
+
     func test_codex_action_required_title_survives_passive_progress_activity() throws {
         let store = WorklaneStore(readyStatusDebounceInterval: 0)
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
@@ -6906,6 +7417,29 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(decoded, payload)
     }
 
+    func test_agent_status_payload_round_trips_agent_launch_snapshot() throws {
+        let payload = AgentStatusPayload(
+            worklaneID: WorklaneID("worklane-main"),
+            paneID: PaneID("worklane-main-shell"),
+            signalKind: .lifecycle,
+            state: .running,
+            origin: .explicitHook,
+            toolName: "Amp",
+            text: nil,
+            sessionID: "T-ZenttyBenchRestore",
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil,
+            agentLaunchSnapshot: AgentLaunchSnapshot(arguments: ["--mode", "smart"])
+        )
+
+        let userInfo = try XCTUnwrap(payload.notificationUserInfo)
+        let decoded = try AgentStatusPayload(userInfo: userInfo)
+
+        XCTAssertEqual(decoded.agentLaunchSnapshot, AgentLaunchSnapshot(arguments: ["--mode", "smart"]))
+        XCTAssertEqual(decoded, payload)
+    }
+
     func test_agent_status_payload_round_trips_window_id() throws {
         let payload = AgentStatusPayload(
             windowID: WindowID("window-main"),
@@ -7017,6 +7551,7 @@ final class AgentStatusSupportTests: XCTestCase {
             ("kimi", "kimi"),
             ("kimi", "kimi-cli"),
             ("opencode", "opencode"),
+            ("amp", "amp"),
             ("pi", "pi"),
         ]
     }

--- a/ZenttyResources/amp/plugins/zentty-amp-zentty.ts
+++ b/ZenttyResources/amp/plugins/zentty-amp-zentty.ts
@@ -1,0 +1,90 @@
+// zentty-amp-plugin-v1
+import type { PluginAPI } from '@ampcode/plugin'
+
+type AmpEvent = {
+	thread?: { id?: string }
+	status?: string
+}
+
+type AmpContext = {
+	thread?: { id?: string }
+}
+
+const cli = process.env.ZENTTY_CLI_BIN || 'zentty'
+
+export default function (amp: PluginAPI) {
+	if (!hasZenttyRoutingEnvironment()) return
+
+	const send = async (eventName: string, event: AmpEvent, ctx: AmpContext, stopCandidate = false) => {
+		const threadID = event.thread?.id || ctx.thread?.id
+		if (!threadID) return
+
+		const payload = {
+			version: 1,
+			event: eventName,
+			agent: {
+				name: 'Amp',
+				pid: positiveInt(process.env.ZENTTY_AMP_PID),
+			},
+			session: { id: threadID },
+			state: stopCandidate ? { stopCandidate: true } : undefined,
+			context: {
+				workingDirectory: process.env.PWD || process.cwd(),
+				launch: {
+					arguments: resumeArguments(),
+				},
+			},
+		}
+
+		try {
+			const child = Bun.spawn([cli, 'ipc', 'agent-event'], {
+				stdin: 'pipe',
+				stdout: 'ignore',
+				stderr: 'ignore',
+				env: ipcEnvironment(),
+			})
+			child.stdin.write(JSON.stringify(payload))
+			child.stdin.end()
+			await child.exited
+		} catch {
+			// Best effort only. Amp should not be affected by Zentty IPC failures.
+		}
+	}
+
+	amp.on('session.start', (event, ctx) => send('session.start', event as AmpEvent, ctx as AmpContext))
+	amp.on('agent.start', (event, ctx) => send('agent.running', event as AmpEvent, ctx as AmpContext))
+	amp.on('agent.end', (event, ctx) => {
+		const ampEvent = event as AmpEvent
+		return send('agent.idle', ampEvent, ctx as AmpContext, ampEvent.status !== 'done')
+	})
+}
+
+function hasZenttyRoutingEnvironment(): boolean {
+	return Boolean(
+		process.env.ZENTTY_INSTANCE_SOCKET &&
+			process.env.ZENTTY_WORKLANE_ID &&
+			process.env.ZENTTY_PANE_ID &&
+			process.env.ZENTTY_AMP_HOOKS_DISABLED !== '1',
+	)
+}
+
+function ipcEnvironment(): typeof process.env {
+	const env = { ...process.env }
+	delete env.AMP_API_KEY
+	return env
+}
+
+function resumeArguments(): string[] {
+	try {
+		const value = JSON.parse(process.env.ZENTTY_AMP_RESUME_ARGUMENTS_JSON || '[]')
+		return Array.isArray(value) ? value.filter((item) => typeof item === 'string' && item.length > 0) : []
+	} catch {
+		return []
+	}
+}
+
+function positiveInt(value: string | undefined): number | undefined {
+	if (!value || !/^[0-9]+$/.test(value)) return undefined
+	const parsed = Number(value)
+	return parsed > 0 ? parsed : undefined
+}

--- a/ZenttyResources/bin/amp/amp
+++ b/ZenttyResources/bin/amp/amp
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export ZENTTY_AGENT_TOOL="amp"
+exec "$(cd "$(dirname "$0")" && pwd)/../shared/zentty-agent-wrapper" "$@"

--- a/ZenttyResources/shell-integration/zentty-bash-integration.bash
+++ b/ZenttyResources/shell-integration/zentty-bash-integration.bash
@@ -25,8 +25,8 @@ _zentty_ensure_wrapper_path() {
     fi
     [[ -n "$wrapper_dirs" || -n "$tmux_shim_dir" ]] || return 0
 
-    local -a wrappers entries cleaned_path next_path
-    local wrapper entry tool_name
+    local -a wrappers entries cleaned_path next_path wrapper_bins real_bins
+    local wrapper entry tool_name binary_name
     wrappers=()
     if [[ -n "$wrapper_dirs" ]]; then
         IFS=: read -r -a wrappers <<< "$wrapper_dirs"
@@ -51,11 +51,24 @@ _zentty_ensure_wrapper_path() {
     for wrapper in "${wrappers[@]}"; do
         [[ -n "$wrapper" ]] || continue
         tool_name="${wrapper##*/}"
-        for entry in "${cleaned_path[@]}"; do
-            if [[ -x "${entry}/${tool_name}" ]]; then
-                next_path+=("$wrapper")
+        wrapper_bins=($(_zentty_wrapper_binary_candidates "$tool_name"))
+        real_bins=($(_zentty_real_binary_candidates "$tool_name"))
+        local has_wrapper_binary=0
+        for binary_name in "${wrapper_bins[@]}"; do
+            if [[ -x "${wrapper}/${binary_name}" ]]; then
+                has_wrapper_binary=1
                 break
             fi
+        done
+        (( has_wrapper_binary )) || continue
+
+        for entry in "${cleaned_path[@]}"; do
+            for binary_name in "${real_bins[@]}"; do
+                if [[ -x "${entry}/${binary_name}" ]]; then
+                    next_path+=("$wrapper")
+                    break 2
+                fi
+            done
         done
     done
     next_path+=("${cleaned_path[@]}")
@@ -82,6 +95,19 @@ _zentty_ensure_wrapper_path() {
     export PATH
 }
 
+_zentty_wrapper_binary_candidates() {
+    local tool_name="$1"
+    case "$tool_name" in
+        cursor) printf '%s\n' "cursor-agent" ;;
+        kimi) printf '%s\n' "kimi" "kimi-cli" ;;
+        *) printf '%s\n' "$tool_name" ;;
+    esac
+}
+
+_zentty_real_binary_candidates() {
+    _zentty_wrapper_binary_candidates "$1"
+}
+
 _zentty_agent_signal() {
     [[ "${ZENTTY_SHELL_INTEGRATION:-1}" == "0" ]] && return 0
     [[ -n "${ZENTTY_INSTANCE_SOCKET:-}" ]] || return 0
@@ -106,6 +132,7 @@ _zentty_report_shell_activity() {
 _zentty_agent_tool_for_command() {
     local cmd="${1##*/}"
     case "$cmd" in
+        amp) printf '%s\n' "Amp" ;;
         claude) printf '%s\n' "Claude Code" ;;
         codex) printf '%s\n' "Codex" ;;
         droid) printf '%s\n' "Droid" ;;

--- a/ZenttyResources/shell-integration/zentty-zsh-integration.zsh
+++ b/ZenttyResources/shell-integration/zentty-zsh-integration.zsh
@@ -29,8 +29,8 @@ _zentty_ensure_wrapper_path() {
         tmux_shim_enabled=1
     fi
     [[ -n "$wrapper_dirs" || -n "$tmux_shim_dir" ]] || return 0
-    local -a wrappers cleaned_path enabled_wrappers next_path
-    local wrapper entry tool_name
+    local -a wrappers cleaned_path enabled_wrappers next_path wrapper_bins real_bins
+    local wrapper entry tool_name binary_name
     wrappers=()
     [[ -z "$wrapper_dirs" ]] || wrappers=("${(@s/:/)wrapper_dirs}")
     cleaned_path=()
@@ -41,10 +41,22 @@ _zentty_ensure_wrapper_path() {
     done
     for wrapper in "${wrappers[@]}"; do
         tool_name="${wrapper:t}"
-        for entry in "${cleaned_path[@]}"; do
-            [[ -x "${entry}/${tool_name}" ]] || continue
-            enabled_wrappers+=("$wrapper")
+        wrapper_bins=($(_zentty_wrapper_binary_candidates "$tool_name"))
+        real_bins=($(_zentty_real_binary_candidates "$tool_name"))
+        local has_wrapper_binary=0
+        for binary_name in "${wrapper_bins[@]}"; do
+            [[ -x "${wrapper}/${binary_name}" ]] || continue
+            has_wrapper_binary=1
             break
+        done
+        (( has_wrapper_binary )) || continue
+
+        for entry in "${cleaned_path[@]}"; do
+            for binary_name in "${real_bins[@]}"; do
+                [[ -x "${entry}/${binary_name}" ]] || continue
+                enabled_wrappers+=("$wrapper")
+                break 2
+            done
         done
     done
     next_path=()
@@ -63,6 +75,19 @@ _zentty_ensure_wrapper_path() {
     fi
     rehash 2>/dev/null || true
     export PATH
+}
+
+_zentty_wrapper_binary_candidates() {
+    local tool_name="$1"
+    case "$tool_name" in
+        cursor) printf '%s\n' "cursor-agent" ;;
+        kimi) printf '%s\n' "kimi" "kimi-cli" ;;
+        *) printf '%s\n' "$tool_name" ;;
+    esac
+}
+
+_zentty_real_binary_candidates() {
+    _zentty_wrapper_binary_candidates "$1"
 }
 
 _zentty_agent_signal() {
@@ -89,6 +114,7 @@ _zentty_report_shell_activity() {
 _zentty_agent_tool_for_command() {
     local cmd="${1:t}"
     case "$cmd" in
+        amp) printf '%s\n' "Amp" ;;
         claude) printf '%s\n' "Claude Code" ;;
         codex) printf '%s\n' "Codex" ;;
         droid) printf '%s\n' "Droid" ;;

--- a/project.yml
+++ b/project.yml
@@ -126,11 +126,12 @@ targets:
           RESOURCES_SRC="${PROJECT_DIR}/ZenttyResources"
           RESOURCES_DST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
-          mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
+          mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/amp/plugins" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
           rsync -a --delete "${RESOURCES_SRC}/bin/" "${RESOURCES_DST}/bin/"
           install -m 755 "${BUILT_PRODUCTS_DIR}/zentty" "${RESOURCES_DST}/bin/shared/zentty"
-          find "${RESOURCES_DST}/bin" -type f \( -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/droid/droid" -o -path "*/gemini/gemini" -o -path "*/kimi/kimi" -o -path "*/kimi/kimi-cli" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" -o -path "*/tmux-shim/tmux" \) -exec chmod 755 {} +
+          find "${RESOURCES_DST}/bin" -type f \( -path "*/amp/amp" -o -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/droid/droid" -o -path "*/gemini/gemini" -o -path "*/kimi/kimi" -o -path "*/kimi/kimi-cli" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" -o -path "*/tmux-shim/tmux" \) -exec chmod 755 {} +
           rsync -a --delete "${RESOURCES_SRC}/shell-integration/" "${RESOURCES_DST}/shell-integration/"
+          rsync -a --delete "${RESOURCES_SRC}/amp/" "${RESOURCES_DST}/amp/"
           rsync -a --delete "${RESOURCES_SRC}/opencode/" "${RESOURCES_DST}/opencode/"
           rsync -a --delete "${RESOURCES_SRC}/pi/" "${RESOURCES_DST}/pi/"
           rsync -a --delete "${RESOURCES_SRC}/ghostty/" "${RESOURCES_DST}/ghostty/"

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -27,16 +27,21 @@ from collections import Counter
 from typing import Any
 
 
-SUPPORTED_AGENTS = ("claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi")
+SUPPORTED_AGENTS = ("amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi")
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BENCH_ROOT = pathlib.Path(__file__).resolve().parent
 DEFAULT_RUNS_DIR = REPO_ROOT / ".agent-bench-runs"
+AMP_PLUGIN_FILE_NAME = "zentty-amp-zentty.ts"
+AMP_PLUGIN_OWNERSHIP_MARKER = "zentty-amp-plugin-v1"
 ROUTING_ENV_KEYS = {
     "ZENTTY_WINDOW_ID",
     "ZENTTY_WORKLANE_ID",
     "ZENTTY_PANE_ID",
     "ZENTTY_INSTANCE_ID",
     "ZENTTY_AGENT_TOOL",
+    "ZENTTY_AMP_PID",
+    "ZENTTY_AMP_RESUME_ARGUMENTS_JSON",
+    "PLUGINS",
     "ZENTTY_CLAUDE_PID",
     "ZENTTY_CODEX_PID",
     "ZENTTY_COPILOT_PID",
@@ -401,6 +406,8 @@ def session_id_matches_pattern(session_id: str, pattern: str) -> bool:
         return session_id_matches_pattern(session_id, "uuid") or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", session_id) is not None
     if pattern == "droid":
         return re.fullmatch(r"[A-Za-z0-9_.:-]+", session_id) is not None
+    if pattern == "amp":
+        return re.fullmatch(r"T-[A-Za-z0-9_-]+", session_id) is not None
     if pattern == "opencode":
         return re.fullmatch(r"ses_[A-Za-z0-9]+", session_id) is not None
     return False
@@ -1084,6 +1091,60 @@ class LaunchPlanner:
 
     def _direct_plan(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
         return self._launch_plan(executable, arguments, {"ZENTTY_AGENT_TOOL": self.profile.name})
+
+    def _plan_amp(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
+        source_home = pathlib.Path(str(environment.get("HOME") or pathlib.Path.home())).expanduser()
+        config_home = pathlib.Path(str(environment.get("XDG_CONFIG_HOME") or source_home / ".config")).expanduser()
+        env = {
+            "ZENTTY_AGENT_TOOL": "amp",
+        }
+        if self._install_amp_plugin(config_home):
+            env["PLUGINS"] = "all"
+
+        resume_arguments = sanitized_amp_resume_arguments(arguments)
+        if resume_arguments:
+            env["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"] = compact_json(resume_arguments)
+        session_start = compact_json({
+            "version": 1,
+            "event": "session.start",
+            "agent": {"name": "Amp", "pid": "__ZENTTY_SELF_PID__"},
+            "context": {"launch": {"arguments": resume_arguments}},
+        })
+        agent_running = compact_json({
+            "version": 1,
+            "event": "agent.running",
+            "agent": {"name": "Amp", "pid": "__ZENTTY_SELF_PID__"},
+            "context": {"launch": {"arguments": resume_arguments}},
+        })
+        return self._launch_plan(
+            executable,
+            arguments,
+            env,
+            prelaunch=[
+                {"subcommand": "agent-event", "arguments": [], "standardInput": session_start},
+                {"subcommand": "agent-event", "arguments": [], "standardInput": agent_running},
+            ],
+        )
+
+    def _install_amp_plugin(self, config_home: pathlib.Path) -> bool:
+        if not self.resources_dir:
+            return False
+        source = self.resources_dir / "amp" / "plugins" / AMP_PLUGIN_FILE_NAME
+        if not source.exists():
+            return False
+
+        destination = config_home / "amp" / "plugins" / AMP_PLUGIN_FILE_NAME
+        if destination.exists():
+            try:
+                existing = destination.read_text(encoding="utf-8")
+            except OSError:
+                existing = ""
+            if AMP_PLUGIN_OWNERSHIP_MARKER not in existing:
+                return False
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        return True
 
     def _plan_claude(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
         hook_command = f'"{shell_escape_double_quoted(cli_path)}" ipc agent-event --adapter=claude'
@@ -2116,6 +2177,67 @@ def copy_directory_contents(source: pathlib.Path, destination: pathlib.Path) -> 
             shutil.copytree(child, target, dirs_exist_ok=True)
         else:
             shutil.copy2(child, target)
+
+
+def sanitized_amp_resume_arguments(arguments: list[str]) -> list[str]:
+    remaining = list(arguments)
+    if remaining and remaining[0] == "amp":
+        remaining = remaining[1:]
+    if len(remaining) >= 2 and remaining[0] in {"threads", "thread", "t"} and remaining[1] in {"continue", "c"}:
+        remaining = remaining[2:]
+        if remaining and re.fullmatch(r"T-[A-Za-z0-9_-]+", remaining[0]):
+            remaining = remaining[1:]
+    if remaining and remaining[0] in {
+        "login",
+        "logout",
+        "mcp",
+        "permission",
+        "permissions",
+        "review",
+        "skill",
+        "skills",
+        "tool",
+        "tools",
+        "update",
+        "up",
+        "usage",
+        "version",
+    }:
+        return []
+    rejected_flags = {"--execute", "--print", "-x", "--help", "-h", "--version", "-V", "--jetbrains"}
+    if any(amp_option_name(argument) in rejected_flags for argument in remaining):
+        return []
+
+    safe_value_options = {"--mode", "-m", "--effort", "--settings-file", "--log-level", "--log-file", "--mcp-config", "--visibility"}
+    dropped_value_options = {"--label", "-l"}
+    dropped_flags = {"--archive", "--stream-json", "--stream-json-input", "--stream-json-thinking", "--json", "--output-format"}
+    sanitized: list[str] = []
+    index = 0
+    while index < len(remaining):
+        argument = remaining[index]
+        option_name = argument.split("=", 1)[0] if argument.startswith("--") else argument
+        if option_name in safe_value_options:
+            if "=" in argument:
+                sanitized.append(argument)
+            elif index + 1 < len(remaining) and not remaining[index + 1].startswith("-"):
+                sanitized.extend([argument, remaining[index + 1]])
+                index += 1
+        elif option_name in dropped_value_options:
+            if "=" not in argument and index + 1 < len(remaining) and not remaining[index + 1].startswith("-"):
+                index += 1
+        elif option_name in dropped_flags:
+            if option_name == "--output-format" and "=" not in argument and index + 1 < len(remaining) and not remaining[index + 1].startswith("-"):
+                index += 1
+        elif argument.startswith("-"):
+            pass
+        else:
+            break
+        index += 1
+    return sanitized
+
+
+def amp_option_name(argument: str) -> str:
+    return argument.split("=", 1)[0] if argument.startswith("--") else argument
 
 
 def shell_escape_double_quoted(value: str) -> str:

--- a/scripts/agent-bench/profiles/amp.json
+++ b/scripts/agent-bench/profiles/amp.json
@@ -1,0 +1,40 @@
+{
+  "name": "amp",
+  "command": "amp",
+  "real_binary_names": ["amp"],
+  "version_args": ["--version"],
+  "launch_args_by_scenario": {
+    "smoke": [
+      "--dangerously-allow-all",
+      "--execute",
+      "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
+    ],
+    "session_capture": [
+      "--dangerously-allow-all",
+      "--execute",
+      "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
+    ],
+    "restore_launch": [
+      "threads",
+      "continue",
+      "T-ZenttyBenchRestore"
+    ]
+  },
+  "expectations": {
+    "smoke": {
+      "required_events": ["session.start", "agent.running"]
+    },
+    "session_capture": {
+      "required_events": ["session.start", "agent.running", "agent.idle"],
+      "session_identity": {
+        "session_id_pattern": "amp",
+        "tracked_pid": true
+      }
+    },
+    "restore_launch": {
+      "required_events": [],
+      "required_bootstrap_arguments": [["threads", "continue", "T-ZenttyBenchRestore"]]
+    }
+  },
+  "skip_patterns": ["login", "auth", "not authenticated", "api key", "sign in", "Unexpected error inside Amp CLI"]
+}

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -942,10 +942,24 @@ class ProfileTests(unittest.TestCase):
 
         self.assertEqual(
             sorted(profiles),
-            ["claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"],
+            ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "kimi", "opencode", "pi"],
         )
         for profile in profiles.values():
             self.assertIn("smoke", profile.expectations)
+
+    def test_amp_profile_covers_session_capture_and_restore_launch(self):
+        profile = agent_bench.load_profiles(ROOT / "profiles")["amp"]
+
+        self.assertEqual(profile.command, "amp")
+        self.assertIn("--execute", profile.launch_args_by_scenario["smoke"])
+        self.assertEqual(
+            profile.expectations["session_capture"].session_identity.session_id_pattern,
+            "amp",
+        )
+        self.assertEqual(
+            profile.expectations["restore_launch"].required_bootstrap_arguments,
+            [["threads", "continue", "T-ZenttyBenchRestore"]],
+        )
 
     def test_cursor_smoke_profile_uses_headless_hook_events(self):
         profile = agent_bench.load_profiles(ROOT / "profiles")["cursor"]
@@ -1457,6 +1471,111 @@ class LaunchPlannerTests(unittest.TestCase):
             self.assertEqual(plan["setEnvironment"]["OPENCODE_CONFIG"], str(overlay / "opencode.json"))
             self.assertTrue(merged["autoupdate"])
             self.assertEqual(merged["permission"]["bash"], "ask")
+
+    def test_amp_plan_installs_plugin_into_user_config_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            real_home = root / "real-home"
+            real_plugin = real_home / ".config" / "amp" / "plugins" / "user.ts"
+            real_plugin.parent.mkdir(parents=True)
+            real_plugin.write_text("// user plugin\n", encoding="utf-8")
+            real_marker = real_home / ".config" / "amp" / "settings.json"
+            real_marker.write_text('{"amp.notifications.enabled":false}\n', encoding="utf-8")
+            real_agents = real_home / ".config" / "amp" / "AGENTS.md"
+            real_agents.write_text("personal amp guidance\n", encoding="utf-8")
+            resources = root / "resources"
+            plugin = resources / "amp" / "plugins" / "zentty-amp-zentty.ts"
+            plugin.parent.mkdir(parents=True)
+            plugin.write_text("// zentty plugin\n", encoding="utf-8")
+            profile = agent_bench.AgentProfile(
+                name="amp",
+                command="amp",
+                real_binary_names=["amp"],
+                version_args=["--version"],
+                launch_args_by_scenario={"smoke": []},
+                expectations={"smoke": agent_bench.ScenarioExpectation("smoke", ["session.start"])},
+            )
+
+            plan = agent_bench.LaunchPlanner(
+                profile=profile,
+                scenario="smoke",
+                run_dir=root / "run",
+                resources_dir=resources,
+            ).plan(
+                {
+                    "arguments": ["--mode", "smart", "hello"],
+                    "environment": {
+                        "ZENTTY_REAL_BINARY": "/usr/local/bin/amp",
+                        "ZENTTY_CLI_BIN": "/tmp/zentty",
+                        "HOME": str(real_home),
+                    },
+                }
+            )
+
+            self.assertNotIn("HOME", plan["setEnvironment"])
+            self.assertNotIn("XDG_CONFIG_HOME", plan["setEnvironment"])
+            self.assertNotIn("AMP_SETTINGS_FILE", plan["setEnvironment"])
+            amp_config = real_home / ".config" / "amp"
+            installed_plugin = amp_config / "plugins" / "zentty-amp-zentty.ts"
+            self.assertTrue(installed_plugin.exists())
+            user_plugin = amp_config / "plugins" / "user.ts"
+            self.assertFalse(user_plugin.is_symlink())
+            self.assertEqual(user_plugin.resolve(), real_plugin.resolve())
+            settings = amp_config / "settings.json"
+            self.assertFalse(settings.is_symlink())
+            self.assertEqual(settings.resolve(), real_marker.resolve())
+            agents = amp_config / "AGENTS.md"
+            self.assertFalse(agents.is_symlink())
+            self.assertEqual(agents.resolve(), real_agents.resolve())
+            self.assertEqual(real_plugin.read_text(encoding="utf-8"), "// user plugin\n")
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_AGENT_TOOL"], "amp")
+            self.assertEqual(plan["setEnvironment"]["PLUGINS"], "all")
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_AMP_RESUME_ARGUMENTS_JSON"], '["--mode","smart"]')
+            self.assertEqual([action["standardInput"] for action in plan["preLaunchActions"]], [
+                '{"version":1,"event":"session.start","agent":{"name":"Amp","pid":"__ZENTTY_SELF_PID__"},"context":{"launch":{"arguments":["--mode","smart"]}}}',
+                '{"version":1,"event":"agent.running","agent":{"name":"Amp","pid":"__ZENTTY_SELF_PID__"},"context":{"launch":{"arguments":["--mode","smart"]}}}',
+            ])
+
+    def test_amp_plan_refuses_to_overwrite_unmarked_plugin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            home = root / "home"
+            existing_plugin = home / ".config" / "amp" / "plugins" / "zentty-amp-zentty.ts"
+            existing_plugin.parent.mkdir(parents=True)
+            existing_plugin.write_text("// user-owned file\n", encoding="utf-8")
+            resources = root / "resources"
+            plugin = resources / "amp" / "plugins" / "zentty-amp-zentty.ts"
+            plugin.parent.mkdir(parents=True)
+            plugin.write_text("// zentty-amp-plugin-v1\n", encoding="utf-8")
+            profile = agent_bench.AgentProfile(
+                name="amp",
+                command="amp",
+                real_binary_names=["amp"],
+                version_args=["--version"],
+                launch_args_by_scenario={"smoke": []},
+                expectations={"smoke": agent_bench.ScenarioExpectation("smoke", ["session.start"])},
+            )
+
+            plan = agent_bench.LaunchPlanner(
+                profile=profile,
+                scenario="smoke",
+                run_dir=root / "run",
+                resources_dir=resources,
+            ).plan(
+                {
+                    "arguments": ["hello"],
+                    "environment": {
+                        "ZENTTY_REAL_BINARY": "/usr/local/bin/amp",
+                        "HOME": str(home),
+                    },
+                }
+            )
+
+            self.assertEqual(existing_plugin.read_text(encoding="utf-8"), "// user-owned file\n")
+            self.assertNotIn("PLUGINS", plan["setEnvironment"])
+
+    def test_amp_resume_argument_sanitizer_rejects_execute_with_value(self):
+        self.assertEqual(agent_bench.sanitized_amp_resume_arguments(["--execute=echo hi"]), [])
 
     def test_timeout_with_skip_pattern_is_classified_as_prerequisite_skip(self):
         result = agent_bench.classify_timeout_result(


### PR DESCRIPTION
## Summary

Zentty can now launch and track Amp as a first-class agent. The integration installs the bundled Amp plugin when it is safe to do so, seeds session/running state before launch, and carries sanitized resume arguments so restored panes can continue the right Amp thread without leaking prompt-style flags.

The shell wrappers now detect Amp commands, the launcher treats Amp subcommands and early-exit flags as passthrough, and agent-bench has an Amp profile with validation for session identity, bootstrap arguments, and redacted routing environment. Existing user Amp plugin files are only replaced when they carry Zentty's ownership marker.

## Testing

- `python3 -m unittest discover -s scripts/agent-bench/tests -p 'test_*.py'` (77 tests)
- `TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test -scheme Zentty -destination 'platform=macOS' -only-testing:ZenttyLogicTests/AgentStatusSupportTests -only-testing:ZenttyLogicTests/AgentResumeCommandBuilderTests -only-testing:ZenttyLogicTests/AgentEventBridgeTests -skip-testing:ZenttyTests -skip-testing:ZenttyIntegrationTests CODE_SIGNING_ALLOWED=NO` (351 selected tests)
