### PR TITLE
feat(clean-copy): sharper pipeline, agent-marker cleanup, context-aware copy menu

### DIFF
--- a/Zentty/Terminal/CleanCopyPipeline.swift
+++ b/Zentty/Terminal/CleanCopyPipeline.swift
@@ -104,8 +104,6 @@ enum CleanCopyPipeline {
 
     // MARK: - Pass 4: Prompt Detection
 
-    private static let promptCharacters: Set<Character> = ["$", ">", "%", "#"]
-
     static func stripPrompts(_ input: String) -> String {
         let lines = input.split(separator: "\n", omittingEmptySubsequences: false)
         let nonEmptyLines = lines.filter { !$0.allSatisfy(\.isWhitespace) }
@@ -124,7 +122,7 @@ enum CleanCopyPipeline {
     }
 
     private static func detectPromptPattern(nonEmptyLines: [Substring]) -> String? {
-        let candidates = ["$ ", "> ", "% ", "# "]
+        let candidates = ["$ ", "> ", "# "]
         let lineCount = nonEmptyLines.count
 
         for candidate in candidates {
@@ -136,9 +134,13 @@ enum CleanCopyPipeline {
                     return candidate
                 }
             } else {
-                // Multi-line: need >60% consistency
-                let ratio = Double(matchCount) / Double(lineCount)
-                if ratio > 0.6 {
+                // Multi-line: strict (true) majority of non-empty lines must match.
+                // n/2+1 with integer division — n=4 needs 3, n=5 needs 3, n=6 needs 4, n=7 needs 4.
+                // Looser than the prior >0.6 threshold for odd n (n=5 used to need 4) — this is
+                // deliberate: it cleans the dominant terminal shape (e.g. 3 commands + 2 output
+                // lines). Accepted trade-off: a 3-of-5 markdown blockquote/comment selection also
+                // loses its `> `/`# ` markers; rare in terminal pastes, so the shell case wins.
+                if matchCount >= lineCount / 2 + 1 {
                     return candidate
                 }
             }
@@ -149,7 +151,10 @@ enum CleanCopyPipeline {
     // MARK: - Pass 4b: Agent Prompt Cleanup
 
     private static let agentPromptMarkers: Set<Character> = ["›", "❯"]
-    private static let boxDrawingCharacterClass = "[│┃╎╏┆┇┊┋╽╿￨｜]"
+    private static let boxDrawingCharacterClass = "[│┃║╎╏┆┇┊┋╽╿￨｜]"
+    private static let borderBoxCharacterClass = "[─━┌┐└┘├┤┬┴┼═║╔╗╚╝╠╣╦╩╬╭╮╯╰┏┓┗┛┣┫┳┻╋]"
+
+    private static let maxAgentPromptReflowLines = 60
 
     static func stripAgentPromptSelection(_ input: String) -> String? {
         let lines = input.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
@@ -162,6 +167,8 @@ enum CleanCopyPipeline {
         else {
             return nil
         }
+
+        guard nonEmpty.count <= maxAgentPromptReflowLines else { return nil }
 
         let candidateLines: [String]
         if let ruleIndex = lines.firstIndex(where: isAgentPromptRuleLine(_:)) {
@@ -187,9 +194,9 @@ enum CleanCopyPipeline {
 
         let content = contentLines.joined(separator: "\n")
         guard !isLikelySourceCode(content),
-              !isLikelyList(nonEmptyContentLines),
-              !isLikelyStructuredData(nonEmptyContentLines),
-              !isLikelyShellTranscript(nonEmptyContentLines)
+              !isLikelyList(content),
+              !isLikelyStructuredData(content),
+              !isLikelyShellTranscript(content)
         else {
             return nil
         }
@@ -215,7 +222,7 @@ enum CleanCopyPipeline {
     private static func isAgentPromptRuleLine(_ line: String) -> Bool {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         guard trimmed.count >= 10 else { return false }
-        let ruleCharacters: Set<Character> = ["─", "━", "—", "-"]
+        let ruleCharacters: Set<Character> = ["─", "━", "—"]
         let ruleCount = trimmed.count(where: { ruleCharacters.contains($0) })
         return ruleCount >= 10 && ruleCount == trimmed.count
     }
@@ -250,11 +257,74 @@ enum CleanCopyPipeline {
         return result
     }
 
+    /// Collapses a single agent-reply paragraph (already split on blank lines by
+    /// `flattenWrappedPromptLines`) into one flat string. The ordered rejoin regexes
+    /// assume the input is one paragraph with no double newlines — passing
+    /// multi-paragraph input here would let `\n+ -> " "` swallow paragraph breaks.
+    ///
+    /// Known accepted false-positive: the path-segment rule fuses any line ending in
+    /// `/` or `~` with the next line, including prose shapes like
+    /// `"Save in /tmp/\n  Then run command"`. Path-wrap is far more common in agent
+    /// output than this shape, so the trade-off favours the path-wrap case.
     private static func flattenPromptParagraph(_ lines: [String]) -> String {
-        lines
-            .joined(separator: " ")
-            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var result = lines.joined(separator: "\n")
+
+        // Hyphen-token boundary: keep wrapped tokens like UUIDs joined without an inserted space.
+        // Lookbehind excludes "-" so a markdown HR run (----------) does not fuse with the next line.
+        result = result.replacingOccurrences(
+            of: #"(?<=[A-Za-z0-9._~])-\s*\n\s*([A-Za-z0-9._~-])"#,
+            with: "-$1",
+            options: .regularExpression
+        )
+
+        // Capitalized identifier mid-break: "N\nODE_PATH" -> "NODE_PATH".
+        // "." is intentionally absent from the LHS so a sentence-boundary like
+        // "Here is the answer.\nHere is more context." does NOT fuse into ".H" —
+        // the later "\n+ -> ' '" pass needs the newline to survive and become a space.
+        // "-" is absent from both sides so a dash run (markdown HR) doesn't fuse with the next line.
+        // The trailing (?=[A-Z0-9_.]) requires the next-line token to continue as an
+        // identifier (2+ chars), so a split identifier (N -> ODE_PATH) still joins while
+        // two standalone capitals don't: "Grade A\nB students" stays "Grade A B students"
+        // (the newline survives to the "\n+ -> ' '" pass). It also subsumes the old (?!\n).
+        result = result.replacingOccurrences(
+            of: #"(?<!\n)([A-Z0-9_])\s*\n\s*([A-Z0-9_.])(?=[A-Z0-9_.])"#,
+            with: "$1$2",
+            options: .regularExpression
+        )
+
+        // Path segment after / or ~: ".../foo/\nbar" -> ".../foo/bar".
+        // Pinned by test_stripAgentPromptSelection_rejoins_path_segment.
+        // Accepted false-positive: prose ending with a trailing "/" or "~" fuses with
+        // the next line ("Save in /tmp/\n  Then run command" -> "Save in /tmp/Then run command").
+        // Don't "fix" this by tightening without a replacement rule for the real path-wrap case.
+        result = result.replacingOccurrences(
+            of: #"(?<=[/~])\s*\n\s*([A-Za-z0-9._-])"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Backslash line continuations collapse to a single space
+        result = result.replacingOccurrences(
+            of: #"\\\s*\n"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        // Remaining newlines fold to a single space
+        result = result.replacingOccurrences(
+            of: #"\n+"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        // Final whitespace squeeze
+        result = result.replacingOccurrences(
+            of: #"\s+"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func isLikelySourceCode(_ text: String) -> Bool {
@@ -274,8 +344,10 @@ enum CleanCopyPipeline {
         return hasCodeLine && hasCodePunctuation
     }
 
-    private static func isLikelyList(_ lines: [String]) -> Bool {
-        let nonEmpty = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    private static func isLikelyList(_ text: String) -> Bool {
+        let nonEmpty = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         guard nonEmpty.count >= 2 else { return false }
 
         let listishCount = nonEmpty.count { line in
@@ -287,16 +359,16 @@ enum CleanCopyPipeline {
         return listishCount >= (nonEmpty.count / 2 + 1)
     }
 
-    private static func isLikelyStructuredData(_ lines: [String]) -> Bool {
-        lines.contains { line in
+    private static func isLikelyStructuredData(_ text: String) -> Bool {
+        text.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if ["{", "}", "[", "]"].contains(trimmed) { return true }
             return trimmed.range(of: #"^["'][^"']+["']\s*:"#, options: .regularExpression) != nil
         }
     }
 
-    private static func isLikelyShellTranscript(_ lines: [String]) -> Bool {
-        let promptLineCount = lines.count { line in
+    private static func isLikelyShellTranscript(_ text: String) -> Bool {
+        let promptLineCount = text.split(separator: "\n", omittingEmptySubsequences: false).count { line in
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             return trimmed.hasPrefix("$ ")
                 || trimmed.hasPrefix("# ")
@@ -370,10 +442,22 @@ enum CleanCopyPipeline {
 
     static func stripBoxDrawingArtifacts(_ input: String) -> String? {
         let boxRegex = try? NSRegularExpression(pattern: boxDrawingCharacterClass)
+        let borderRegex = try? NSRegularExpression(pattern: borderBoxCharacterClass)
         let fullRange = NSRange(input.startIndex..., in: input)
-        guard boxRegex?.firstMatch(in: input, range: fullRange) != nil else { return nil }
+        guard boxRegex?.firstMatch(in: input, range: fullRange) != nil
+            || borderRegex?.firstMatch(in: input, range: fullRange) != nil
+        else { return nil }
 
-        var result = input.replacingOccurrences(of: "│ │", with: " ")
+        // Drop full-border lines (e.g. ┌────┐ / └────┘ panel edges, ──── separators).
+        // Requires at least 3 border chars so a lone diagram glyph stays untouched.
+        let borderLinePattern = #"^\s*\#(borderBoxCharacterClass){3,}\s*$"#
+        var result = input.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { line in
+                line.range(of: borderLinePattern, options: .regularExpression) == nil
+            }
+            .joined(separator: "\n")
+
+        result = result.replacingOccurrences(of: "│ │", with: " ")
 
         let boxAfterPipePattern = #"\|[ \t]*\#(boxDrawingCharacterClass)+[ \t]*"#
         result = result.replacingOccurrences(
@@ -442,6 +526,12 @@ enum CleanCopyPipeline {
         )
 
         let cleaned = trimTrailingWhitespacePerLine(result)
+        // Decoration-only selections (e.g. a lone "──────" divider or "│" fragment) can
+        // reduce to nothing. Treat that as a no-op so we never overwrite the clipboard with
+        // an empty string — an unchanged selection beats an emptied one.
+        if cleaned.allSatisfy(\.isWhitespace), !input.allSatisfy(\.isWhitespace) {
+            return nil
+        }
         return cleaned == input ? nil : cleaned
     }
 

--- a/Zentty/Terminal/CleanCopyPipeline.swift
+++ b/Zentty/Terminal/CleanCopyPipeline.swift
@@ -150,7 +150,7 @@ enum CleanCopyPipeline {
 
     // MARK: - Pass 4b: Agent Prompt Cleanup
 
-    private static let agentPromptMarkers: Set<Character> = ["›", "❯"]
+    private static let agentPromptMarkers: Set<Character> = ["›", "❯", "•", "⏺", "●"]
     private static let boxDrawingCharacterClass = "[│┃║╎╏┆┇┊┋╽╿￨｜]"
     private static let borderBoxCharacterClass = "[─━┌┐└┘├┤┬┴┼═║╔╗╚╝╠╣╦╩╬╭╮╯╰┏┓┗┛┣┫┳┻╋]"
 
@@ -169,6 +169,15 @@ enum CleanCopyPipeline {
         }
 
         guard nonEmpty.count <= maxAgentPromptReflowLines else { return nil }
+
+        // Agent reflow targets a single message: one leading marker, then continuation lines.
+        // Two or more marker-led lines means a real bullet list (• a / • b), a multi-message
+        // selection, or stacked ⏺ tool calls — reflowing would fuse them. Bail.
+        let markerLineCount = nonEmpty.count { line in
+            guard let first = line.trimmingCharacters(in: .whitespaces).first else { return false }
+            return agentPromptMarkers.contains(first)
+        }
+        guard markerLineCount <= 1 else { return nil }
 
         let candidateLines: [String]
         if let ruleIndex = lines.firstIndex(where: isAgentPromptRuleLine(_:)) {

--- a/Zentty/UI/PaneStrip/PaneContainerView.swift
+++ b/Zentty/UI/PaneStrip/PaneContainerView.swift
@@ -1297,12 +1297,24 @@ final class PaneContainerView: NSView {
             action: #selector(NSText.copy(_:)),
             symbolName: "doc.on.doc"
         ))
-        customMenu.addItem(makeContextMenuItem(
-            title: "Clean Copy",
-            action: #selector(MainWindowController.cleanCopy(_:)),
-            symbolName: "sparkles.rectangle.stack",
-            fallbackSymbolName: "doc.on.doc"
-        ))
+        // With auto-clean on, the plain "Copy" above already produces cleaned text, so a separate
+        // "Clean Copy" would just duplicate it. Offer "Copy Raw" instead — the escape hatch for the
+        // unmodified selection. With auto-clean off, "Copy" is raw, so "Clean Copy" is the useful companion.
+        if CleanCopyPipeline.isAutoCleanEnabled {
+            customMenu.addItem(makeContextMenuItem(
+                title: "Copy Raw",
+                action: #selector(MainWindowController.copyRaw(_:)),
+                symbolName: "doc.plaintext",
+                fallbackSymbolName: "doc.on.doc"
+            ))
+        } else {
+            customMenu.addItem(makeContextMenuItem(
+                title: "Clean Copy",
+                action: #selector(MainWindowController.cleanCopy(_:)),
+                symbolName: "sparkles.rectangle.stack",
+                fallbackSymbolName: "doc.on.doc"
+            ))
+        }
         customMenu.addItem(makeContextMenuItem(
             title: "Paste",
             action: #selector(NSText.paste(_:)),

--- a/ZenttyLogicTests/CleanCopyPipelineTests.swift
+++ b/ZenttyLogicTests/CleanCopyPipelineTests.swift
@@ -129,9 +129,12 @@ final class CleanCopyPipelineTests: XCTestCase {
         XCTAssertEqual(result, "ls\ncd foo\npwd\noutput\necho hi")
     }
 
-    func test_stripPrompts_percent_sign() {
+    func test_stripPrompts_does_not_strip_percent_prefix() {
+        // % is no longer a candidate prompt — too many false positives in prose
+        // (e.g. "10% done", "5% used"). zsh users who genuinely paste % prompts
+        // pay a small tax in exchange for far fewer false strips.
         let input = "% ls\n% cd\n% pwd\n% echo"
-        XCTAssertEqual(CleanCopyPipeline.stripPrompts(input), "ls\ncd\npwd\necho")
+        XCTAssertEqual(CleanCopyPipeline.stripPrompts(input), input)
     }
 
     func test_stripPrompts_hash_sign() {
@@ -527,6 +530,192 @@ final class CleanCopyPipelineTests: XCTestCase {
         let input = "curl -I https://example.com | │ head -n 5"
         let result = CleanCopyPipeline.clean(input)
         XCTAssertEqual(result.text, "curl -I https://example.com | head -n 5")
+        XCTAssertTrue(result.wasModified)
+    }
+
+    // MARK: - Strict-Majority Prompt Threshold
+
+    func test_stripPrompts_below_strict_majority_does_not_strip() {
+        // 3 of 6 lines have "$ " — needs >= n/2+1 = 4 to strip
+        let input = "$ ls\n$ cd\n$ pwd\nout1\nout2\nout3"
+        XCTAssertEqual(CleanCopyPipeline.stripPrompts(input), input)
+    }
+
+    func test_stripPrompts_at_strict_majority_strips() {
+        // 4 of 6 lines have "$ " — meets n/2+1 = 4
+        let input = "$ ls\n$ cd\n$ pwd\n$ echo\nout1\nout2"
+        XCTAssertEqual(
+            CleanCopyPipeline.stripPrompts(input),
+            "ls\ncd\npwd\necho\nout1\nout2"
+        )
+    }
+
+    func test_stripPrompts_n5_three_matches_strips() {
+        // n=5, 3 matches: strict-majority threshold (n/2+1 = 3) — strips.
+        // The prior >0.6 continuous threshold would have required 4 here;
+        // this test pins the looser-for-odd-n behavior down.
+        let input = "$ ls\n$ cd\n$ pwd\nout1\nout2"
+        XCTAssertEqual(
+            CleanCopyPipeline.stripPrompts(input),
+            "ls\ncd\npwd\nout1\nout2"
+        )
+    }
+
+    func test_stripPrompts_n5_three_blockquote_lines_strips_accepted_tradeoff() {
+        // Accepted trade-off: 3-of-5 `> ` lines hit the true-majority threshold and
+        // strip, even though this looks like a markdown blockquote. Pins the
+        // deliberate odd-n behavior; see detectPromptPattern.
+        let input = "> quoted one\n> quoted two\n> quoted three\nplain four\nplain five"
+        XCTAssertEqual(
+            CleanCopyPipeline.stripPrompts(input),
+            "quoted one\nquoted two\nquoted three\nplain four\nplain five"
+        )
+    }
+
+    // MARK: - Agent Prompt Rule Detection
+
+    func test_stripAgentPromptSelection_ignores_ascii_dash_rule() {
+        // A plain "----------" run is a markdown HR, not an agent rule separator.
+        // Earlier behavior treated it as a rule and discarded the content above it.
+        let input = """
+        › Here is text above
+        ----------
+        And text below the rule
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Here is text above ---------- And text below the rule"
+        )
+    }
+
+    func test_stripAgentPromptSelection_skips_reflow_over_60_lines() {
+        // Synthetic 70 non-empty lines under a chevron — safety valve returns nil.
+        let body = Array(repeating: "more content here", count: 70).joined(separator: "\n")
+        let input = "› first line\n" + body
+        XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
+    }
+
+    // MARK: - Token-Preserving Flatten
+
+    func test_stripAgentPromptSelection_preserves_hyphen_wrapped_token() {
+        let input = """
+        › open /tmp/scan-qr-f1cc4328-eb1d-4a3c-9bd2-
+          f1a4ccda5f6a.png
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "open /tmp/scan-qr-f1cc4328-eb1d-4a3c-9bd2-f1a4ccda5f6a.png"
+        )
+    }
+
+    func test_stripAgentPromptSelection_rejoins_capitalized_identifier() {
+        let input = """
+        › export N
+          ODE_PATH=/usr/bin
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "export NODE_PATH=/usr/bin"
+        )
+    }
+
+    func test_stripAgentPromptSelection_does_not_fuse_standalone_capitals() {
+        // A single uppercase word at a wrap boundary must NOT fuse with the next
+        // line's leading capital. The rejoin rule requires the second token to be
+        // 2+ identifier chars, so split identifiers (N -> ODE_PATH) still join
+        // while two real words stay separated.
+        let input = """
+        › Grade A
+          B students passed
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Grade A B students passed"
+        )
+    }
+
+    func test_stripAgentPromptSelection_preserves_space_after_period() {
+        // Sentence-boundary "." must NOT fuse with the next-line capital. The
+        // capital regex's LHS class excludes "." for this reason — the newline
+        // has to survive to the "\n+ -> ' '" pass so a space lands between sentences.
+        let input = """
+        › Here is the answer.
+          Here is more context.
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Here is the answer. Here is more context."
+        )
+    }
+
+    func test_stripAgentPromptSelection_rejoins_path_segment() {
+        let input = """
+        › open ~/Library/
+          Application Support/Zentty
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "open ~/Library/Application Support/Zentty"
+        )
+    }
+
+    // MARK: - Horizontal Box Drawing
+
+    func test_stripBoxDrawingArtifacts_removes_full_border_box() {
+        let input = "┌──────┐\n│ hello │\n└──────┘"
+        XCTAssertEqual(CleanCopyPipeline.stripBoxDrawingArtifacts(input), "hello")
+    }
+
+    func test_stripBoxDrawingArtifacts_drops_internal_horizontal_separator() {
+        let input = "above\n──────\nbelow"
+        XCTAssertEqual(CleanCopyPipeline.stripBoxDrawingArtifacts(input), "above\nbelow")
+    }
+
+    func test_stripBoxDrawingArtifacts_handles_rounded_corner_panel() {
+        let input = "╭──────╮\n│ hello │\n╰──────╯"
+        XCTAssertEqual(CleanCopyPipeline.stripBoxDrawingArtifacts(input), "hello")
+    }
+
+    func test_stripBoxDrawingArtifacts_preserves_em_dash() {
+        // U+2014 em-dash is NOT a box-drawing character; prose stays intact.
+        XCTAssertNil(CleanCopyPipeline.stripBoxDrawingArtifacts("em — dash — usage"))
+    }
+
+    func test_stripBoxDrawingArtifacts_lone_separator_returns_nil() {
+        // A selection that is nothing but a divider has no real content to clean —
+        // returning nil keeps the original on the clipboard instead of emptying it.
+        XCTAssertNil(CleanCopyPipeline.stripBoxDrawingArtifacts("──────"))
+    }
+
+    func test_pipeline_lone_separator_is_unmodified() {
+        let result = CleanCopyPipeline.clean("──────")
+        XCTAssertEqual(result.text, "──────")
+        XCTAssertFalse(result.wasModified)
+    }
+
+    // MARK: - End-to-End Panel
+
+    func test_pipeline_strips_full_claude_code_panel() {
+        let input = """
+        ╭──────────────────────────────────╮
+        │   Hello, this is the message.    │
+        ╰──────────────────────────────────╯
+        """
+        let result = CleanCopyPipeline.clean(input)
+        XCTAssertEqual(result.text, "Hello, this is the message.")
+        XCTAssertTrue(result.wasModified)
+    }
+
+    func test_pipeline_strips_double_line_panel() {
+        // ║ (U+2551) is the double-line vertical; needs to be in boxDrawingCharacterClass
+        // so the middle line gets its leading/trailing decoration stripped end-to-end.
+        let input = """
+        ╔══════════════════╗
+        ║   Hello, world.   ║
+        ╚══════════════════╝
+        """
+        let result = CleanCopyPipeline.clean(input)
+        XCTAssertEqual(result.text, "Hello, world.")
         XCTAssertTrue(result.wasModified)
     }
 }

--- a/ZenttyLogicTests/CleanCopyPipelineTests.swift
+++ b/ZenttyLogicTests/CleanCopyPipelineTests.swift
@@ -327,6 +327,118 @@ final class CleanCopyPipelineTests: XCTestCase {
         XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
     }
 
+    // MARK: - Bullet / Marker Agent Output
+
+    func test_pipeline_cleans_bullet_led_agent_output() {
+        // Peter's example: a • bullet message with an indented continuation paragraph.
+        let input = """
+        • Hi Peter — I'll keep this review tight and focus only on issues worth fixing before merge.
+
+          Using the code-review skill because this is a branch diff review.
+        """
+
+        let result = CleanCopyPipeline.clean(input)
+        XCTAssertEqual(
+            result.text,
+            "Hi Peter — I'll keep this review tight and focus only on issues worth fixing before merge."
+                + "\n\nUsing the code-review skill because this is a branch diff review."
+        )
+        XCTAssertTrue(result.wasModified)
+    }
+
+    func test_stripAgentPromptSelection_reflows_bullet_wrapped_paragraph() {
+        let input = """
+        • Hi Peter — I'll keep this review
+          tight and focus only on issues.
+
+          Using the code-review skill.
+        """
+
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Hi Peter — I'll keep this review tight and focus only on issues."
+                + "\n\nUsing the code-review skill."
+        )
+    }
+
+    func test_stripAgentPromptSelection_cleans_record_circle_message() {
+        // ⏺ (U+23FA) is Claude Code's message/tool-line marker.
+        let input = """
+        ⏺ Ran the analysis and found two
+          issues worth fixing.
+        """
+
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Ran the analysis and found two issues worth fixing."
+        )
+    }
+
+    func test_stripAgentPromptSelection_cleans_filled_circle_message() {
+        // ● (U+25CF) is used as a leading status/message glyph by some agents.
+        let input = """
+        ● Models available and ready
+          to take the next task.
+        """
+
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection(input),
+            "Models available and ready to take the next task."
+        )
+    }
+
+    func test_stripAgentPromptSelection_does_not_flatten_bullet_list() {
+        let input = """
+        • first item
+        • second item
+        • third item
+        """
+
+        XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
+    }
+
+    func test_stripAgentPromptSelection_does_not_flatten_short_wrapped_bullet_list() {
+        // The regression the multi-marker guard exists for: a 2-item • list whose first item
+        // wraps. Stripping the first bullet would undercount the list, so the older post-strip
+        // isLikelyList check alone would have reflowed these into one run.
+        let input = """
+        • First item that wraps onto
+          a second line
+        • Second item
+        """
+
+        XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
+    }
+
+    func test_stripAgentPromptSelection_does_not_flatten_stacked_tool_calls() {
+        // Two ⏺ tool-call lines are separate messages, not one wrapped paragraph.
+        let input = """
+        ⏺ Read(CleanCopyPipeline.swift)
+        ⏺ Edit(CleanCopyPipeline.swift)
+        """
+
+        XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
+    }
+
+    func test_stripAgentPromptSelection_does_not_flatten_filled_circle_list() {
+        let input = """
+        ● one
+        ● two
+        ● three
+        """
+
+        XCTAssertNil(CleanCopyPipeline.stripAgentPromptSelection(input))
+    }
+
+    func test_stripAgentPromptSelection_strips_single_bullet_line() {
+        // Accepted trade-off: a lone single-line bullet loses its marker, consistent with how
+        // › / ❯ treat single lines. Rare in terminal pastes.
+        XCTAssertEqual(
+            CleanCopyPipeline.stripAgentPromptSelection("• just one thing"),
+            "just one thing"
+        )
+    }
+
     // MARK: - Box Drawing Cleanup
 
     func test_stripBoxDrawingArtifacts_removes_pipe_decoration() {

--- a/ZenttyLogicTests/PaneContainerViewTests.swift
+++ b/ZenttyLogicTests/PaneContainerViewTests.swift
@@ -1770,6 +1770,39 @@ final class PaneContainerViewTests: AppKitTestCase {
         )
     }
 
+    func test_context_menu_swaps_clean_copy_for_copy_raw_when_auto_clean_enabled() throws {
+        let original = CleanCopyPipeline.isAutoCleanEnabled
+        CleanCopyPipeline.isAutoCleanEnabled = true
+        addTeardownBlock { CleanCopyPipeline.isAutoCleanEnabled = original }
+
+        let adapter = PaneContainerTerminalAdapterSpy()
+        let pane = PaneState(id: PaneID("shell"), title: "shell")
+        let runtime = PaneRuntime(
+            pane: pane,
+            adapter: adapter,
+            metadataSink: { _, _ in },
+            eventSink: { _, _ in }
+        )
+        let paneView = PaneContainerView(
+            pane: pane,
+            width: 420,
+            height: 520,
+            emphasis: 1,
+            isFocused: true,
+            runtime: runtime,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+
+        let menu = try XCTUnwrap(paneView.contextMenuForTesting())
+
+        // With auto-clean on, "Copy" already cleans, so the redundant "Clean Copy" is replaced
+        // by "Copy Raw" — the escape hatch for the unmodified selection.
+        XCTAssertNil(menu.item(withTitle: "Clean Copy"))
+        let copyRaw = try XCTUnwrap(menu.item(withTitle: "Copy Raw"))
+        XCTAssertEqual(copyRaw.action, #selector(MainWindowController.copyRaw(_:)))
+        XCTAssertNotNil(copyRaw.image)
+    }
+
     func test_context_menu_places_restored_command_rerun_first_when_available() throws {
         let adapter = PaneContainerTerminalAdapterSpy()
         let pane = PaneState(id: PaneID("shell"), title: "shell")


### PR DESCRIPTION
Three changes to terminal clean-copy, building on the existing pipeline.

## Sharper cleaning passes

Tightened the prompt, agent-reflow, and box-drawing passes so a copied selection lands closer to plain prose: soft-wrapped paragraphs rejoin, box-drawing borders get stripped, and a decoration-only selection (a lone `──────` divider) no longer clears the clipboard. When cleaning would reduce the text to nothing, it now no-ops instead of overwriting what you had.

## Agent-marker cleanup

Copy a single agent message that starts with a marker glyph and the pipeline strips the marker, dedents the continuation, and reflows the wrapped paragraph. Covers `›`, `❯`, `•`, `⏺`, `●` — the last three are new, and `⏺` is Claude Code's own line marker.

The trap: `•`/`●` are also Markdown bullets and `⏺` tool-call lines come stacked. So there's a guard — if two or more lines lead with a marker, bail. That leaves real bullet lists, stacked tool calls, and multi-message selections untouched, and only cleans the single-message case this is meant for.

## Context-aware copy menu

When "Always clean copies" is on, the plain Copy already cleans, so the right-click menu's separate Clean Copy item did nothing different. It now shows Copy Raw instead, the way to grab the unmodified text while auto-clean is on. With the setting off it's back to Clean Copy. The Edit menu bar keeps both either way.

## Tests

All in `ZenttyLogicTests` (parallel-safe). Per-glyph cleaning, the list/tool-call guards, the empty-clipboard guard, and the menu swap each get coverage. Logic gate green.
