### PR TITLE
Preserve symlinked config files on save (resolve symlink before atomic write)

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		04F27F3F3AE18FF0B4F78B44 /* AgentStatusPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79972CCAB3361277D4E949C /* AgentStatusPayload.swift */; };
 		04FBB07EC9E2D91E5E396E13 /* SidebarUpdateAvailableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C5FAFF027DE8001A510FB1 /* SidebarUpdateAvailableRowView.swift */; };
 		05944E45FEE283040A77FA52 /* BookmarkRestoreLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B89A97084B5AF5AFF873E2C /* BookmarkRestoreLogger.swift */; };
+		05EECCAB1101344FE5F62D63 /* FileManagerSymlinkWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F82C671DE7FF0200C2DF6E /* FileManagerSymlinkWriteTests.swift */; };
 		064942C21BFD943CB5C8D46F /* LibghosttyAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDF1EF89E46D6EEECB8A320 /* LibghosttyAdapter.swift */; };
 		066389EC522A58949B0D4A67 /* KeyboardShortcutPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A553F140B785B8FE4755F8 /* KeyboardShortcutPreviewView.swift */; };
 		07E50EB750385888A65693C9 /* WorkspaceRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EC695460C843672AEAAF36 /* WorkspaceRecipe.swift */; };
@@ -388,6 +389,7 @@
 		CBA82B1C9557F98AD04A8672 /* SidebarPaneRowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9407DEA6B0DE6363B46DE0A /* SidebarPaneRowViews.swift */; };
 		CC3E9AE062D12B88458DA88B /* FuzzyMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0EFB8B00D5CA9A67589A3A /* FuzzyMatcher.swift */; };
 		CD00F629DE6FF4C470C1879C /* DragReorderHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712CB2F8BC16BB3B666A085 /* DragReorderHapticFeedback.swift */; };
+		CDA589887C4F0F21EEE4A1DF /* FileManager+SymlinkWrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */; };
 		CDF1BF1E9C25A9C932CF64CC /* ServerBrowserCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD55E4B84C3278A35AB5B50B /* ServerBrowserCatalogTests.swift */; };
 		CE2B404DBF241C89DDD59410 /* WorkspaceTemplateExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AE87CC3F4EB591D08B9A7 /* WorkspaceTemplateExporterTests.swift */; };
 		CEDAF9621D24A72064947A90 /* SidebarDropPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */; };
@@ -533,6 +535,7 @@
 		017D80D8C20309A5F3A34381 /* PanePresentationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanePresentationStateTests.swift; sourceTree = "<group>"; };
 		02126D22E8F87E9B608D3CB9 /* SidebarStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarStatusResolver.swift; sourceTree = "<group>"; };
 		02F71D1415EE0BF0891E75B0 /* TerminalClipboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClipboardTests.swift; sourceTree = "<group>"; };
+		02F82C671DE7FF0200C2DF6E /* FileManagerSymlinkWriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerSymlinkWriteTests.swift; sourceTree = "<group>"; };
 		03C5FAFF027DE8001A510FB1 /* SidebarUpdateAvailableRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarUpdateAvailableRowView.swift; sourceTree = "<group>"; };
 		041FEB5F657A57B5668D9BFD /* LibghosttyRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyRuntime.swift; sourceTree = "<group>"; };
 		0529815FA8F05D8F52601625 /* CommandTooltipFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandTooltipFormatter.swift; sourceTree = "<group>"; };
@@ -720,6 +723,7 @@
 		65EC1382544ECD4896FE2CBD /* GrokCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokCanonicalReEmitter.swift; sourceTree = "<group>"; };
 		664E62FC352B56CA7B035AC1 /* TaskManagerPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerPresentationTests.swift; sourceTree = "<group>"; };
 		677818B56188202E6289EC96 /* WorklaneColorMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorMenuItemView.swift; sourceTree = "<group>"; };
+		68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+SymlinkWrite.swift"; sourceTree = "<group>"; };
 		691FE92E923A9E00EC8B6063 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		69E99517E9EAA4D99552859C /* WorkspaceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplate.swift; sourceTree = "<group>"; };
 		6BC138BE273ED92291124633 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -1171,6 +1175,7 @@
 				293AA59A5E4EADF8A732366F /* Project */,
 				F3B659FA07E637930201AA95 /* Restore */,
 				6F37DC5B648E5CF1534CBCDB /* Servers */,
+				7D9B00E94B71E29FCA58A4FA /* Support */,
 				D11BB75179160944959BEF6F /* TaskManager */,
 				0104E62A52C4F12B4CF27F80 /* TaskRunners */,
 				C6E32875C15556A3A4C2AF9D /* Terminal */,
@@ -1328,6 +1333,14 @@
 				08406A303FAF5F5CC9447272 /* ThirdPartyLicenseCatalog.swift */,
 			);
 			path = About;
+			sourceTree = "<group>";
+		};
+		7D9B00E94B71E29FCA58A4FA /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 		7F1FD0AFD7DC8203464D5523 /* Layout */ = {
@@ -1705,6 +1718,7 @@
 				359071C23827A5E0F2CD2B92 /* DockerServerDiscoveryTests.swift */,
 				A23FA3A9E846FAAD01B1BB06 /* DragReorderHapticClassifierTests.swift */,
 				F3635744998023F6E8482386 /* ErrorReportingBootstrapTests.swift */,
+				02F82C671DE7FF0200C2DF6E /* FileManagerSymlinkWriteTests.swift */,
 				81A2C70428D2C375764E7ABC /* GhosttyAppearanceSettingsCoordinatorTests.swift */,
 				721E6055678BA716A5355856 /* GhosttyConfigEnvironmentTests.swift */,
 				88F585980C0838B39C356960 /* GhosttyConfigWriterTests.swift */,
@@ -2099,6 +2113,7 @@
 				A9C59E3E7F7283D0FE87F832 /* DockerServerDiscoveryTests.swift in Sources */,
 				966CD805A3D009565385A8EC /* DragReorderHapticClassifierTests.swift in Sources */,
 				E511155EB8DA78AFF0AC5AF0 /* ErrorReportingBootstrapTests.swift in Sources */,
+				05EECCAB1101344FE5F62D63 /* FileManagerSymlinkWriteTests.swift in Sources */,
 				766437EFD82EA8FDAAF2331F /* GhosttyAppearanceSettingsCoordinatorTests.swift in Sources */,
 				1AAB86CCFCE4E436FE751AA1 /* GhosttyConfigEnvironmentTests.swift in Sources */,
 				220E7BB4EA5B4822878899CB /* GhosttyConfigWriterTests.swift in Sources */,
@@ -2296,6 +2311,7 @@
 				DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */,
 				257E380BBDC29CDFE3389A48 /* ExplicitAgentStateReducer.swift in Sources */,
 				260AB2147508C0997EDC89BC /* FallbackTitleHeuristicReducer.swift in Sources */,
+				CDA589887C4F0F21EEE4A1DF /* FileManager+SymlinkWrite.swift in Sources */,
 				1B09BB8607C4D3B0775B3B6F /* FlippedSidebarDocumentView.swift in Sources */,
 				CC3E9AE062D12B88458DA88B /* FuzzyMatcher.swift in Sources */,
 				43F75CCFD2060C335CEAEC51 /* GeneralSettingsSectionViewController.swift in Sources */,

--- a/Zentty/Bookmarks/BookmarkStore.swift
+++ b/Zentty/Bookmarks/BookmarkStore.swift
@@ -136,12 +136,15 @@ final class BookmarkStore {
     private func persist() {
         let bundle = WorkspaceTemplateBundle(savedAt: Date(), templates: templates)
         do {
+            // Write through a symlinked bookmarks.json so dotfile setups keep their link
+            // instead of having it clobbered by the atomic temp+rename.
+            let targetURL = fileManager.resolvingSymlinkTarget(at: fileURL)
             try fileManager.createDirectory(
-                at: fileURL.deletingLastPathComponent(),
+                at: targetURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
             let data = try encoder.encode(bundle)
-            try data.write(to: fileURL, options: .atomic)
+            try data.write(to: targetURL, options: .atomic)
         } catch {
             bookmarkStoreLogger.error(
                 "Failed to persist bookmarks to \(self.fileURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"

--- a/Zentty/Config/AppConfigStore.swift
+++ b/Zentty/Config/AppConfigStore.swift
@@ -197,9 +197,14 @@ final class AppConfigStore: @unchecked Sendable {
     }
 
     private static func persist(config: AppConfig, to fileURL: URL, fileManager: FileManager) throws {
-        let directoryURL = fileURL.deletingLastPathComponent()
-        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        // Write through a symlinked config.toml so dotfile setups (Stow, chezmoi, …)
+        // keep their link instead of having it clobbered by the atomic temp+rename.
+        let targetURL = fileManager.resolvingSymlinkTarget(at: fileURL)
+        try fileManager.createDirectory(
+            at: targetURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         let source = AppConfigTOML.encode(config.normalized())
-        try Data(source.utf8).write(to: fileURL, options: .atomic)
+        try Data(source.utf8).write(to: targetURL, options: .atomic)
     }
 }

--- a/Zentty/Support/FileManager+SymlinkWrite.swift
+++ b/Zentty/Support/FileManager+SymlinkWrite.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension FileManager {
+    /// Resolves a trailing symlink so an atomic write targets the real file and
+    /// preserves the link instead of replacing it with a regular file.
+    ///
+    /// `.atomic` writes to a temp file and `rename()`s it over the destination, which
+    /// replaces a symlink's own inode. Dotfile managers (GNU Stow, chezmoi, yadm,
+    /// dotbot) rely on these links; clobbering them silently detaches the live config
+    /// from the tracked repo. Writing through to the symlink's real target keeps both
+    /// the crash-safety of the atomic write and the link.
+    ///
+    /// Walks a chain on the final path component only — intermediate directory symlinks
+    /// are followed transparently by the OS, so they need no special handling. Returns:
+    /// - `url` unchanged when its final component is not a symlink;
+    /// - the chain's real target (the first non-symlink), which for a broken link is its
+    ///   missing target so the write materializes the file there instead of over the link;
+    /// - the original `url` when the chain is cyclic or deeper than the hop limit — a
+    ///   degenerate setup with no real target to write through (and one that can't be
+    ///   written through anyway), where the original location is the safe fallback.
+    func resolvingSymlinkTarget(at url: URL) -> URL {
+        var resolved = url
+        var visited: Set<String> = []
+        for _ in 0..<32 {
+            guard let destination = try? destinationOfSymbolicLink(atPath: resolved.path) else {
+                return resolved
+            }
+            guard visited.insert(resolved.path).inserted else {
+                break
+            }
+            resolved = URL(
+                fileURLWithPath: destination,
+                relativeTo: resolved.deletingLastPathComponent()
+            ).absoluteURL
+        }
+        return url
+    }
+}

--- a/Zentty/UI/Settings/GhosttyAppearanceSettingsCoordinator.swift
+++ b/Zentty/UI/Settings/GhosttyAppearanceSettingsCoordinator.swift
@@ -496,7 +496,9 @@ final class GhosttyAppearanceSettingsCoordinator: AppearanceSettingsConfigCoordi
         from stack: GhosttyConfigEnvironment.ResolvedStack,
         pendingMutation: PendingMutation?
     ) {
-        let targetURL = stack.preferredCreateTargetURL
+        // Resolve a symlinked target so a stowed ghostty config keeps its link instead
+        // of being clobbered by the atomic temp+rename (see FileManager+SymlinkWrite).
+        let targetURL = fileManager.resolvingSymlinkTarget(at: stack.preferredCreateTargetURL)
         var content = stack.loadFiles.compactMap { try? String(contentsOf: $0, encoding: .utf8) }
             .joined(separator: "\n")
         content = applyingOverrides(from: stack.localOverrideContents, to: content)

--- a/Zentty/UI/Theme/GhosttyConfigWriter.swift
+++ b/Zentty/UI/Theme/GhosttyConfigWriter.swift
@@ -42,9 +42,13 @@ final class GhosttyConfigWriter: GhosttyConfigWriting {
 
     private func writeAtomically(_ content: String) {
         let data = Data(content.utf8)
-        let directory = configURL.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try? data.write(to: configURL, options: .atomic)
+        let fileManager = FileManager.default
+        // Write through a symlinked ghostty config so dotfile setups keep their link
+        // instead of having it clobbered by the atomic temp+rename.
+        let targetURL = fileManager.resolvingSymlinkTarget(at: configURL)
+        let directory = targetURL.deletingLastPathComponent()
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? data.write(to: targetURL, options: .atomic)
     }
 
     static func sanitizedThemeName(_ name: String) -> String {

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -219,6 +219,109 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertEqual(store.current.openWith.customApps.map(\.id), ["custom:bbedit"])
     }
 
+    // MARK: - Symlinked config (issue #15)
+
+    func test_store_preserves_symlinked_config_on_save() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        let targetURL = repoDirURL.appendingPathComponent("config.toml")
+        try "[sidebar]\nwidth = 100\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        // Stow-style: ~/.config/zentty/config.toml -> dotfiles/config.toml
+        let linkURL = homeDirURL.appendingPathComponent("config.toml")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let store = AppConfigStore(
+            fileURL: linkURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        try store.update { config in
+            config.sidebar.width = 344
+        }
+
+        // The link must survive the save instead of becoming a regular file.
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            targetURL.path
+        )
+        // The new content lands in the real target...
+        let targetContents = try String(contentsOf: targetURL, encoding: .utf8)
+        XCTAssertTrue(targetContents.contains("width = 344"))
+        // ...and is visible when reading through the link.
+        let throughLink = try String(contentsOf: linkURL, encoding: .utf8)
+        XCTAssertTrue(throughLink.contains("width = 344"))
+        // In-memory state reflects the save and isn't clobbered by a stray reload.
+        XCTAssertEqual(store.current.sidebar.width, 344)
+    }
+
+    func test_store_preserves_relative_symlink_on_save() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        let targetURL = repoDirURL.appendingPathComponent("config.toml")
+        try "[sidebar]\nwidth = 100\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let linkURL = homeDirURL.appendingPathComponent("config.toml")
+        try FileManager.default.createSymbolicLink(
+            atPath: linkURL.path,
+            withDestinationPath: "../dotfiles/config.toml"
+        )
+
+        let store = AppConfigStore(
+            fileURL: linkURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        try store.update { config in
+            config.sidebar.width = 512
+        }
+
+        // The relative link is preserved verbatim.
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            "../dotfiles/config.toml"
+        )
+        let targetContents = try String(contentsOf: targetURL, encoding: .utf8)
+        XCTAssertTrue(targetContents.contains("width = 512"))
+        XCTAssertEqual(store.current.sidebar.width, 512)
+    }
+
+    func test_store_preserves_symlink_on_initial_create() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        // Link points at a target that does not exist yet (broken link), so init
+        // takes the `.missing` persist path and must materialize the target.
+        let targetURL = repoDirURL.appendingPathComponent("config.toml")
+        let linkURL = homeDirURL.appendingPathComponent("config.toml")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        _ = AppConfigStore(
+            fileURL: linkURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            targetURL.path
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: targetURL.path))
+    }
+
     func test_config_round_trips_server_detection_and_browser_preference() throws {
         let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
         let store = AppConfigStore(

--- a/ZenttyLogicTests/BookmarkStoreTests.swift
+++ b/ZenttyLogicTests/BookmarkStoreTests.swift
@@ -52,6 +52,31 @@ final class BookmarkStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.templates.map(\.name), ["Demo"])
     }
 
+    func test_upsert_preserves_symlinked_file_on_save() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        let targetURL = repoDirURL.appendingPathComponent("bookmarks.json")
+        // Stow-style: ~/.config/zentty/bookmarks.json -> dotfiles/bookmarks.json
+        let linkURL = homeDirURL.appendingPathComponent("bookmarks.json")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let store = BookmarkStore(fileURL: linkURL)
+        store.upsert(WorkspaceTemplate(name: "Demo", kind: .bookmark))
+
+        // The link must survive the save instead of becoming a regular file...
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            targetURL.path
+        )
+        // ...and the bookmarks land in the real target, readable through the link.
+        let reloaded = BookmarkStore(fileURL: linkURL)
+        XCTAssertEqual(reloaded.templates.map(\.name), ["Demo"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: targetURL.path))
+    }
+
     func test_upsert_updates_existing_template() {
         let store = BookmarkStore(fileURL: fileURL)
         let id = UUID()

--- a/ZenttyLogicTests/FileManagerSymlinkWriteTests.swift
+++ b/ZenttyLogicTests/FileManagerSymlinkWriteTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Zentty
+
+final class FileManagerSymlinkWriteTests: XCTestCase {
+    private var temporaryDirectoryURL: URL!
+    private let fileManager = FileManager.default
+
+    override func setUpWithError() throws {
+        temporaryDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ZenttyTests.SymlinkWrite.\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectoryURL {
+            try? fileManager.removeItem(at: temporaryDirectoryURL)
+        }
+        temporaryDirectoryURL = nil
+    }
+
+    func test_regular_file_returns_same_url() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        try "hello".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: fileURL)
+
+        XCTAssertEqual(resolved.path, fileURL.path)
+    }
+
+    func test_missing_file_returns_same_url() {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("does-not-exist.toml")
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: fileURL)
+
+        XCTAssertEqual(resolved.path, fileURL.path)
+    }
+
+    func test_absolute_symlink_returns_target() throws {
+        let targetURL = temporaryDirectoryURL.appendingPathComponent("target.toml")
+        try "real".write(to: targetURL, atomically: true, encoding: .utf8)
+        let linkURL = temporaryDirectoryURL.appendingPathComponent("link.toml")
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: linkURL)
+
+        XCTAssertEqual(resolved.path, targetURL.path)
+    }
+
+    func test_relative_symlink_returns_resolved_target() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("repo", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try fileManager.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        let targetURL = repoDirURL.appendingPathComponent("config.toml")
+        try "real".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        // home/config.toml -> ../repo/config.toml  (relative destination)
+        let linkURL = homeDirURL.appendingPathComponent("config.toml")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: "../repo/config.toml")
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: linkURL)
+
+        XCTAssertEqual(resolved.standardizedFileURL.path, targetURL.standardizedFileURL.path)
+    }
+
+    func test_broken_symlink_returns_target_path() throws {
+        let targetURL = temporaryDirectoryURL.appendingPathComponent("missing-target.toml")
+        let linkURL = temporaryDirectoryURL.appendingPathComponent("link.toml")
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: linkURL)
+
+        XCTAssertEqual(resolved.path, targetURL.path)
+        XCTAssertFalse(fileManager.fileExists(atPath: resolved.path))
+    }
+
+    func test_chained_symlink_returns_final_target() throws {
+        let targetURL = temporaryDirectoryURL.appendingPathComponent("target.toml")
+        try "real".write(to: targetURL, atomically: true, encoding: .utf8)
+        let middleURL = temporaryDirectoryURL.appendingPathComponent("middle.toml")
+        try fileManager.createSymbolicLink(at: middleURL, withDestinationURL: targetURL)
+        let linkURL = temporaryDirectoryURL.appendingPathComponent("link.toml")
+        try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: middleURL)
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: linkURL)
+
+        XCTAssertEqual(resolved.path, targetURL.path)
+    }
+
+    func test_cyclic_symlink_falls_back_to_original_url() throws {
+        let aURL = temporaryDirectoryURL.appendingPathComponent("a.toml")
+        let bURL = temporaryDirectoryURL.appendingPathComponent("b.toml")
+        // a -> b and b -> a forms a cycle: there is no real target, so resolution must
+        // terminate and fall back to the original path rather than loop or pick a link.
+        try fileManager.createSymbolicLink(at: aURL, withDestinationURL: bURL)
+        try fileManager.createSymbolicLink(at: bURL, withDestinationURL: aURL)
+
+        let resolved = fileManager.resolvingSymlinkTarget(at: aURL)
+
+        XCTAssertEqual(resolved.path, aURL.path)
+    }
+}

--- a/ZenttyLogicTests/GhosttyAppearanceSettingsCoordinatorTests.swift
+++ b/ZenttyLogicTests/GhosttyAppearanceSettingsCoordinatorTests.swift
@@ -186,6 +186,43 @@ final class GhosttyAppearanceSettingsCoordinatorTests: AppKitTestCase {
         XCTAssertEqual(reloadCount, 1)
     }
 
+    func test_createSharedConfig_preservesSymlinkedTarget() async throws {
+        let store = makeConfigStore()
+        try store.update { config in
+            config.appearance.preferredDarkThemeName = "LocalTheme"
+            config.appearance.localThemeName = "LocalTheme"
+        }
+
+        // Stow-style: ~/.config/ghostty/config.ghostty is a symlink into a dotfiles repo.
+        let dotfilesDir = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        try FileManager.default.createDirectory(at: dotfilesDir, withIntermediateDirectories: true)
+        let dotfilesTarget = dotfilesDir.appendingPathComponent("config")
+
+        let linkURL = coordinatorTestCreateTargetURL()
+        try FileManager.default.createDirectory(
+            at: linkURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: dotfilesTarget)
+
+        let coordinator = makeCoordinator(
+            store: store,
+            decisionProvider: { _ in .createSharedConfig },
+            runtimeReload: {}
+        )
+
+        await coordinator.createSharedConfig(presentingWindow: nil)
+
+        // The link must survive instead of being replaced by a regular file...
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            dotfilesTarget.path
+        )
+        // ...and the generated config lands in the real dotfiles target.
+        let content = try String(contentsOf: dotfilesTarget, encoding: .utf8)
+        XCTAssertTrue(content.contains("theme = LocalTheme"))
+    }
+
     func test_applyThemeMode_writesGhosttyPairAndKeepsInactiveSlotMemory() async throws {
         let store = makeConfigStore()
         var reloadCount = 0

--- a/ZenttyLogicTests/GhosttyConfigWriterTests.swift
+++ b/ZenttyLogicTests/GhosttyConfigWriterTests.swift
@@ -155,4 +155,32 @@ final class GhosttyConfigWriterTests: XCTestCase {
         XCTAssertTrue(content.contains("font-size = 16"))
         XCTAssertFalse(content.contains("font-size = 14"))
     }
+
+    // MARK: - Symlink preservation (issue #15)
+
+    func test_writeTheme_preserves_symlinked_config_on_save() throws {
+        let repoDirURL = temporaryDirectoryURL.appendingPathComponent("dotfiles", isDirectory: true)
+        let homeDirURL = temporaryDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDirURL, withIntermediateDirectories: true)
+
+        let targetURL = repoDirURL.appendingPathComponent("config")
+        try "theme = OldTheme\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        // Stow-style: ~/.config/ghostty/config -> dotfiles/config
+        let linkURL = homeDirURL.appendingPathComponent("config")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let writer = GhosttyConfigWriter(configURL: linkURL)
+        writer.writeTheme("NewTheme")
+
+        // The link must survive instead of becoming a regular file.
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path),
+            targetURL.path
+        )
+        let targetContents = try String(contentsOf: targetURL, encoding: .utf8)
+        XCTAssertTrue(targetContents.contains("theme = NewTheme"))
+        XCTAssertFalse(targetContents.contains("OldTheme"))
+    }
 }


### PR DESCRIPTION
## The problem

If your `~/.config/zentty/config.toml` is a symlink, which it usually is when you manage dotfiles with Stow, chezmoi, yadm, or dotbot, saving any setting in Zentty replaced the symlink with a plain file. The link to your repo broke on the first save and your config quietly drifted out of version control. Folding the whole `~/.config/zentty/` dir into a repo isn't a real workaround either, since it also holds runtime state that shouldn't be tracked.

## Why

`Data.write(to:options:.atomic)` writes a temp file and renames it over the destination. That rename swaps out the symlink's own inode, so the link becomes a regular file and the real target in your repo stops getting updates. Same footgun vim hits without `backupcopy=yes`.

## The fix

A small `FileManager.resolvingSymlinkTarget(at:)` helper resolves a trailing symlink to its real target before the atomic write. The temp-and-rename then happens in the target's directory, so the link stays put and we keep the crash-safety of an atomic write.

Applied to every user-facing config/data file Zentty writes:

- `config.toml` (`AppConfigStore`)
- `~/.config/ghostty/config`, both write paths: value updates (`GhosttyConfigWriter`) and the initial "Create Ghostty Config" flow (`GhosttyAppearanceSettingsCoordinator`)
- `bookmarks.json` (`BookmarkStore`), which sits in the same directory

Runtime state (`restore-*.json`) is left alone on purpose. It shouldn't be version-controlled.

The helper handles relative, absolute, chained, and broken links. Cyclic or absurdly deep chains fall back to writing at the original path.

## Tests

Each store has a regression test: the link survives a save and the new content lands in the real target. The helper itself has unit tests across all the link shapes. 90 tests pass.

Closes #15
