### PR TITLE
feat(terminal): paste selection on middle-click

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		F0FF1DAC11BDA07A28868FE4 /* TrackpadPanGestureDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25EF5AC625776DA85911237 /* TrackpadPanGestureDriver.swift */; };
 		F12EB9E3A329F13DDB765ADC /* NotificationChromeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B5C0E6A8057294C72424F6 /* NotificationChromeCoordinator.swift */; };
 		F17C5EDE0329D1956313C3AA /* SidebarBookmarksButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB93DE6432DD894D0CA2C72 /* SidebarBookmarksButton.swift */; };
+		F1A423CE593B1A50B31AC4BD /* LibghosttyViewMiddleClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB9D05A6887CB439CE0E066 /* LibghosttyViewMiddleClickTests.swift */; };
 		F1E79CD825C39C592E844B63 /* PaneRuntimeRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76857E75C1FF0BD95C889941 /* PaneRuntimeRegistryTests.swift */; };
 		F246DE4E17B65DFEA465BF98 /* OpenWithCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572BB2FACCFA8A236D880F28 /* OpenWithCatalogTests.swift */; };
 		F2CC773E6329B7259DDB1868 /* SidebarWidthPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4764B4017D1DF1354C6FFB /* SidebarWidthPreference.swift */; };
@@ -760,6 +761,7 @@
 		7F299D46F21F8BC295D1F0B3 /* PaneContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneContainerView.swift; sourceTree = "<group>"; };
 		7F6BDCBDE4E090275233D9D3 /* PaneDragHitTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragHitTestingTests.swift; sourceTree = "<group>"; };
 		7F97C3054D1F1E57C716DCAB /* WorklaneDestinationCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneDestinationCatalogTests.swift; sourceTree = "<group>"; };
+		7FB9D05A6887CB439CE0E066 /* LibghosttyViewMiddleClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyViewMiddleClickTests.swift; sourceTree = "<group>"; };
 		8062E55664628AC4197A39C3 /* HermesTitleStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleStatusTests.swift; sourceTree = "<group>"; };
 		810F6A39773D41286D4D344F /* FuzzyMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatcherTests.swift; sourceTree = "<group>"; };
 		8132E7564D882D85A155D2B5 /* DiscoveryIPCHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryIPCHandlerTests.swift; sourceTree = "<group>"; };
@@ -1722,6 +1724,7 @@
 				7905A1748912E4A0FDCC9A9B /* LibghosttySurfaceKeyEventTests.swift */,
 				CCC0F177C0A82F2B0F3EEEA5 /* LibghosttySurfaceScrollHostViewTests.swift */,
 				57CF2D04183C614FB5439EB3 /* LibghosttyViewDragDropTests.swift */,
+				7FB9D05A6887CB439CE0E066 /* LibghosttyViewMiddleClickTests.swift */,
 				E0253BE7E0C15D8168A3491D /* LibghosttyViewScrollRoutingTests.swift */,
 				AC57A5961773BEF94EA2766D /* MenuBarFleetStateTests.swift */,
 				34287004519EE20785262426 /* MenuBarFleetSummaryTests.swift */,
@@ -2115,6 +2118,7 @@
 				A543B6ABD356776262A865EB /* LibghosttySurfaceKeyEventTests.swift in Sources */,
 				FD8C4C1A52364128ABA52568 /* LibghosttySurfaceScrollHostViewTests.swift in Sources */,
 				AF6C18AB558A8952DC241DEE /* LibghosttyViewDragDropTests.swift in Sources */,
+				F1A423CE593B1A50B31AC4BD /* LibghosttyViewMiddleClickTests.swift in Sources */,
 				0D16861AE92EDD029878BCBA /* LibghosttyViewScrollRoutingTests.swift in Sources */,
 				3CC098EF165DACF970D8F497 /* MenuBarFleetStateTests.swift in Sources */,
 				048F5C9C722C2885FE803161 /* MenuBarFleetSummaryTests.swift in Sources */,

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -1793,6 +1793,66 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         _ = handleSecondaryMouseUpForContextMenuRouting(event)
     }
 
+    override func otherMouseDown(with event: NSEvent) {
+        guard let button = Self.ghosttyMouseButton(forButtonNumber: event.buttonNumber) else {
+            super.otherMouseDown(with: event)
+            return
+        }
+        guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
+            return
+        }
+        // Match left/right click: focus the clicked pane so a middle-click paste (and
+        // any subsequent typing) lands in the pane the user actually clicked.
+        window?.makeFirstResponder(self)
+        forwardMousePosition(event)
+        _ = surfaceController?.sendMouseButton(
+            state: GHOSTTY_MOUSE_PRESS,
+            button: button,
+            modifiers: event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        )
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
+            return
+        }
+        forwardMousePosition(event)
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        guard let button = Self.ghosttyMouseButton(forButtonNumber: event.buttonNumber) else {
+            super.otherMouseUp(with: event)
+            return
+        }
+        guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
+            return
+        }
+        forwardMousePosition(event)
+        _ = surfaceController?.sendMouseButton(
+            state: GHOSTTY_MOUSE_RELEASE,
+            button: button,
+            modifiers: event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        )
+    }
+
+    /// Maps an AppKit `otherMouse*` button number to the libghostty mouse button enum.
+    ///
+    /// `otherMouseDown` fires for the middle button and any extra buttons (back/forward),
+    /// so we map only the buttons libghostty understands and ignore the rest. Mirrors
+    /// Ghostty's own `Ghostty.Input.MouseButton(fromNSEventButtonNumber:)` mapping; the
+    /// middle button is what enables middle-click paste (libghostty pastes the selection
+    /// clipboard on a middle-button press).
+    private static func ghosttyMouseButton(
+        forButtonNumber buttonNumber: Int
+    ) -> ghostty_input_mouse_button_e? {
+        switch buttonNumber {
+        case 2: return GHOSTTY_MOUSE_MIDDLE
+        case 3: return GHOSTTY_MOUSE_EIGHT // back
+        case 4: return GHOSTTY_MOUSE_NINE // forward
+        default: return nil
+        }
+    }
+
     override func scrollWheel(with event: NSEvent) {
         if consumeScrollWheelForTerminalInputIfNeeded(event) {
             return

--- a/ZenttyLogicTests/LibghosttyViewMiddleClickTests.swift
+++ b/ZenttyLogicTests/LibghosttyViewMiddleClickTests.swift
@@ -1,0 +1,129 @@
+import AppKit
+import GhosttyKit
+import XCTest
+@testable import Zentty
+
+/// Verifies that `LibghosttyView` forwards `otherMouse*` button events to the surface.
+///
+/// The actual middle-click *paste* happens inside libghostty (a middle-button press
+/// makes the core paste the selection clipboard). The contract Zentty owns is simply
+/// forwarding the right button to the surface; that is what these tests pin down.
+@MainActor
+final class LibghosttyViewMiddleClickTests: AppKitTestCase {
+    private var view: LibghosttyView!
+    private var surface: MiddleClickSurfaceSpy!
+
+    override func setUp() {
+        super.setUp()
+        view = LibghosttyView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        surface = MiddleClickSurfaceSpy()
+        view.bind(surfaceController: surface)
+    }
+
+    override func tearDown() {
+        view = nil
+        surface = nil
+        super.tearDown()
+    }
+
+    func test_middle_click_forwards_press_and_release_as_middle() throws {
+        view.otherMouseDown(with: try makeOtherMouseEvent(type: .otherMouseDown, buttonNumber: 2))
+        view.otherMouseUp(with: try makeOtherMouseEvent(type: .otherMouseUp, buttonNumber: 2))
+
+        XCTAssertEqual(surface.sentMouseButtons.count, 2)
+        XCTAssertEqual(surface.sentMouseButtons.first?.state, GHOSTTY_MOUSE_PRESS)
+        XCTAssertEqual(surface.sentMouseButtons.first?.button, GHOSTTY_MOUSE_MIDDLE)
+        XCTAssertEqual(surface.sentMouseButtons.last?.state, GHOSTTY_MOUSE_RELEASE)
+        XCTAssertEqual(surface.sentMouseButtons.last?.button, GHOSTTY_MOUSE_MIDDLE)
+    }
+
+    func test_back_button_maps_to_ghostty_eight() throws {
+        view.otherMouseDown(with: try makeOtherMouseEvent(type: .otherMouseDown, buttonNumber: 3))
+
+        XCTAssertEqual(surface.sentMouseButtons.count, 1)
+        XCTAssertEqual(surface.sentMouseButtons.first?.button, GHOSTTY_MOUSE_EIGHT)
+    }
+
+    func test_forward_button_maps_to_ghostty_nine() throws {
+        view.otherMouseDown(with: try makeOtherMouseEvent(type: .otherMouseDown, buttonNumber: 4))
+
+        XCTAssertEqual(surface.sentMouseButtons.count, 1)
+        XCTAssertEqual(surface.sentMouseButtons.first?.button, GHOSTTY_MOUSE_NINE)
+    }
+
+    func test_unmapped_other_button_is_ignored() throws {
+        view.otherMouseDown(with: try makeOtherMouseEvent(type: .otherMouseDown, buttonNumber: 7))
+        view.otherMouseUp(with: try makeOtherMouseEvent(type: .otherMouseUp, buttonNumber: 7))
+
+        XCTAssertTrue(surface.sentMouseButtons.isEmpty)
+    }
+
+    func test_modifiers_are_passed_through() throws {
+        view.otherMouseDown(
+            with: try makeOtherMouseEvent(type: .otherMouseDown, buttonNumber: 2, flags: .maskShift)
+        )
+
+        XCTAssertEqual(surface.sentMouseButtons.count, 1)
+        XCTAssertTrue(surface.sentMouseButtons.first?.modifiers.contains(.shift) ?? false)
+    }
+}
+
+// MARK: - Test Doubles
+
+@MainActor
+private func makeOtherMouseEvent(
+    type: CGEventType,
+    buttonNumber: Int,
+    flags: CGEventFlags = []
+) throws -> NSEvent {
+    let source = try XCTUnwrap(CGEventSource(stateID: .hidSystemState))
+    let cgEvent = try XCTUnwrap(
+        CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: .zero,
+            mouseButton: .center
+        )
+    )
+    // CGMouseButton only names left/right/center, so set the button number explicitly
+    // for back/forward (3/4) and any other button we want to simulate.
+    cgEvent.setIntegerValueField(.mouseEventButtonNumber, value: Int64(buttonNumber))
+    cgEvent.flags = flags
+    return try XCTUnwrap(NSEvent(cgEvent: cgEvent))
+}
+
+private final class MiddleClickSurfaceSpy: LibghosttySurfaceControlling {
+    struct MouseButtonEvent: Equatable {
+        let state: ghostty_input_mouse_state_e
+        let button: ghostty_input_mouse_button_e
+        let modifiers: NSEvent.ModifierFlags
+    }
+
+    var hasScrollback = false
+    var cellWidth: CGFloat = 8
+    var cellHeight: CGFloat = 16
+    var searchDidChange: ((TerminalSearchEvent) -> Void)?
+    private(set) var sentMouseButtons: [MouseButtonEvent] = []
+
+    func updateViewport(size: CGSize, scale: CGFloat, displayID: UInt32?) {}
+    func setFocused(_ isFocused: Bool) {}
+    func setOcclusionVisible(_ isVisible: Bool) {}
+    func refresh() {}
+    func sendKey(event: NSEvent, action: TerminalKeyAction, text: String?, composing: Bool) -> Bool { true }
+    func sendMouseScroll(x: Double, y: Double, precision: Bool, momentum: NSEvent.Phase) {}
+    func sendMousePosition(_ position: CGPoint, modifiers: NSEvent.ModifierFlags) {}
+    func sendMouseButton(
+        state: ghostty_input_mouse_state_e,
+        button: ghostty_input_mouse_button_e,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Bool {
+        sentMouseButtons.append(MouseButtonEvent(state: state, button: button, modifiers: modifiers))
+        return false
+    }
+    func sendText(_ text: String) {}
+    func submitReturn() {}
+    func performBindingAction(_ action: String) -> Bool { true }
+    func hasSelection() -> Bool { false }
+    func close() {}
+    func inheritedConfig(for context: ghostty_surface_context_e) -> ghostty_surface_config_s? { nil }
+}


### PR DESCRIPTION
Middle-click now pastes the current selection into the terminal, the primary-selection behavior you get in Ghostty and most X11 terminals. Select text in a pane, middle-click, and it lands at the cursor.

Zentty already had the selection-clipboard pipeline in place: a dedicated selection pasteboard, `copy-on-select = clipboard`, and the read/write clipboard callbacks. What was missing is that `LibghosttyView` forwarded left, right, and scroll events to libghostty but never the middle button, so the core never saw the press that triggers the paste. This adds the `otherMouse*` handlers.

Button 2 maps to `MIDDLE`. The back/forward side buttons (3/4) ride the same `otherMouse*` path, so they map to `EIGHT`/`NINE` and now reach mouse-reporting TUIs too. Buttons we don't recognize fall through to the responder chain instead of being swallowed. The clicked pane takes focus first, matching left- and right-click. The paste logic stays inside libghostty, so it still reports the click instead of pasting when an app has mouse reporting on.

Verified on a physical 3-button mouse. `LibghosttyViewMiddleClickTests` covers the forwarding contract: middle/back/forward mapping, unmapped buttons ignored, and modifier passthrough.

Closes dedene/zentty#14
