### PR TITLE
feat(notifications): add custom notification sounds

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		5C90188186788922397ADD4A /* ProjectFileResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2531220560D56153939CB /* ProjectFileResolver.swift */; };
 		5CCCEA997B0C6BEA30A00A99 /* AboutMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994F524FDC5F10D6A7A96354 /* AboutMetadata.swift */; };
 		5DC7AC548DD0073978E02681 /* KeyboardShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B076EBD34D3A673A0937579 /* KeyboardShortcutResolverTests.swift */; };
+		5FA8FA00D8D061136E09373B /* NotificationSoundManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4B42ADBF99ECA847C27E19 /* NotificationSoundManagerTests.swift */; };
 		60F13E1D9931F1321C002362 /* ServerRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66E9360C107E9A7D3F05652 /* ServerRelevance.swift */; };
 		617C88C4ED936D565FD635F7 /* WorklaneReviewStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FE17A010577717370EFBCB /* WorklaneReviewStateResolver.swift */; };
 		6219CFABA673D1F436C3EBB2 /* PresentationDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789E529A7E4C195C7F216396 /* PresentationDraft.swift */; };
@@ -455,6 +456,7 @@
 		EDDA5E4E1273F0E81FBBE882 /* SettingsNavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29DBB882ABDF747B9DDA76 /* SettingsNavigationHistory.swift */; };
 		EDE18C0DA4C79997711F2528 /* ZenttyBreadcrumbs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B83CC56F8834AA75E2315BC /* ZenttyBreadcrumbs.swift */; };
 		EDF799E6005B1597EEA1314D /* AppDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63590216920018B71F1ACB7A /* AppDelegateTests.swift */; };
+		EE2D32723FAD470779B8D7F9 /* NotificationSoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */; };
 		EE970D14373E2C135E45C480 /* ThemeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73931D75238B5C4F1427B708 /* ThemeCoordinator.swift */; };
 		EEC22296EE34DF6250AD3DAD /* BookmarkNameSuggester.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C0137453B47FE9FC59D1E /* BookmarkNameSuggester.swift */; };
 		EF0F88674C95591761ACB87B /* BookmarksPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C551F8BB4DD16E95F8BDEFA2 /* BookmarksPopoverView.swift */; };
@@ -813,6 +815,7 @@
 		9C0FDE2EFAFDF416D3D66490 /* HookCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCanonicalReEmitter.swift; sourceTree = "<group>"; };
 		9C9964E75CAB137C49B15001 /* AboutMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutMetadataTests.swift; sourceTree = "<group>"; };
 		9D4020F350259F84864071D9 /* PathCopiedToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCopiedToastView.swift; sourceTree = "<group>"; };
+		9D4B42ADBF99ECA847C27E19 /* NotificationSoundManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundManagerTests.swift; sourceTree = "<group>"; };
 		9DBF3974DC90A1B68DB02135 /* BookmarksPopoverMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPopoverMetrics.swift; sourceTree = "<group>"; };
 		9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStore.swift; sourceTree = "<group>"; };
 		9E981E6DAD0FE2A00554CEEA /* WorklaneStoreCrossWindowTransferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreCrossWindowTransferTests.swift; sourceTree = "<group>"; };
@@ -962,6 +965,7 @@
 		E5F5891F160455B55F41BB5F /* HermesHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesHooksInstaller.swift; sourceTree = "<group>"; };
 		E6D7092CD7460BABDBD68C6E /* CommandPaletteTaskRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteTaskRunnerTests.swift; sourceTree = "<group>"; };
 		E6F07CFD4C44251C24400B38 /* WorklaneSessionEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneSessionEnvironment.swift; sourceTree = "<group>"; };
+		E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundManager.swift; sourceTree = "<group>"; };
 		E84313842197C75BCA9CE6E8 /* HermesTitleOverrideReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleOverrideReducer.swift; sourceTree = "<group>"; };
 		E89BAAA51D175EA4CC9174AA /* RecentCommandsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCommandsTracker.swift; sourceTree = "<group>"; };
 		EA5DD7A1968777DF9C77029D /* LibghosttySelectionAutoscrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySelectionAutoscrollControllerTests.swift; sourceTree = "<group>"; };
@@ -1104,6 +1108,7 @@
 		1C0506CDB868054B09C5CA8D /* AppState */ = {
 			isa = PBXGroup;
 			children = (
+				E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */,
 				9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */,
 				E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */,
 				54894343178398AA618315E4 /* PaneFocusHistory.swift */,
@@ -1731,6 +1736,7 @@
 				FD6F1935CE1012DD80C4954D /* MenuBarStatusPresentationTests.swift */,
 				88AFF05A04C7107BED6423F8 /* MoveToWorklaneMenuBuilderTests.swift */,
 				C771F4DD0F6077D2E72754D0 /* NotificationPopoverViewModelTests.swift */,
+				9D4B42ADBF99ECA847C27E19 /* NotificationSoundManagerTests.swift */,
 				859E02462A30A35800CA0123 /* NotificationStoreTests.swift */,
 				11E538276A60D58C85CD53E0 /* OpenCodeLiveThemeSyncTests.swift */,
 				C675B0F7ABA617674B6D9A82 /* OpenCodeThemeSyncTests.swift */,
@@ -2124,6 +2130,7 @@
 				308705984BE6FCCDC7CB25F8 /* MenuBarStatusPresentationTests.swift in Sources */,
 				B4C1005AD0D618DCB0A4C13D /* MoveToWorklaneMenuBuilderTests.swift in Sources */,
 				D4A63F03ECDA1CF35971F9DE /* NotificationPopoverViewModelTests.swift in Sources */,
+				5FA8FA00D8D061136E09373B /* NotificationSoundManagerTests.swift in Sources */,
 				F326460BA08B4AB927FD355F /* NotificationStoreTests.swift in Sources */,
 				03C2B5400305B015742248E2 /* OpenCodeLiveThemeSyncTests.swift in Sources */,
 				D5977945BCFB04E468408EC3 /* OpenCodeThemeSyncTests.swift in Sources */,
@@ -2339,6 +2346,7 @@
 				F12EB9E3A329F13DDB765ADC /* NotificationChromeCoordinator.swift in Sources */,
 				FA750A3CFFC86E664AAA4A00 /* NotificationInboxButton.swift in Sources */,
 				C9042A63C4AF443C0A4C8A55 /* NotificationPopoverView.swift in Sources */,
+				EE2D32723FAD470779B8D7F9 /* NotificationSoundManager.swift in Sources */,
 				AF800D9AC1461F47A82F6214 /* NotificationStore.swift in Sources */,
 				22A5ED0A03EBCBB3248944C3 /* NotificationsSettingsSectionViewController.swift in Sources */,
 				AA1411A91AE771850C12A19B /* OpenCodeLiveThemeSync.swift in Sources */,

--- a/Zentty/AppState/NotificationSoundManager.swift
+++ b/Zentty/AppState/NotificationSoundManager.swift
@@ -1,0 +1,281 @@
+import AppKit
+import AudioToolbox
+import Foundation
+
+/// Manages installation and preview of custom notification sounds.
+/// Custom sounds are converted via afconvert into the app's Library/Sounds directory
+/// as "zentty-custom-<uuid>.caf" (the internal name stored in AppConfig).
+/// A fresh file name is minted on every install so macOS never serves a stale cached
+/// sound for a reused name; older custom files are pruned once the new one is committed.
+/// The original display name is persisted separately for UI.
+enum NotificationSoundManager {
+    typealias SoundConverter = (_ source: URL, _ destination: URL) throws -> Void
+
+    /// All custom sound files share this prefix so they can be recognised and pruned.
+    static let customFilePrefix = "zentty-custom-"
+    static let customFileExtension = "caf"
+
+    /// True when `name` denotes one of our installed custom sound files.
+    static func isCustomSoundName(_ name: String) -> Bool {
+        name.hasPrefix(customFilePrefix) && name.hasSuffix(".\(customFileExtension)")
+    }
+
+    private static func makeCustomFileName() -> String {
+        "\(customFilePrefix)\(UUID().uuidString).\(customFileExtension)"
+    }
+
+    private struct CustomSoundInstallTransaction: Sendable {
+        let internalName: String
+        let displayName: String
+        let destinationURL: URL
+        let temporaryDirectory: URL
+    }
+
+    /// Override for tests (e.g. temp dir). Set before use and clear in tearDown.
+    nonisolated(unsafe) static var soundsDirectoryOverride: URL?
+    nonisolated(unsafe) static var libraryDirectoryOverride: URL?
+    nonisolated(unsafe) static var converterOverride: SoundConverter?
+
+    static var soundsDirectory: URL {
+        if let override = soundsDirectoryOverride { return override }
+        let libraryDirectory = libraryDirectoryOverride
+            ?? FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library", isDirectory: true)
+        return libraryDirectory
+            .appendingPathComponent("Sounds", isDirectory: true)
+    }
+
+    /// Installs a user-picked audio file as the active custom notification sound.
+    /// Converts all selected files using `afconvert` (to CAF/ima4).
+    /// Returns the internal name to store in soundName and the human display name.
+    static func installCustomSound(from source: URL) throws -> (internalName: String, displayName: String) {
+        try installCustomSound(from: source) { _, _ in }
+    }
+
+    /// Installs a custom sound and commits the persisted selection transactionally.
+    /// If persistence fails, the previous installed sound file is restored.
+    @discardableResult
+    static func installCustomSound(
+        from source: URL,
+        persistSelection: (_ internalName: String, _ displayName: String) throws -> Void
+    ) throws -> (internalName: String, displayName: String) {
+        let transaction = try prepareCustomSoundInstall(from: source)
+        do {
+            try persistSelection(transaction.internalName, transaction.displayName)
+            finishCustomSoundInstall(transaction)
+        } catch {
+            rollbackCustomSoundInstall(transaction)
+            throw error
+        }
+
+        return (transaction.internalName, transaction.displayName)
+    }
+
+    /// Async variant for UI callers. File conversion and rollback stay off the main actor;
+    /// the persisted selection is committed on the main actor.
+    @discardableResult
+    static func installCustomSound(
+        from source: URL,
+        persistSelection: @MainActor (_ internalName: String, _ displayName: String) throws -> Void
+    ) async throws -> (internalName: String, displayName: String) {
+        let transaction = try await Task.detached(priority: .userInitiated) {
+            try prepareCustomSoundInstall(from: source)
+        }.value
+
+        do {
+            try await MainActor.run {
+                try persistSelection(transaction.internalName, transaction.displayName)
+            }
+            await Task.detached(priority: .utility) {
+                finishCustomSoundInstall(transaction)
+            }.value
+        } catch {
+            await Task.detached(priority: .utility) {
+                rollbackCustomSoundInstall(transaction)
+            }.value
+            throw error
+        }
+
+        return (transaction.internalName, transaction.displayName)
+    }
+
+    private static func prepareCustomSoundInstall(from source: URL) throws -> CustomSoundInstallTransaction {
+        let fm = FileManager.default
+        let dir = soundsDirectory
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+
+        // Each install gets a unique file name so macOS never replays a stale cached sound
+        // for a reused name. The previous custom file is left untouched until the new
+        // selection is committed, then pruned in finishCustomSoundInstall.
+        let internalName = makeCustomFileName()
+        let destURL = dir.appendingPathComponent(internalName)
+        let displayName = source.lastPathComponent
+        let transactionID = UUID().uuidString
+        let temporaryDirectory = dir.appendingPathComponent(".zentty-sound-\(transactionID)", isDirectory: true)
+        let temporaryURL = temporaryDirectory.appendingPathComponent(internalName)
+
+        try fm.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+        var transactionPrepared = false
+        defer {
+            if !transactionPrepared {
+                try? fm.removeItem(at: temporaryDirectory)
+            }
+        }
+
+        if let sourceDuration = audioDuration(of: source), sourceDuration > 30 {
+            throw NotificationSoundInstallError.tooLong(sourceDuration)
+        }
+
+        do {
+            try convertSound(from: source, to: temporaryURL)
+            try validateConvertedSoundDuration(at: temporaryURL)
+        } catch {
+            try? fm.removeItem(at: temporaryDirectory)
+            throw error
+        }
+
+        do {
+            try fm.moveItem(at: temporaryURL, to: destURL)
+            transactionPrepared = true
+            return CustomSoundInstallTransaction(
+                internalName: internalName,
+                displayName: displayName,
+                destinationURL: destURL,
+                temporaryDirectory: temporaryDirectory
+            )
+        } catch {
+            try? fm.removeItem(at: temporaryDirectory)
+            throw error
+        }
+    }
+
+    private static func finishCustomSoundInstall(_ transaction: CustomSoundInstallTransaction) {
+        try? FileManager.default.removeItem(at: transaction.temporaryDirectory)
+        // Drop the previous custom sound (and any orphans) now that the new one is committed.
+        pruneCustomSounds(keeping: transaction.internalName)
+    }
+
+    private static func rollbackCustomSoundInstall(_ transaction: CustomSoundInstallTransaction) {
+        // The new file was never committed; remove only it and the temp dir. Any previously
+        // installed custom file keeps its own name and stays referenced by the persisted config.
+        try? FileManager.default.removeItem(at: transaction.destinationURL)
+        try? FileManager.default.removeItem(at: transaction.temporaryDirectory)
+    }
+
+    /// Removes every installed custom sound file except `keepName` (pass nil to remove all).
+    /// Used to clear the previous selection on a fresh install and when the user switches
+    /// back to a system or default sound.
+    static func pruneCustomSounds(keeping keepName: String?) {
+        let dir = soundsDirectory
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else {
+            return
+        }
+        for entry in entries where isCustomSoundName(entry) && entry != keepName {
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(entry))
+        }
+    }
+
+    private static func convertSound(from source: URL, to destination: URL) throws {
+        if let converterOverride {
+            try converterOverride(source, destination)
+            return
+        }
+
+        let afconvert = Process()
+        afconvert.executableURL = URL(fileURLWithPath: "/usr/bin/afconvert")
+        afconvert.arguments = ["-f", "caff", "-d", "ima4", source.path, destination.path]
+        let stderrPipe = Pipe()
+        afconvert.standardError = stderrPipe
+
+        do {
+            try afconvert.run()
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            throw NotificationSoundInstallError.conversionFailed("Could not launch afconvert: \(error.localizedDescription)")
+        }
+
+        // Drain stderr to EOF before waiting: reading to EOF completes when afconvert closes
+        // its stderr on exit, so it doubles as the wait and continuously empties the pipe —
+        // it can never deadlock on a full buffer the way waitUntilExit()-then-read could.
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        afconvert.waitUntilExit()
+        let stderr = String(data: stderrData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if afconvert.terminationStatus != 0 {
+            try? FileManager.default.removeItem(at: destination)
+            var reason = "afconvert exited with status \(afconvert.terminationStatus)"
+            if let stderr, !stderr.isEmpty {
+                reason += ": \(stderr)"
+            }
+            throw NotificationSoundInstallError.conversionFailed(reason)
+        }
+    }
+
+    private static func validateConvertedSoundDuration(at url: URL) throws {
+        guard let duration = audioDuration(of: url) else {
+            throw NotificationSoundInstallError.conversionFailed("Could not determine converted audio duration.")
+        }
+        if duration > 30 {
+            throw NotificationSoundInstallError.tooLong(duration)
+        }
+    }
+
+    private static func audioDuration(of url: URL) -> TimeInterval? {
+        var audioFile: AudioFileID?
+        let openStatus = AudioFileOpenURL(url as CFURL, .readPermission, 0, &audioFile)
+        guard openStatus == noErr, let audioFile else {
+            return nil
+        }
+        defer { AudioFileClose(audioFile) }
+
+        var duration: TimeInterval = 0
+        var size = UInt32(MemoryLayout<TimeInterval>.size)
+        let durationStatus = AudioFileGetProperty(
+            audioFile,
+            kAudioFilePropertyEstimatedDuration,
+            &size,
+            &duration
+        )
+        guard durationStatus == noErr, duration.isFinite, duration >= 0 else {
+            return nil
+        }
+        return duration
+    }
+
+    /// Returns a file URL suitable for NSSound(contentsOf:) preview for custom sounds, or nil.
+    static func urlForPreview(soundName: String) -> URL? {
+        guard isCustomSoundName(soundName) else { return nil }
+        let url = soundsDirectory.appendingPathComponent(soundName)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    /// Attempts to play a preview of the given sound (delegates custom to file URL).
+    /// Returns true if preview was started.
+    @discardableResult
+    static func playPreview(for soundName: String) -> Bool {
+        if let url = urlForPreview(soundName: soundName),
+           let sound = NSSound(contentsOf: url, byReference: true) {
+            return sound.play()
+        }
+        return false
+    }
+}
+
+enum NotificationSoundInstallError: Error, LocalizedError {
+    case tooLong(TimeInterval)
+    case conversionFailed(String)
+    case fileOperationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .tooLong(let seconds):
+            let reported = max(0, Int(seconds.rounded()))
+            return "The selected sound is \(reported) seconds long. Please choose a file 30 seconds or shorter."
+        case .conversionFailed(let reason):
+            return "Could not convert the audio file for use as a notification sound (\(reason))."
+        case .fileOperationFailed(let reason):
+            return "File operation failed while installing custom sound: \(reason)"
+        }
+    }
+}

--- a/Zentty/Config/AppConfig.swift
+++ b/Zentty/Config/AppConfig.swift
@@ -114,8 +114,18 @@ struct AppConfig: Equatable, Sendable {
     struct Notifications: Equatable, Sendable {
         /// Empty string means system default sound.
         var soundName: String
+        /// Display name for a user-chosen custom sound file (when soundName is the internal custom file).
+        var customSoundDisplayName: String?
 
-        static let `default` = Notifications(soundName: "")
+        static let `default` = Notifications(soundName: "", customSoundDisplayName: nil)
+
+        func normalized() -> Notifications {
+            var normalized = self
+            if !NotificationSoundManager.isCustomSoundName(normalized.soundName) {
+                normalized.customSoundDisplayName = nil
+            }
+            return normalized
+        }
     }
 
     struct Confirmations: Equatable, Sendable {
@@ -247,6 +257,7 @@ struct AppConfig: Equatable, Sendable {
         normalized.openWith = normalized.openWith.normalized()
         normalized.serverDetection = normalized.serverDetection.normalized()
         normalized.shortcuts = normalized.shortcuts.normalized()
+        normalized.notifications = normalized.notifications.normalized()
         return normalized
     }
 }

--- a/Zentty/Config/AppConfigTOML.swift
+++ b/Zentty/Config/AppConfigTOML.swift
@@ -142,6 +142,9 @@ enum AppConfigTOML {
         lines.append("")
         lines.append("[notifications]")
         lines.append("sound_name = \(encode(string: config.notifications.soundName))")
+        if let customDisplayName = config.notifications.customSoundDisplayName {
+            lines.append("custom_sound_display_name = \(encode(string: customDisplayName))")
+        }
 
         lines.append("")
         lines.append("[confirmations]")
@@ -696,6 +699,11 @@ enum AppConfigTOML {
                 return false
             }
             config.notifications.soundName = value
+        case "custom_sound_display_name":
+            guard let value = decodeString(assignment.value) else {
+                return false
+            }
+            config.notifications.customSoundDisplayName = value
         default:
             return true
         }

--- a/Zentty/UI/Settings/NotificationsSettingsSectionViewController.swift
+++ b/Zentty/UI/Settings/NotificationsSettingsSectionViewController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UniformTypeIdentifiers
 import UserNotifications
 
 @MainActor
@@ -10,6 +11,9 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
             "Purr", "Sosumi", "Submarine", "Tink",
         ]
     }
+
+    private struct ChooseCustomSoundSentinel {}
+    private let chooseCustomSentinel = ChooseCustomSoundSentinel()
 
     private let configStore: AppConfigStore
     private var currentNotifications: AppConfig.Notifications = .default
@@ -193,17 +197,14 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
         rightStack.spacing = 8
         rightStack.translatesAutoresizingMaskIntoConstraints = false
 
-        soundPopupButton.removeAllItems()
-        soundPopupButton.addItem(withTitle: "Default")
-        soundPopupButton.lastItem?.representedObject = "" as String
-        for sound in Sound.systemSounds {
-            soundPopupButton.addItem(withTitle: sound)
-            soundPopupButton.lastItem?.representedObject = sound as String
-        }
         soundPopupButton.target = self
         soundPopupButton.action = #selector(handleSoundChanged(_:))
-        soundPopupButton.setContentHuggingPriority(.required, for: .horizontal)
+        soundPopupButton.cell?.lineBreakMode = .byTruncatingMiddle
+        soundPopupButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        soundPopupButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         rightStack.addArrangedSubview(soundPopupButton)
+        soundPopupButton.widthAnchor.constraint(lessThanOrEqualToConstant: 260).isActive = true
+        rebuildSoundPopupItems()
 
         playButton.bezelStyle = .rounded
         playButton.image = NSImage(
@@ -262,15 +263,37 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
 
     @objc
     private func handleSoundChanged(_ sender: NSPopUpButton) {
-        guard let soundName = sender.selectedItem?.representedObject as? String else { return }
+        let rep = sender.selectedItem?.representedObject
+        if rep is ChooseCustomSoundSentinel {
+            presentCustomSoundPicker()
+            // Revert visual selection immediately; picker sheet will drive final state
+            selectSoundPopupItem(for: currentNotifications.soundName)
+            return
+        }
+        guard let soundName = rep as? String else { return }
+        let isCustom = NotificationSoundManager.isCustomSoundName(soundName)
         try? configStore.update { config in
             config.notifications.soundName = soundName
+            if !isCustom {
+                config.notifications.customSoundDisplayName = nil
+            }
         }
         currentNotifications = configStore.current.notifications
+        if !isCustom {
+            // Switching back to a system/default sound: drop the orphaned custom file now.
+            // Synchronous on the main actor — this user-initiated settings change already
+            // writes TOML synchronously, and inline ordering removes the install/prune race.
+            NotificationSoundManager.pruneCustomSounds(keeping: nil)
+            // Rebuild so the now-stale "Custom: …" entry (its file was just deleted) disappears.
+            selectSoundPopupItem(for: soundName)
+        }
     }
 
     @objc
     private func handlePlaySound(_ sender: Any?) {
+        if NotificationSoundManager.playPreview(for: currentNotifications.soundName) {
+            return
+        }
         let soundName = currentNotifications.soundName
         if soundName.isEmpty {
             NSSound(named: "Tink")?.play()
@@ -324,6 +347,7 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
 
     private func selectSoundPopupItem(for soundName: String) {
         guard isViewLoaded else { return }
+        rebuildSoundPopupItems()
         let index =
             soundPopupButton.itemArray.firstIndex {
                 ($0.representedObject as? String) == soundName
@@ -337,6 +361,93 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
         label.lineBreakMode = .byWordWrapping
         label.maximumNumberOfLines = 0
         return label
+    }
+
+    // MARK: - Sound Popup (dynamic for custom)
+
+    private func rebuildSoundPopupItems() {
+        soundPopupButton.removeAllItems()
+
+        soundPopupButton.addItem(withTitle: "Default")
+        soundPopupButton.lastItem?.representedObject = "" as String
+
+        for sound in Sound.systemSounds {
+            soundPopupButton.addItem(withTitle: sound)
+            soundPopupButton.lastItem?.representedObject = sound as String
+        }
+
+        // Keep the installed custom sound selectable even when older config has no display name.
+        if NotificationSoundManager.isCustomSoundName(currentNotifications.soundName) {
+            let display = currentNotifications.customSoundDisplayName ?? "Custom Sound"
+            let title = "Custom: \(display)"
+            soundPopupButton.addItem(withTitle: title)
+            soundPopupButton.lastItem?.representedObject = currentNotifications.soundName as String
+            soundPopupButton.lastItem?.toolTip = title
+        }
+
+        soundPopupButton.addItem(withTitle: "Choose Custom Audio File…")
+        soundPopupButton.lastItem?.representedObject = chooseCustomSentinel
+    }
+
+    private func presentCustomSoundPicker() {
+        guard let window = view.window else { return }
+        let panel = NSOpenPanel()
+        panel.prompt = "Choose"
+        panel.message = "Select a short audio file (WAV, AIFF, CAF, MP3, M4A, etc.) to use for notifications."
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.audio]
+
+        panel.beginSheetModal(for: window) { [weak self] response in
+            guard let self = self, response == .OK, let url = panel.url else {
+                self?.selectSoundPopupItem(for: self?.currentNotifications.soundName ?? "")
+                return
+            }
+            self.installAndSelectCustomSound(from: url)
+        }
+    }
+
+    private func installAndSelectCustomSound(from source: URL) {
+        setCustomSoundInstallInProgress(true)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.setCustomSoundInstallInProgress(false)
+            }
+
+            do {
+                let (internalName, displayName) = try await NotificationSoundManager.installCustomSound(from: source) {
+                    internalName, displayName in
+                    try self.configStore.update { config in
+                        config.notifications.soundName = internalName
+                        config.notifications.customSoundDisplayName = displayName
+                    }
+                }
+                self.currentNotifications = self.configStore.current.notifications
+                self.rebuildSoundPopupItems()
+                self.selectSoundPopupItem(for: internalName)
+                _ = NotificationSoundManager.playPreview(for: internalName)
+            } catch {
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = "Could not install custom sound"
+                alert.informativeText = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                if let win = self.view.window {
+                    alert.beginSheetModal(for: win) { _ in
+                        self.selectSoundPopupItem(for: self.currentNotifications.soundName)
+                    }
+                } else {
+                    alert.runModal()
+                    self.selectSoundPopupItem(for: self.currentNotifications.soundName)
+                }
+            }
+        }
+    }
+
+    private func setCustomSoundInstallInProgress(_ isInProgress: Bool) {
+        soundPopupButton.isEnabled = !isInProgress
+        playButton.isEnabled = !isInProgress
     }
 
     // MARK: - For Testing
@@ -353,14 +464,38 @@ final class NotificationsSettingsSectionViewController: SettingsScrollableSectio
         (soundPopupButton.selectedItem?.representedObject as? String) ?? ""
     }
 
+    var selectedSoundTitle: String {
+        soundPopupButton.selectedItem?.title ?? ""
+    }
+
+    var selectedSoundTooltip: String? {
+        soundPopupButton.selectedItem?.toolTip
+    }
+
+    var soundPopupWidthForTesting: CGFloat {
+        soundPopupButton.frame.width
+    }
+
     var availableSoundNames: [String] {
         soundPopupButton.itemArray.compactMap { $0.representedObject as? String }
+    }
+
+    func selectSoundForTesting(_ soundName: String) {
+        selectSoundPopupItem(for: soundName)
+        handleSoundChanged(soundPopupButton)
     }
 }
 
 func resolvedNotificationSound(for soundName: String) -> UNNotificationSound {
-    if soundName.isEmpty {
+    guard let notificationSoundName = resolvedNotificationSoundName(for: soundName) else {
         return .default
     }
-    return UNNotificationSound(named: UNNotificationSoundName(rawValue: soundName))
+    return UNNotificationSound(named: notificationSoundName)
+}
+
+func resolvedNotificationSoundName(for soundName: String) -> UNNotificationSoundName? {
+    if soundName.isEmpty {
+        return nil
+    }
+    return UNNotificationSoundName(rawValue: soundName)
 }

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -1099,6 +1099,121 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertTrue(store.current.agentTeams.enabled)
     }
 
+    func test_notifications_custom_sound_display_name_roundtrips_through_toml_and_store() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        let customName = "zentty-custom-sample.caf"
+        try store.update { config in
+            config.notifications.soundName = customName
+            config.notifications.customSoundDisplayName = "My Personal Chime.mp3"
+        }
+
+        XCTAssertEqual(store.current.notifications.soundName, customName)
+        XCTAssertEqual(store.current.notifications.customSoundDisplayName, "My Personal Chime.mp3")
+
+        let persisted = try String(contentsOf: fileURL)
+        XCTAssertTrue(persisted.contains("[notifications]"))
+        XCTAssertTrue(persisted.contains("sound_name = \"zentty-custom-sample.caf\""))
+        XCTAssertTrue(persisted.contains("custom_sound_display_name = \"My Personal Chime.mp3\""))
+
+        // Simulate reload from disk (new store instance)
+        let reloaded = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+        XCTAssertEqual(reloaded.current.notifications.soundName, customName)
+        XCTAssertEqual(reloaded.current.notifications.customSoundDisplayName, "My Personal Chime.mp3")
+
+        // Clearing custom display on switch to system sound
+        try reloaded.update { config in
+            config.notifications.soundName = "Tink"
+            config.notifications.customSoundDisplayName = nil
+        }
+        let cleared = try String(contentsOf: fileURL)
+        XCTAssertFalse(cleared.contains("custom_sound_display_name"))
+        XCTAssertTrue(cleared.contains("sound_name = \"Tink\""))
+    }
+
+    func test_notifications_legacy_custom_sound_name_without_display_roundtrips() throws {
+        // The pre-rotation fixed file name must still be recognised as a custom sound so
+        // existing configs keep their selection after upgrade.
+        let legacyName = "zentty-custom-notification.caf"
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(legacyName))
+
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        try """
+        [notifications]
+        sound_name = "\(legacyName)"
+        """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        // Custom name + nil display (from decode starting at .default) survives normalization.
+        XCTAssertEqual(store.current.notifications.soundName, legacyName)
+        XCTAssertNil(store.current.notifications.customSoundDisplayName)
+
+        let reloaded = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+        XCTAssertEqual(reloaded.current.notifications.soundName, legacyName)
+        XCTAssertNil(reloaded.current.notifications.customSoundDisplayName)
+    }
+
+    func test_notifications_custom_sound_display_name_is_normalized_away_for_system_sound_on_load() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        try """
+        [notifications]
+        sound_name = "Glass"
+        custom_sound_display_name = "Stale Custom.mp3"
+        """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(store.current.notifications.soundName, "Glass")
+        XCTAssertNil(store.current.notifications.customSoundDisplayName)
+    }
+
+    func test_notifications_custom_sound_display_name_is_normalized_away_for_system_sound_on_update() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        try store.update { config in
+            config.notifications.soundName = "Glass"
+            config.notifications.customSoundDisplayName = "Stale Custom.mp3"
+        }
+
+        XCTAssertEqual(store.current.notifications.soundName, "Glass")
+        XCTAssertNil(store.current.notifications.customSoundDisplayName)
+        let persisted = try String(contentsOf: fileURL)
+        XCTAssertFalse(persisted.contains("custom_sound_display_name"))
+    }
+
     private func makeDefaults(suffix: String) -> UserDefaults {
         let suiteName = "ZenttyTests.AppConfigStoreTests.\(suffix).\(UUID().uuidString)"
         defaultsSuiteNames.append(suiteName)

--- a/ZenttyLogicTests/NotificationSoundManagerTests.swift
+++ b/ZenttyLogicTests/NotificationSoundManagerTests.swift
@@ -1,0 +1,387 @@
+import AVFoundation
+import UserNotifications
+import XCTest
+@testable import Zentty
+
+final class NotificationSoundManagerTests: XCTestCase {
+    private var originalOverride: URL?
+    private var originalLibraryDirectoryOverride: URL?
+    private var originalConverterOverride: NotificationSoundManager.SoundConverter?
+    private var tempSoundsDir: URL!
+    private var tempHomeDir: URL!
+
+    override func setUpWithError() throws {
+        originalOverride = NotificationSoundManager.soundsDirectoryOverride
+        originalLibraryDirectoryOverride = NotificationSoundManager.libraryDirectoryOverride
+        originalConverterOverride = NotificationSoundManager.converterOverride
+        tempSoundsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ZenttyTests.NotificationSoundManager.\(UUID().uuidString)", isDirectory: true)
+        tempHomeDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ZenttyTests.NotificationSoundManager.Home.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempSoundsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempHomeDir, withIntermediateDirectories: true)
+        NotificationSoundManager.soundsDirectoryOverride = tempSoundsDir
+        NotificationSoundManager.libraryDirectoryOverride = nil
+        NotificationSoundManager.converterOverride = nil
+    }
+
+    override func tearDownWithError() throws {
+        NotificationSoundManager.soundsDirectoryOverride = originalOverride
+        NotificationSoundManager.libraryDirectoryOverride = originalLibraryDirectoryOverride
+        NotificationSoundManager.converterOverride = originalConverterOverride
+        if let tempSoundsDir {
+            try? FileManager.default.removeItem(at: tempSoundsDir)
+        }
+        if let tempHomeDir {
+            try? FileManager.default.removeItem(at: tempHomeDir)
+        }
+    }
+
+    func test_soundsDirectory_uses_override() {
+        XCTAssertEqual(NotificationSoundManager.soundsDirectory, tempSoundsDir)
+    }
+
+    func test_soundsDirectory_defaultsToCurrentUserLibrarySoundsDirectory() {
+        NotificationSoundManager.soundsDirectoryOverride = nil
+        let libraryDirectory = tempHomeDir.appendingPathComponent("Library", isDirectory: true)
+        NotificationSoundManager.libraryDirectoryOverride = libraryDirectory
+
+        let expected = libraryDirectory
+            .appendingPathComponent("Sounds", isDirectory: true)
+
+        XCTAssertEqual(NotificationSoundManager.soundsDirectory, expected)
+    }
+
+    func test_isCustomSoundName_matchesPrefixAndExtension() {
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName("zentty-custom-\(UUID().uuidString).caf"))
+        // Legacy fixed name from before rotation still matches the prefix.
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName("zentty-custom-notification.caf"))
+        XCTAssertFalse(NotificationSoundManager.isCustomSoundName("Glass"))
+        XCTAssertFalse(NotificationSoundManager.isCustomSoundName(""))
+        XCTAssertFalse(NotificationSoundManager.isCustomSoundName("zentty-custom-abc.mp3"))
+        XCTAssertFalse(NotificationSoundManager.isCustomSoundName("other-custom-abc.caf"))
+    }
+
+    func test_installCustomSound_convertsSystemAiff_andProvidesPreviewURL() throws {
+        let source = URL(fileURLWithPath: "/System/Library/Sounds/Glass.aiff")
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw XCTSkip("No Glass.aiff available for test")
+        }
+
+        let result = try NotificationSoundManager.installCustomSound(from: source)
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(result.internalName))
+        XCTAssertFalse(result.displayName.isEmpty)
+
+        let installed = tempSoundsDir.appendingPathComponent(result.internalName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installed.path))
+
+        let previewURL = NotificationSoundManager.urlForPreview(soundName: result.internalName)
+        XCTAssertEqual(previewURL, installed)
+    }
+
+    func test_installCustomSound_mintsUniqueInternalNamePerInstall() throws {
+        let source = try makeConvertibleSource(named: "source.input")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        let first = try NotificationSoundManager.installCustomSound(from: source)
+        let second = try NotificationSoundManager.installCustomSound(from: source)
+
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(first.internalName))
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(second.internalName))
+        XCTAssertNotEqual(first.internalName, second.internalName)
+    }
+
+    func test_installCustomSound_convertsToCustomCafAndPreservesDisplayName() throws {
+        let source = try makeValidAudioSource(named: "Chime-日本語.aiff")
+        var conversion: (source: URL, destination: URL)?
+        NotificationSoundManager.converterOverride = { sourceURL, destinationURL in
+            conversion = (sourceURL, destinationURL)
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        let result = try NotificationSoundManager.installCustomSound(from: source)
+
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(result.internalName))
+        XCTAssertEqual(result.displayName, "Chime-日本語.aiff")
+        XCTAssertEqual(conversion?.source, source)
+        XCTAssertEqual(conversion?.destination.lastPathComponent, result.internalName)
+        let installed = tempSoundsDir.appendingPathComponent(result.internalName)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installed.path))
+    }
+
+    func test_installCustomSound_removesPartialDestinationWhenConversionFails() throws {
+        let source = try makeValidAudioSource(named: "Broken.aiff")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Data("partial".utf8).write(to: destinationURL)
+            throw NotificationSoundInstallError.conversionFailed("bad codec")
+        }
+
+        XCTAssertThrowsError(try NotificationSoundManager.installCustomSound(from: source))
+
+        XCTAssertEqual(try customSoundFiles(), [])
+    }
+
+    func test_installCustomSound_prunesPreviousCustomFileOnSuccessfulInstall() throws {
+        let source = try makeConvertibleSource(named: "source.input")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        let first = try NotificationSoundManager.installCustomSound(from: source)
+        XCTAssertEqual(try customSoundFiles(), [first.internalName])
+
+        let second = try NotificationSoundManager.installCustomSound(from: source)
+
+        // The first file is pruned; only the freshly installed one remains.
+        XCTAssertEqual(try customSoundFiles(), [second.internalName])
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: tempSoundsDir.appendingPathComponent(first.internalName).path)
+        )
+    }
+
+    func test_installCustomSound_keepsPreviousFileWhenPersistSelectionFails() throws {
+        enum TestError: Error {
+            case persistence
+        }
+
+        let existingName = "zentty-custom-existing.caf"
+        let existing = tempSoundsDir.appendingPathComponent(existingName)
+        try Data("previous-caf".utf8).write(to: existing)
+        let source = try makeConvertibleSource(named: "source.input")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        XCTAssertThrowsError(
+            try NotificationSoundManager.installCustomSound(from: source) { _, _ in
+                throw TestError.persistence
+            }
+        )
+
+        // The previously installed file is untouched and the aborted install left nothing behind.
+        XCTAssertEqual(try Data(contentsOf: existing), Data("previous-caf".utf8))
+        XCTAssertEqual(try customSoundFiles(), [existingName])
+    }
+
+    func test_installCustomSoundAsync_runsConversionOffMainAndPersistsOnMainThread() async throws {
+        let source = try makeConvertibleSource(named: "source.input")
+        final class ThreadCapture: @unchecked Sendable {
+            private let lock = NSLock()
+            private(set) var converterRanOnMainThread: Bool?
+            private(set) var persistenceRanOnMainThread: Bool?
+
+            func recordConverterThread() {
+                lock.lock()
+                converterRanOnMainThread = Thread.isMainThread
+                lock.unlock()
+            }
+
+            func recordPersistenceThread() {
+                lock.lock()
+                persistenceRanOnMainThread = Thread.isMainThread
+                lock.unlock()
+            }
+        }
+
+        let capture = ThreadCapture()
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            capture.recordConverterThread()
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        let result = try await NotificationSoundManager.installCustomSound(from: source) { _, _ in
+            capture.recordPersistenceThread()
+        }
+
+        XCTAssertTrue(NotificationSoundManager.isCustomSoundName(result.internalName))
+        XCTAssertEqual(capture.converterRanOnMainThread, false)
+        XCTAssertEqual(capture.persistenceRanOnMainThread, true)
+    }
+
+    func test_installCustomSoundAsync_keepsPreviousFileWhenPersistSelectionFails() async throws {
+        enum TestError: Error {
+            case persistence
+        }
+
+        let existingName = "zentty-custom-existing.caf"
+        let existing = tempSoundsDir.appendingPathComponent(existingName)
+        try Data("previous-caf".utf8).write(to: existing)
+        let source = try makeConvertibleSource(named: "source.input")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        do {
+            _ = try await NotificationSoundManager.installCustomSound(from: source) { _, _ in
+                throw TestError.persistence
+            }
+            XCTFail("Expected persistence failure")
+        } catch TestError.persistence {
+            XCTAssertEqual(try Data(contentsOf: existing), Data("previous-caf".utf8))
+            XCTAssertEqual(try customSoundFiles(), [existingName])
+        } catch {
+            XCTFail("Expected persistence failure, got \(error)")
+        }
+    }
+
+    func test_pruneCustomSounds_removesAllCustomFilesWhenKeepingNil() throws {
+        let names = ["zentty-custom-a.caf", "zentty-custom-b.caf"]
+        for name in names {
+            try Data("x".utf8).write(to: tempSoundsDir.appendingPathComponent(name))
+        }
+        // A non-custom file must survive pruning.
+        let keeper = tempSoundsDir.appendingPathComponent("Glass.aiff")
+        try Data("keep".utf8).write(to: keeper)
+
+        NotificationSoundManager.pruneCustomSounds(keeping: nil)
+
+        XCTAssertEqual(try customSoundFiles(), [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: keeper.path))
+    }
+
+    func test_installCustomSound_rejectsConvertedSoundLongerThanThirtySecondsWhenSourceDurationIsUnreadable() throws {
+        let source = tempSoundsDir.appendingPathComponent("SourceWithUnreadableDuration.zenttytest")
+        try Data("not actually audio but converter accepts it".utf8).write(to: source)
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 31, to: destinationURL)
+        }
+
+        XCTAssertThrowsError(try NotificationSoundManager.installCustomSound(from: source)) { error in
+            guard case NotificationSoundInstallError.tooLong = error else {
+                return XCTFail("Expected tooLong, got \(error)")
+            }
+        }
+
+        XCTAssertEqual(try customSoundFiles(), [])
+    }
+
+    func test_installCustomSound_rejectsConvertedSoundWhenDurationCannotBeDetermined() throws {
+        let source = try makeValidAudioSource(named: "ReadableSource.aiff")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Data("not a readable converted sound".utf8).write(to: destinationURL)
+        }
+
+        XCTAssertThrowsError(try NotificationSoundManager.installCustomSound(from: source)) { error in
+            guard case NotificationSoundInstallError.conversionFailed(let reason) = error else {
+                return XCTFail("Expected conversionFailed, got \(error)")
+            }
+            XCTAssertTrue(reason.localizedCaseInsensitiveContains("duration"))
+        }
+
+        XCTAssertEqual(try customSoundFiles(), [])
+    }
+
+    func test_installCustomSound_reportsAfconvertStderrWithoutNestedLocalizedError() throws {
+        let source = tempSoundsDir.appendingPathComponent("NotAudio.aiff")
+        try Data("not audio".utf8).write(to: source)
+
+        XCTAssertThrowsError(try NotificationSoundManager.installCustomSound(from: source)) { error in
+            guard case NotificationSoundInstallError.conversionFailed(let reason) = error else {
+                return XCTFail("Expected conversionFailed, got \(error)")
+            }
+            XCTAssertFalse(reason.contains("Could not convert the audio file"))
+            XCTAssertTrue(reason.localizedCaseInsensitiveContains("afconvert"))
+            XCTAssertTrue(reason.localizedCaseInsensitiveContains("input file"))
+        }
+    }
+
+    func test_playPreview_returnsFalse_forUnknownSound() {
+        let played = NotificationSoundManager.playPreview(for: "NonExistentSoundName")
+        XCTAssertFalse(played)
+    }
+
+    func test_installCustomSound_createsDirectoryIfMissing() throws {
+        let nested = tempSoundsDir.appendingPathComponent("NestedCustomSounds", isDirectory: true)
+        NotificationSoundManager.soundsDirectoryOverride = nested
+        XCTAssertFalse(FileManager.default.fileExists(atPath: nested.path))
+
+        let source = URL(fileURLWithPath: "/System/Library/Sounds/Ping.aiff")
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw XCTSkip("No Ping.aiff for test")
+        }
+
+        let result = try NotificationSoundManager.installCustomSound(from: source)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nested.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nested.appendingPathComponent(result.internalName).path))
+    }
+
+    func test_resolvedNotificationSoundName_usesCustomFileNameForDeliveredNotifications() {
+        let customName = "zentty-custom-\(UUID().uuidString).caf"
+        let soundName = resolvedNotificationSoundName(for: customName)
+
+        XCTAssertEqual(soundName?.rawValue, customName)
+        XCTAssertNil(resolvedNotificationSoundName(for: ""))
+    }
+
+    func test_urlForPreview_returnsNil_forMissingCustomFile() {
+        // Covers plan edge "missing custom file"
+        let url = NotificationSoundManager.urlForPreview(
+            soundName: "zentty-custom-\(UUID().uuidString).caf"
+        )
+        XCTAssertNil(url)
+    }
+
+    func test_installCustomSound_preservesNonAsciiDisplayName() throws {
+        let source = try makeValidAudioSource(named: "Chime-日本語.aiff")
+        NotificationSoundManager.converterOverride = { _, destinationURL in
+            try Self.writeSilentAudio(duration: 1, to: destinationURL)
+        }
+
+        let result = try NotificationSoundManager.installCustomSound(from: source)
+
+        XCTAssertEqual(result.displayName, "Chime-日本語.aiff")
+    }
+
+    func test_notificationSoundInstallError_localizedDescriptions() {
+        let tooLong = NotificationSoundInstallError.tooLong(42)
+        XCTAssertTrue(tooLong.errorDescription?.contains("42") ?? false)
+        XCTAssertTrue(tooLong.errorDescription?.contains("30") ?? false)
+
+        let conv = NotificationSoundInstallError.conversionFailed("afconvert missing")
+        XCTAssertTrue(conv.errorDescription?.contains("afconvert") ?? false)
+
+        let fileOp = NotificationSoundInstallError.fileOperationFailed("perm denied")
+        XCTAssertTrue(fileOp.errorDescription?.contains("perm") ?? false)
+    }
+
+    // MARK: - Helpers
+
+    /// Custom sound files currently present in the overridden sounds directory, sorted.
+    private func customSoundFiles() throws -> [String] {
+        guard FileManager.default.fileExists(atPath: tempSoundsDir.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(atPath: tempSoundsDir.path)
+            .filter { NotificationSoundManager.isCustomSoundName($0) }
+            .sorted()
+    }
+
+    /// A real AIFF copied from the system so `audioDuration(of:)` succeeds on the source.
+    private func makeValidAudioSource(named fileName: String) throws -> URL {
+        let source = URL(fileURLWithPath: "/System/Library/Sounds/Glass.aiff")
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw XCTSkip("No Glass.aiff available for test")
+        }
+        let destination = tempSoundsDir.appendingPathComponent(fileName)
+        try FileManager.default.copyItem(at: source, to: destination)
+        return destination
+    }
+
+    /// A non-audio source file. `audioDuration(of:)` returns nil for it, so the install relies
+    /// on the converter override (no system audio dependency, never an XCTSkip).
+    private func makeConvertibleSource(named fileName: String) throws -> URL {
+        let source = tempSoundsDir.appendingPathComponent(fileName)
+        try Data("source".utf8).write(to: source)
+        return source
+    }
+
+    private static func writeSilentAudio(duration: TimeInterval, to destination: URL) throws {
+        let sampleRate = 8_000.0
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1))
+        let file = try AVAudioFile(forWriting: destination, settings: format.settings)
+        let frameCount = AVAudioFrameCount((duration * sampleRate).rounded(.up))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+        buffer.frameLength = frameCount
+        try file.write(from: buffer)
+    }
+}

--- a/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
+++ b/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
@@ -5,6 +5,21 @@ import XCTest
 
 @MainActor
 final class SettingsWindowControllerTests: XCTestCase {
+    private var savedSoundsDirectoryOverride: URL?
+    private var tempSoundsDir: URL?
+
+    override func setUp() {
+        super.setUp()
+        // Notification-sound settings tests can trigger pruneCustomSounds, which scans the
+        // sounds directory. Redirect it at a temp dir so it never touches the real
+        // ~/Library/Sounds (and never deletes a developer's installed custom sound).
+        savedSoundsDirectoryOverride = NotificationSoundManager.soundsDirectoryOverride
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ZenttyTests.SettingsWindow.Sounds.\(UUID().uuidString)", isDirectory: true)
+        tempSoundsDir = tempDir
+        NotificationSoundManager.soundsDirectoryOverride = tempDir
+    }
+
     override func tearDown() {
         NSApp.windows.forEach { window in
             window.orderOut(nil)
@@ -14,6 +29,11 @@ final class SettingsWindowControllerTests: XCTestCase {
         let settled = XCTestExpectation(description: "AppKit window teardown settled")
         DispatchQueue.main.async { settled.fulfill() }
         _ = XCTWaiter.wait(for: [settled], timeout: 1.0)
+
+        NotificationSoundManager.soundsDirectoryOverride = savedSoundsDirectoryOverride
+        if let tempSoundsDir {
+            try? FileManager.default.removeItem(at: tempSoundsDir)
+        }
 
         super.tearDown()
     }
@@ -1519,6 +1539,107 @@ final class SettingsWindowControllerTests: XCTestCase {
             contentController.currentSectionViewController as? NotificationsSettingsSectionViewController
         )
         XCTAssertEqual(notificationsController.selectedSoundName, "Glass")
+    }
+
+    func test_notifications_section_shows_custom_sound_entry_without_display_name() throws {
+        let store = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
+        )
+        let customName = "zentty-custom-sample.caf"
+        try store.update { config in
+            config.notifications.soundName = customName
+            config.notifications.customSoundDisplayName = nil
+        }
+
+        let controller = SettingsWindowController(
+            configStore: store,
+            initialSection: .notifications
+        )
+        addTeardownBlock { controller.window?.close() }
+
+        controller.show(section: .notifications, sender: nil)
+
+        let contentController = try XCTUnwrap(
+            controller.window?.contentViewController as? SettingsViewController
+        )
+        contentController.loadViewIfNeeded()
+        waitForLayout()
+
+        let notificationsController = try XCTUnwrap(
+            contentController.currentSectionViewController as? NotificationsSettingsSectionViewController
+        )
+        XCTAssertEqual(notificationsController.selectedSoundName, customName)
+        XCTAssertEqual(notificationsController.selectedSoundTitle, "Custom: Custom Sound")
+        XCTAssertTrue(notificationsController.availableSoundNames.contains(customName))
+    }
+
+    func test_notifications_section_clearsCustomDisplayName_whenSwitchingToSystemSound() throws {
+        let store = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
+        )
+        try store.update { config in
+            config.notifications.soundName = "zentty-custom-sample.caf"
+            config.notifications.customSoundDisplayName = "Personal Chime.mp3"
+        }
+
+        let controller = SettingsWindowController(
+            configStore: store,
+            initialSection: .notifications
+        )
+        addTeardownBlock { controller.window?.close() }
+
+        controller.show(section: .notifications, sender: nil)
+
+        let contentController = try XCTUnwrap(
+            controller.window?.contentViewController as? SettingsViewController
+        )
+        contentController.loadViewIfNeeded()
+        waitForLayout()
+
+        let notificationsController = try XCTUnwrap(
+            contentController.currentSectionViewController as? NotificationsSettingsSectionViewController
+        )
+        notificationsController.selectSoundForTesting("Glass")
+
+        XCTAssertEqual(store.current.notifications.soundName, "Glass")
+        XCTAssertNil(store.current.notifications.customSoundDisplayName)
+        // Regression: the custom file is pruned on switch, so its stale "Custom: …" popup
+        // entry must be rebuilt away — otherwise reselecting it points at a deleted file.
+        XCTAssertFalse(notificationsController.availableSoundNames.contains("zentty-custom-sample.caf"))
+        XCTAssertEqual(notificationsController.selectedSoundName, "Glass")
+    }
+
+    func test_notifications_section_caps_custom_sound_popup_width_for_long_display_name() throws {
+        let longName = String(repeating: "VeryLongCustomNotificationSoundName", count: 8) + ".aiff"
+        let customName = "zentty-custom-sample.caf"
+        let store = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
+        )
+        try store.update { config in
+            config.notifications.soundName = customName
+            config.notifications.customSoundDisplayName = longName
+        }
+
+        let controller = SettingsWindowController(
+            configStore: store,
+            initialSection: .notifications
+        )
+        addTeardownBlock { controller.window?.close() }
+
+        controller.show(section: .notifications, sender: nil)
+
+        let contentController = try XCTUnwrap(
+            controller.window?.contentViewController as? SettingsViewController
+        )
+        contentController.loadViewIfNeeded()
+        waitForLayout()
+
+        let notificationsController = try XCTUnwrap(
+            contentController.currentSectionViewController as? NotificationsSettingsSectionViewController
+        )
+        XCTAssertEqual(notificationsController.selectedSoundName, customName)
+        XCTAssertLessThanOrEqual(notificationsController.soundPopupWidthForTesting, 260)
+        XCTAssertEqual(notificationsController.selectedSoundTooltip, "Custom: \(longName)")
     }
 
     func test_updates_privacy_section_defaults_update_channel_to_stable() throws {


### PR DESCRIPTION
Lets you pick any short audio file as the sound for agent-attention notifications, instead of being stuck with the built-in macOS set.

## What you get

- A **Choose Custom Audio File…** entry in Settings → Notifications. Pick a WAV/AIFF/CAF/MP3/M4A and it becomes your notification sound.
- The chosen file shows in the dropdown as **Custom: <filename>**, with a preview button to hear it before committing.
- Switch back to a system sound or Default whenever you want; the custom file gets cleaned up on its own.

## How it works

The picked file is converted with `afconvert` to a CAF and stored in `~/Library/Sounds`, which is where `UNNotificationSound` looks for custom sounds on a non-sandboxed app.

A few parts were fiddlier than they look:

- **Stale-sound cache.** macOS caches notification sounds by filename and will happily replay an old clip if you reuse a name. Each install mints a fresh `zentty-custom-<uuid>.caf`, so the system never serves a cached sound.
- **Transactional install.** Conversion happens in a temp subdirectory. Only after the selection is persisted does the new file get committed and the previous one pruned. If persistence fails, it rolls back and leaves the prior sound untouched.
- **Length cap.** Sources longer than 30s are rejected up front (macOS ignores longer notification sounds anyway), and the check runs against both the source and the converted output.
- **No pipe deadlock.** `afconvert`'s stderr is drained to EOF before waiting on the process, so a chatty error can't fill the buffer and hang the conversion.

`customSoundDisplayName` travels alongside `soundName` in the TOML config and is normalized away whenever the selection isn't a custom sound, so legacy configs and system-sound selections stay tidy.

## Testing

- `NotificationSoundManagerTests` — 21 tests, all green, including a real-`afconvert` case that confirms conversion errors are surfaced rather than swallowed or double-wrapped.
- Config round-trip and normalization in `AppConfigStoreTests`; UI behavior (custom entry, prune-on-switch, long-name width cap) in the hosted settings tests.
- Verified end to end on a local signed build: picked a file, previewed it, and confirmed a delivered notification plays the custom sound.