### PR TITLE
feat(menubar): render agent status as tinted pills

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		0D16861AE92EDD029878BCBA /* LibghosttyViewScrollRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0253BE7E0C15D8168A3491D /* LibghosttyViewScrollRoutingTests.swift */; };
 		0ED2C234E696C111255B212A /* LibghosttyAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2671C2153DB1DFA70522E94 /* LibghosttyAdapterTests.swift */; };
 		0F7546B851229BA46CC5DCFA /* TaskManagerRootPIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF50948B1AF143E418C8144 /* TaskManagerRootPIDTests.swift */; };
+		0FC2D0AD60F418A128BCDBFF /* MenuBarStatusPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */; };
 		1041B5CDF3EA5C978F3580BC /* PanePresentationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017D80D8C20309A5F3A34381 /* PanePresentationStateTests.swift */; };
 		105EFDDB2995F6500AE4DF21 /* BookmarkStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA071E0AD16A044F7C2F644 /* BookmarkStoreTests.swift */; };
 		1138CA064359EDBA85184C91 /* SidebarWindowRenderability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148ED833C80F99325F84B76D /* SidebarWindowRenderability.swift */; };
@@ -219,6 +220,7 @@
 		701C39983F9037EC0FCFFEE4 /* AgentIPCDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C15EEBB2B6060FDC3C8A05 /* AgentIPCDiscoveryTests.swift */; };
 		70376AF5E484DF3488252AF0 /* GenericProgressReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9CA26FCDC9E619509598B /* GenericProgressReducer.swift */; };
 		7092D2398E62448ACE248486 /* UpdatesPrivacySettingsSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D089E7F235904D263884DDE /* UpdatesPrivacySettingsSectionViewController.swift */; };
+		7115A33B57187951D4A21AC9 /* MenuBarStatusPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A737F0825F4D13EFA5A94495 /* MenuBarStatusPaletteTests.swift */; };
 		71A0F88C4E10E1934E39BBEE /* CommandPaletteBackdropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B012FD12A48B0C31EE3634C /* CommandPaletteBackdropTests.swift */; };
 		720727A2DA0A0EA0C32EC86E /* ClaudeHookSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344F4EE24498B605D2794B3 /* ClaudeHookSessionStore.swift */; };
 		727FCBEA281EEB8A67E1D89D /* ThirdPartyLicenseCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08406A303FAF5F5CC9447272 /* ThirdPartyLicenseCatalog.swift */; };
@@ -242,6 +244,7 @@
 		7CE41197B205C6CF70AFC9E6 /* WorkspaceRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771FEDEE47A531015097EFC7 /* WorkspaceRecipeTests.swift */; };
 		7DD2CFCE524E07DC28C237AA /* OpenCodeOverlayLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B5D7C3DB0445971F90C314 /* OpenCodeOverlayLayout.swift */; };
 		7ED5FFE55C98A62091A15F31 /* WorkspaceTemplateCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401E6BE21FE6807C37229D42 /* WorkspaceTemplateCaptureTests.swift */; };
+		7FBF99216EE72CD797AD778F /* MenuBarStatusKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED428A10BCCAA8E53954028A /* MenuBarStatusKindTests.swift */; };
 		8000FFBB2A9BB2606A89CD92 /* PaneLayoutSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF38754F46DCDAAF2D32B847 /* PaneLayoutSizing.swift */; };
 		80151BBA3E6C4EBB099460AB /* TerminalPaneHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F82AEDB8F3C8B3C5F014D8D /* TerminalPaneHostView.swift */; };
 		801ECD25402540B6F022BC3F /* KeyboardShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A94FD26FCD146425105D3FD /* KeyboardShortcutResolver.swift */; };
@@ -372,6 +375,7 @@
 		C48A3F29901F1422CD1FD7BC /* WorklanePeekSelectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D0A8D1F663DD3E708212FD /* WorklanePeekSelectionStateTests.swift */; };
 		C4F35E741F4A20FEA6E0B5C4 /* ZenttyCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F4075E849631130D781E1 /* ZenttyCLI.swift */; };
 		C57C067DB3163F1B09E7E72F /* PresentationReducerContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 058230B7588E412C374895C9 /* PresentationReducerContext.swift */; };
+		C57DE7B45F0BEFFDC8EC7371 /* MenuBarStatusPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */; };
 		C6172682FC0925AEB869BAE8 /* SettingsDetailContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E1D70DC92F5918033D26D /* SettingsDetailContainerViewController.swift */; };
 		C6FC32D748BD8642629B7321 /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C749B84F3DFA56E1241551D1 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A00B46795D7A242D2C9107 /* SettingsWindowController.swift */; };
@@ -392,6 +396,7 @@
 		CE2B404DBF241C89DDD59410 /* WorkspaceTemplateExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AE87CC3F4EB591D08B9A7 /* WorkspaceTemplateExporterTests.swift */; };
 		CEDAF9621D24A72064947A90 /* SidebarDropPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */; };
 		CEE6C654BA6B3D3F6FCFCAE2 /* PaneFocusHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CE6484C3A7D0F443F1FF10 /* PaneFocusHistoryController.swift */; };
+		CF13A269F19FE08C54099974 /* MenuBarStatusPillViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A01AB73197CAAE9E3D77A0 /* MenuBarStatusPillViewTests.swift */; };
 		D089F5366F16515499AD92E4 /* TmuxFormatRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8595DD2E83A66FAD57B960 /* TmuxFormatRendererTests.swift */; };
 		D0C44C284C252D950CB890FA /* WorklaneAttentionChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B72357CA80C59A161F7BE2 /* WorklaneAttentionChipView.swift */; };
 		D11DCA299BC0C937EAED0001 /* PaneSplitBehaviorOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7137F467A63630BC5D08A61 /* PaneSplitBehaviorOptionView.swift */; };
@@ -425,6 +430,7 @@
 		DFC95AFE3D93BC03C215FC0E /* WorkspaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E99517E9EAA4D99552859C /* WorkspaceTemplate.swift */; };
 		E091B391CA413E9D9C495CB6 /* WorklaneAttentionSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1BDFF2B71B2BDFF1DF60EA /* WorklaneAttentionSummaryBuilder.swift */; };
 		E092E65843424D641089F829 /* MenuBarAgentIconInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77EBA78773A292B4B9858DD5 /* MenuBarAgentIconInspector.swift */; };
+		E0D0A39516DBC6367F61E913 /* MenuBarStatusKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E6AFBC242DD01217E89E74 /* MenuBarStatusKind.swift */; };
 		E1386EB98808607C67C5A1DF /* WorklaneStoreColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0985A47CE1D3B2023DCD7265 /* WorklaneStoreColorTests.swift */; };
 		E1A94D74E0101FEB0BB2C79C /* PaneDragHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876089DABC0460791806F3E /* PaneDragHitTesting.swift */; };
 		E2A2053AF99C0387818EE8D8 /* WorklaneAttentionNotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6243B7C8B8AE57798C0BFC0 /* WorklaneAttentionNotificationCoordinator.swift */; };
@@ -729,6 +735,7 @@
 		7017B142217423B1126B8E2A /* WindowChromeRowLayoutPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeRowLayoutPlanner.swift; sourceTree = "<group>"; };
 		70234FD008E68026E8248FF5 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		70374B78DC61EC0409E65329 /* WorkspaceTemplateCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateCapture.swift; sourceTree = "<group>"; };
+		70A01AB73197CAAE9E3D77A0 /* MenuBarStatusPillViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPillViewTests.swift; sourceTree = "<group>"; };
 		7109E246F70CEBB6CD34E13F /* PassiveServerDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveServerDetection.swift; sourceTree = "<group>"; };
 		7120EEE7A0C06BD8315283B9 /* MainWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowControllerTests.swift; sourceTree = "<group>"; };
 		71F8B44C4FD096811C87A476 /* WorkspaceTemplateExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateExporter.swift; sourceTree = "<group>"; };
@@ -834,6 +841,7 @@
 		A69A77914C4BDFB2D9C46C3F /* ServerOpenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOpenService.swift; sourceTree = "<group>"; };
 		A6AC3A2E72C18928AB5ADE0B /* Zentty.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Zentty.entitlements; sourceTree = "<group>"; };
 		A6C4B3E5FFC590B5695ACC9C /* ServerListenerScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerListenerScannerTests.swift; sourceTree = "<group>"; };
+		A737F0825F4D13EFA5A94495 /* MenuBarStatusPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPaletteTests.swift; sourceTree = "<group>"; };
 		A78A6A6B85882097AFFAE3EE /* WorklaneStoreGitContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreGitContextTests.swift; sourceTree = "<group>"; };
 		A7C08D48B1B22F2F7C54A6BF /* ClosedPaneRestoreHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedPaneRestoreHelpers.swift; sourceTree = "<group>"; };
 		A823EFDA23F3B1CC30E29182 /* SettingsContentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContentHeaderView.swift; sourceTree = "<group>"; };
@@ -937,6 +945,8 @@
 		D58B814CCB50A93D946D971E /* JSONKeyAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONKeyAccess.swift; sourceTree = "<group>"; };
 		D649A4BADA61361091434B5E /* GhosttyThemeLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyThemeLibraryTests.swift; sourceTree = "<group>"; };
 		D66E9360C107E9A7D3F05652 /* ServerRelevance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelevance.swift; sourceTree = "<group>"; };
+		D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPillView.swift; sourceTree = "<group>"; };
+		D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPalette.swift; sourceTree = "<group>"; };
 		D9B72357CA80C59A161F7BE2 /* WorklaneAttentionChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionChipView.swift; sourceTree = "<group>"; };
 		D9C47104BD130C28676BA079 /* SparkleAppUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleAppUpdateController.swift; sourceTree = "<group>"; };
 		DAA052B6DDCA1EE9D9F58BC0 /* PaneLayoutPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutPreferencesTests.swift; sourceTree = "<group>"; };
@@ -964,12 +974,14 @@
 		E6F07CFD4C44251C24400B38 /* WorklaneSessionEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneSessionEnvironment.swift; sourceTree = "<group>"; };
 		E84313842197C75BCA9CE6E8 /* HermesTitleOverrideReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleOverrideReducer.swift; sourceTree = "<group>"; };
 		E89BAAA51D175EA4CC9174AA /* RecentCommandsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCommandsTracker.swift; sourceTree = "<group>"; };
+		E8E6AFBC242DD01217E89E74 /* MenuBarStatusKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusKind.swift; sourceTree = "<group>"; };
 		EA5DD7A1968777DF9C77029D /* LibghosttySelectionAutoscrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySelectionAutoscrollControllerTests.swift; sourceTree = "<group>"; };
 		EB3CF0787F91406CE385FEB3 /* PaneDragCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragCoordinator.swift; sourceTree = "<group>"; };
 		EB40B6883D6232A52132FA30 /* PresentationPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationPipeline.swift; sourceTree = "<group>"; };
 		EB869749410CBF86B97FA142 /* PaneAgentReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentReducer.swift; sourceTree = "<group>"; };
 		EC6B0309F5F34D3C1D5AE4AB /* ShellEscapingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEscapingTests.swift; sourceTree = "<group>"; };
 		ECBF42F4F7C6419804A6596F /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		ED428A10BCCAA8E53954028A /* MenuBarStatusKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusKindTests.swift; sourceTree = "<group>"; };
 		ED4764B4017D1DF1354C6FFB /* SidebarWidthPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPreference.swift; sourceTree = "<group>"; };
 		EDB71268537F60FF02894F12 /* WindowChromeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeViewTests.swift; sourceTree = "<group>"; };
 		EDDFDCEF34526A6C5882223E /* ClaudeStopNotificationRaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeStopNotificationRaceTests.swift; sourceTree = "<group>"; };
@@ -1055,7 +1067,10 @@
 				CFCF742A64E2965D1F7D4D01 /* MenuBarPaneSnapshotBuilder.swift */,
 				240CC203167EC1DDFBE0E4C7 /* MenuBarStatusController.swift */,
 				3E897BEAD66845ACE3042923 /* MenuBarStatusIconRenderer.swift */,
+				E8E6AFBC242DD01217E89E74 /* MenuBarStatusKind.swift */,
 				0B761568FFEEF65421C52232 /* MenuBarStatusMenuBuilder.swift */,
+				D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */,
+				D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */,
 				F56A80724E5ABFBF4B39D945 /* MenuBarStatusPresentation.swift */,
 			);
 			path = MenuBar;
@@ -1727,7 +1742,10 @@
 				34287004519EE20785262426 /* MenuBarFleetSummaryTests.swift */,
 				CE365ED4E3CCFFABE034B748 /* MenuBarPaneSnapshotBuilderTests.swift */,
 				97BCD869C25CE3A03966E138 /* MenuBarStatusIconRendererTests.swift */,
+				ED428A10BCCAA8E53954028A /* MenuBarStatusKindTests.swift */,
 				11A8C749F0AF726434D683DF /* MenuBarStatusMenuBuilderTests.swift */,
+				A737F0825F4D13EFA5A94495 /* MenuBarStatusPaletteTests.swift */,
+				70A01AB73197CAAE9E3D77A0 /* MenuBarStatusPillViewTests.swift */,
 				FD6F1935CE1012DD80C4954D /* MenuBarStatusPresentationTests.swift */,
 				88AFF05A04C7107BED6423F8 /* MoveToWorklaneMenuBuilderTests.swift */,
 				C771F4DD0F6077D2E72754D0 /* NotificationPopoverViewModelTests.swift */,
@@ -2120,7 +2138,10 @@
 				048F5C9C722C2885FE803161 /* MenuBarFleetSummaryTests.swift in Sources */,
 				28A580E86AE3F5FA21B503CE /* MenuBarPaneSnapshotBuilderTests.swift in Sources */,
 				45CA5569E440A611369B2B6C /* MenuBarStatusIconRendererTests.swift in Sources */,
+				7FBF99216EE72CD797AD778F /* MenuBarStatusKindTests.swift in Sources */,
 				1D47A2074AD0A7C5540125B0 /* MenuBarStatusMenuBuilderTests.swift in Sources */,
+				7115A33B57187951D4A21AC9 /* MenuBarStatusPaletteTests.swift in Sources */,
+				CF13A269F19FE08C54099974 /* MenuBarStatusPillViewTests.swift in Sources */,
 				308705984BE6FCCDC7CB25F8 /* MenuBarStatusPresentationTests.swift in Sources */,
 				B4C1005AD0D618DCB0A4C13D /* MoveToWorklaneMenuBuilderTests.swift in Sources */,
 				D4A63F03ECDA1CF35971F9DE /* NotificationPopoverViewModelTests.swift in Sources */,
@@ -2332,7 +2353,10 @@
 				97B65FB19965EAA7236041C5 /* MenuBarPaneSnapshotBuilder.swift in Sources */,
 				3DCEE3808B8F472765A37298 /* MenuBarStatusController.swift in Sources */,
 				AF08C5460E79E0F91F32FF41 /* MenuBarStatusIconRenderer.swift in Sources */,
+				E0D0A39516DBC6367F61E913 /* MenuBarStatusKind.swift in Sources */,
 				8245A5A1336710207AB3DD17 /* MenuBarStatusMenuBuilder.swift in Sources */,
+				0FC2D0AD60F418A128BCDBFF /* MenuBarStatusPalette.swift in Sources */,
+				C57DE7B45F0BEFFDC8EC7371 /* MenuBarStatusPillView.swift in Sources */,
 				6FF9CBE04C1698140C7DA14F /* MenuBarStatusPresentation.swift in Sources */,
 				196932893F690C070D526631 /* MockTerminalAdapter.swift in Sources */,
 				326A9B40B1266ADE43A7BD7B /* MoveToWorklaneMenuBuilder.swift in Sources */,

--- a/Zentty/UI/MenuBar/MenuBarFleetState.swift
+++ b/Zentty/UI/MenuBar/MenuBarFleetState.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Aggregate menu bar status across all agent panes (claude-status style).
-enum MenuBarFleetState: Equatable, Sendable {
+enum MenuBarFleetState: Equatable, Sendable, CaseIterable {
     case waiting
     case stopped
     case compacting

--- a/Zentty/UI/MenuBar/MenuBarStatusIconRenderer.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusIconRenderer.swift
@@ -131,10 +131,11 @@ enum MenuBarStatusIconRenderer {
     static func agentIconImage(
         for agentTool: AgentTool,
         fleetState: MenuBarFleetState,
-        appearance: NSAppearance? = nil
+        appearance: NSAppearance? = nil,
+        badged: Bool = true
     ) -> NSImage? {
         guard let baseImage = agentIconTemplateImage(for: agentTool) else { return nil }
-        guard fleetState != .idle else {
+        guard badged, fleetState != .idle else {
             return unbadgedAgentImage(
                 baseImage: baseImage,
                 canvasSide: agentIconSide,
@@ -176,56 +177,6 @@ enum MenuBarStatusIconRenderer {
         case .idle:
             return .secondaryLabelColor
         }
-    }
-
-    static func statusTextColor(
-        for fleetState: MenuBarFleetState,
-        appearance: NSAppearance? = nil
-    ) -> NSColor {
-        let badgeColor = dotColor(for: fleetState)
-        guard fleetState != .idle else { return badgeColor }
-
-        return readableStatusTextColor(
-            from: badgeColor,
-            on: menuTextContrastBackground(for: appearance)
-        )
-    }
-
-    private static func menuTextContrastBackground(for appearance: NSAppearance?) -> NSColor {
-        let appearanceName = appearance?.bestMatch(from: [.aqua, .darkAqua])
-        if appearanceName == .darkAqua {
-            return NSColor(calibratedWhite: 0.18, alpha: 1)
-        }
-        return NSColor(calibratedWhite: 0.74, alpha: 1)
-    }
-
-    private static func readableStatusTextColor(
-        from color: NSColor,
-        on background: NSColor,
-        minimumContrast: CGFloat = 4.5
-    ) -> NSColor {
-        let base = color.srgbClamped.withAlphaComponent(1)
-        guard base.contrastRatio(against: background) < minimumContrast else {
-            return base
-        }
-
-        let target = background.isDarkThemeColor ? NSColor.white : NSColor.black
-        var low: CGFloat = 0
-        var high: CGFloat = 1
-        var best = base.ensuringTextContrast(on: background, minimum: minimumContrast)
-
-        for _ in 0..<18 {
-            let amount = (low + high) / 2
-            let candidate = base.mixed(towards: target, amount: amount).withAlphaComponent(1)
-            if candidate.contrastRatio(against: background) >= minimumContrast {
-                best = candidate
-                high = amount
-            } else {
-                low = amount
-            }
-        }
-
-        return best
     }
 
     private static func menuBarResourceBundles() -> [Bundle] {

--- a/Zentty/UI/MenuBar/MenuBarStatusKind.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusKind.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Visual status of an agent pane as shown in the menu-bar dropdown.
+///
+/// Derived from a pane's ``MenuBarFleetState`` plus its
+/// ``WorklaneAttentionState``. The only state the fleet state cannot express on
+/// its own is "ready" — an idle pane that has just finished and is awaiting the
+/// user's next move — which we surface distinctly (a blue pill) rather than
+/// letting it read as plain idle.
+enum MenuBarStatusKind: String, CaseIterable, Equatable, Sendable {
+    case running
+    case compacting
+    case needsInput
+    case stoppedEarly
+    case ready
+    case idle
+
+    /// Resolve the status kind from the two fields the snapshot already carries.
+    ///
+    /// `fleetState` is authoritative for everything except distinguishing
+    /// "ready" from "idle": both are `.idle`, separated only by the pane's
+    /// `attentionState == .ready`.
+    static func resolve(
+        fleetState: MenuBarFleetState,
+        attentionState: WorklaneAttentionState?
+    ) -> MenuBarStatusKind {
+        switch fleetState {
+        case .active:
+            return .running
+        case .compacting:
+            return .compacting
+        case .waiting:
+            return .needsInput
+        case .stopped:
+            return .stoppedEarly
+        case .idle:
+            return attentionState == .ready ? .ready : .idle
+        }
+    }
+
+    init(snapshot: MenuBarPaneSnapshot) {
+        self = MenuBarStatusKind.resolve(
+            fleetState: snapshot.fleetState,
+            attentionState: snapshot.attentionState
+        )
+    }
+}

--- a/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
@@ -346,7 +346,12 @@ private final class MenuBarAgentRowView: NSView {
         titleLabel.frame = NSRect(x: textX, y: 21, width: textWidth, height: titleHeight)
         contextLabel.frame = NSRect(x: textX, y: 5, width: textWidth, height: contextHeight)
 
-        let pillY = hasAge ? 22 : ((bounds.height - pillSize.height) / 2).rounded()
+        // On two-line (timestamp) rows, center the pill on the title line so its
+        // box matches the title's and the age sits on the subtitle line — equal
+        // padding above/below. On single-line rows, center it in the row.
+        let pillY = hasAge
+            ? (titleLabel.frame.midY - pillSize.height / 2).rounded()
+            : ((bounds.height - pillSize.height) / 2).rounded()
         pillView.frame = NSRect(
             x: rightEdge - pillWidth,
             y: pillY,

--- a/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
@@ -200,8 +200,6 @@ private final class MenuBarAgentRowView: NSView {
         static let iconTextSpacing: CGFloat = 10
         // Gap between the title/context column and the right-aligned status block.
         static let columnGap: CGFloat = 16
-        // Width reserved left of the status text for the task-progress indicator.
-        static let progressLeadingWidth: CGFloat = 13
     }
 
     private let snapshot: MenuBarPaneSnapshot
@@ -214,10 +212,8 @@ private final class MenuBarAgentRowView: NSView {
     private let iconView = MenuBarAgentIconView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let contextLabel = NSTextField(labelWithString: "")
-    private let statusLabel = NSTextField(labelWithString: "")
+    private let pillView = MenuBarStatusPillView()
     private let ageLabel = NSTextField(labelWithString: "")
-    private let progressIndicator = SidebarTaskProgressIndicatorView()
-    private let progressRevealView = SidebarTaskProgressRevealView()
     private var trackingAreaValue: NSTrackingArea?
     private var isHovered = false
 #if DEBUG
@@ -301,10 +297,7 @@ private final class MenuBarAgentRowView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        statusLabel.textColor = MenuBarStatusIconRenderer.statusTextColor(
-            for: snapshot.fleetState,
-            appearance: menuAppearance ?? effectiveAppearance
-        )
+        configurePill()
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -332,19 +325,19 @@ private final class MenuBarAgentRowView: NSView {
 
         let rightEdge = bounds.width - Metrics.horizontalPadding
         let textX = iconView.frame.maxX + Metrics.iconTextSpacing
-        let statusY: CGFloat = ageLabel.stringValue.isEmpty ? 13 : 22
+        let hasAge = ageLabel.stringValue.isEmpty == false
 
-        // Size the status/age block to its actual content and hug the right edge,
+        // Right block: the status pill, with the age label beneath it when
+        // present. Size it to the pill's actual content and hug the right edge,
         // so short statuses (e.g. "Idle") don't reserve a wide empty column. The
         // title/context then fill the remaining width up to a small gap.
-        // Measure the text directly (not via intrinsicContentSize): a truncating
-        // label that gets a narrow frame during the menu's sizing passes reports a
-        // shrunken intrinsicContentSize, which would clip the status text.
-        let statusTextWidth = measuredTextWidth(of: statusLabel)
+        let pillSize = pillView.intrinsicContentSize
         let ageTextWidth = measuredTextWidth(of: ageLabel)
-        let revealWidth = (progressIndicator.isHidden || isHovered == false) ? 0 : progressRevealView.expandedWidth
-        let progressWidth: CGFloat = progressIndicator.isHidden ? 0 : (Metrics.progressLeadingWidth + revealWidth)
-        let rightBlockWidth = max(progressWidth + statusTextWidth, ageTextWidth)
+        // Never let an unusually long status push the pill into the icon/title:
+        // cap its width at the space right of the title start and let the pill
+        // truncate its own label.
+        let pillWidth = min(pillSize.width, max(0, rightEdge - textX))
+        let rightBlockWidth = max(pillWidth, ageTextWidth)
         let rightBlockX = rightEdge - rightBlockWidth
 
         let textWidth = max(0, rightBlockX - textX - Metrics.columnGap)
@@ -353,13 +346,13 @@ private final class MenuBarAgentRowView: NSView {
         titleLabel.frame = NSRect(x: textX, y: 21, width: textWidth, height: titleHeight)
         contextLabel.frame = NSRect(x: textX, y: 5, width: textWidth, height: contextHeight)
 
-        let statusTextX = rightEdge - statusTextWidth
-        statusLabel.frame = NSRect(x: statusTextX, y: statusY, width: statusTextWidth, height: 17)
-        if progressIndicator.isHidden == false {
-            let revealX = statusTextX - revealWidth
-            progressRevealView.frame = NSRect(x: revealX, y: statusY, width: revealWidth, height: 16)
-            progressIndicator.frame = NSRect(x: revealX - Metrics.progressLeadingWidth, y: statusY + 2, width: 11, height: 11)
-        }
+        let pillY = hasAge ? 22 : ((bounds.height - pillSize.height) / 2).rounded()
+        pillView.frame = NSRect(
+            x: rightEdge - pillWidth,
+            y: pillY,
+            width: pillWidth,
+            height: pillSize.height
+        )
         ageLabel.frame = NSRect(x: rightEdge - ageTextWidth, y: 5, width: ageTextWidth, height: 16)
     }
 
@@ -377,22 +370,17 @@ private final class MenuBarAgentRowView: NSView {
         contextLabel.lineBreakMode = .byTruncatingMiddle
         contextLabel.maximumNumberOfLines = 1
 
-        statusLabel.font = .systemFont(ofSize: 12, weight: .medium)
-        statusLabel.alignment = .right
-        statusLabel.lineBreakMode = .byTruncatingTail
-        statusLabel.maximumNumberOfLines = 1
-
         ageLabel.font = .systemFont(ofSize: 11, weight: .regular)
         ageLabel.textColor = .secondaryLabelColor
         ageLabel.alignment = .right
         ageLabel.lineBreakMode = .byTruncatingTail
         ageLabel.maximumNumberOfLines = 1
 
-        progressIndicator.onHoverEntered = { [weak self] in
+        pillView.onProgressHoverEntered = { [weak self] in
             self?.setHovered(true)
         }
 
-        [iconView, titleLabel, contextLabel, statusLabel, ageLabel, progressIndicator, progressRevealView].forEach {
+        [iconView, titleLabel, contextLabel, pillView, ageLabel].forEach {
             addSubview($0)
         }
     }
@@ -405,30 +393,23 @@ private final class MenuBarAgentRowView: NSView {
         )
         titleLabel.stringValue = snapshot.primaryText
         contextLabel.stringValue = snapshot.contextText ?? snapshot.agentTool.displayName
-        statusLabel.stringValue = snapshot.statusLabel
-        statusLabel.textColor = MenuBarStatusIconRenderer.statusTextColor(
-            for: snapshot.fleetState,
-            appearance: menuAppearance ?? effectiveAppearance
-        )
         ageLabel.stringValue = ageText(for: snapshot)
-
-        let progressColor = snapshot.fleetState == .idle ? NSColor.secondaryLabelColor : NSColor.systemGreen
-        progressIndicator.configure(
-            taskProgress: snapshot.taskProgress,
-            color: progressColor,
-            animated: false,
-            reducedMotion: true
-        )
-        progressRevealView.configure(
-            taskProgress: snapshot.taskProgress,
-            color: progressColor,
-            font: .systemFont(ofSize: 11, weight: .regular)
-        )
-        progressRevealView.setRevealed(false, animated: false, reducedMotion: true)
+        configurePill()
 
         setAccessibilityRole(.menuItem)
         setAccessibilityLabel(MenuBarStatusMenuBuilder.itemTitle(for: snapshot))
         setAccessibilityValue(snapshot.contextText)
+    }
+
+    private func configurePill() {
+        pillView.configure(
+            kind: MenuBarStatusKind(snapshot: snapshot),
+            text: snapshot.statusLabel,
+            taskProgress: snapshot.taskProgress,
+            appearance: menuAppearance ?? effectiveAppearance,
+            reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+        )
+        needsLayout = true
     }
 
     /// Full rendered width of a label's text, independent of its current frame
@@ -441,7 +422,7 @@ private final class MenuBarAgentRowView: NSView {
     private func setHovered(_ hovered: Bool) {
         guard isHovered != hovered else { return }
         isHovered = hovered
-        progressRevealView.setRevealed(hovered, animated: true, reducedMotion: false)
+        pillView.setRevealed(hovered, animated: true, reducedMotion: false)
         needsLayout = true
         needsDisplay = true
     }
@@ -542,7 +523,8 @@ private final class MenuBarAgentIconView: NSView {
         imageView.image = MenuBarStatusIconRenderer.agentIconImage(
             for: agentTool,
             fleetState: fleetState,
-            appearance: menuAppearance ?? effectiveAppearance
+            appearance: menuAppearance ?? effectiveAppearance,
+            badged: false
         )
     }
 }

--- a/Zentty/UI/MenuBar/MenuBarStatusPalette.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusPalette.swift
@@ -1,0 +1,123 @@
+import AppKit
+
+/// Curated, menu-native status colors for the dropdown's tinted pills.
+///
+/// Each ``MenuBarStatusKind`` has explicit light and dark variants, hand-tuned
+/// for legibility on the translucent status menu (raw Apple system colors get
+/// muddy when contrast-corrected against the real vibrancy material). Two hues
+/// per kind: a deep/bright **text** color for the label and leading dot, and a
+/// vivid **tint** base for the pill fill and border. Keeping them separate is
+/// what keeps the label readable on top of its own fill.
+///
+/// Colors are resolved concretely from an explicit appearance (the menu forces
+/// its appearance, and the pill is layer-backed), so there are no dynamic
+/// `NSColor` / `CALayer` resolution surprises. The hex-packing mirrors
+/// ``WorklaneColor``.
+enum MenuBarStatusPalette {
+    /// Pill fill/border opacity over the translucent menu. When the user has
+    /// Reduce Transparency on, both push toward opaque so the pill reads without
+    /// vibrancy behind it.
+    private enum Alpha {
+        static let fillLight: CGFloat = 0.15
+        static let fillDark: CGFloat = 0.18
+        static let borderLight: CGFloat = 0.32
+        static let borderDark: CGFloat = 0.34
+        static let fillReduced: CGFloat = 0.30
+        static let borderReduced: CGFloat = 0.55
+    }
+
+    private struct Hex {
+        let dark: UInt32
+        let light: UInt32
+    }
+
+    /// Label + leading-dot color. Deep on light, bright on dark.
+    private static func textHex(for kind: MenuBarStatusKind) -> Hex {
+        switch kind {
+        case .running, .compacting:
+            return Hex(dark: 0x46E07E, light: 0x1B8A3E)
+        case .needsInput:
+            return Hex(dark: 0xFFC24B, light: 0x9A6400)
+        case .stoppedEarly:
+            return Hex(dark: 0xFF7A6E, light: 0xC5372C)
+        case .ready:
+            return Hex(dark: 0x5AB0FF, light: 0x0A66D6)
+        case .idle:
+            return Hex(dark: 0xA4A4AA, light: 0x6B6B70)
+        }
+    }
+
+    /// Fill + border tint base — the vivid mid hue, lighter than the text color.
+    private static func tintHex(for kind: MenuBarStatusKind) -> Hex {
+        switch kind {
+        case .running, .compacting:
+            return Hex(dark: 0x30C864, light: 0x30B450)
+        case .needsInput:
+            return Hex(dark: 0xFFB428, light: 0xFFAA14)
+        case .stoppedEarly:
+            return Hex(dark: 0xFF5A50, light: 0xFF463C)
+        case .ready:
+            return Hex(dark: 0x288CFF, light: 0x007AFF)
+        case .idle:
+            return Hex(dark: 0x969E9E, light: 0x787880)
+        }
+    }
+
+    // MARK: - Concrete resolution (single source of truth)
+
+    static func labelColor(for kind: MenuBarStatusKind, isDark: Bool) -> NSColor {
+        color(packed(textHex(for: kind), isDark: isDark))
+    }
+
+    /// The leading dot matches the label color.
+    static func dotColor(for kind: MenuBarStatusKind, isDark: Bool) -> NSColor {
+        labelColor(for: kind, isDark: isDark)
+    }
+
+    static func fillColor(
+        for kind: MenuBarStatusKind,
+        isDark: Bool,
+        reduceTransparency: Bool
+    ) -> NSColor {
+        let alpha = reduceTransparency
+            ? Alpha.fillReduced
+            : (isDark ? Alpha.fillDark : Alpha.fillLight)
+        return color(packed(tintHex(for: kind), isDark: isDark), alpha: alpha)
+    }
+
+    static func borderColor(
+        for kind: MenuBarStatusKind,
+        isDark: Bool,
+        reduceTransparency: Bool
+    ) -> NSColor {
+        let alpha = reduceTransparency
+            ? Alpha.borderReduced
+            : (isDark ? Alpha.borderDark : Alpha.borderLight)
+        return color(packed(tintHex(for: kind), isDark: isDark), alpha: alpha)
+    }
+
+    /// Whether the given appearance should resolve to the dark variants.
+    static func isDark(_ appearance: NSAppearance?) -> Bool {
+        appearance?.bestMatch(from: [
+            .darkAqua,
+            .vibrantDark,
+            .accessibilityHighContrastDarkAqua,
+            .accessibilityHighContrastVibrantDark,
+        ]) != nil
+    }
+
+    // MARK: - Helpers
+
+    private static func packed(_ hex: Hex, isDark: Bool) -> UInt32 {
+        isDark ? hex.dark : hex.light
+    }
+
+    private static func color(_ packed: UInt32, alpha: CGFloat = 1) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat((packed >> 16) & 0xFF) / 255.0,
+            green: CGFloat((packed >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(packed & 0xFF) / 255.0,
+            alpha: alpha
+        )
+    }
+}

--- a/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
@@ -142,22 +142,22 @@ final class MenuBarStatusPillView: NSView {
         }
         x += leadingWidth + Metrics.leadingToContentGap
 
+        // Vertically center the label, and place the hover-reveal detail in the
+        // same band so its "N/M tasks ·" text shares the label's baseline
+        // instead of riding high in a full-height box.
+        let labelHeight = ceil(label.fittingSize.height)
+        let contentY = ((bounds.height - labelHeight) / 2).rounded()
+
         let revealWidth = (hasProgress && isRevealed) ? revealView.expandedWidth : 0
-        revealView.frame = NSRect(x: x, y: 0, width: revealWidth, height: bounds.height)
+        revealView.frame = NSRect(x: x, y: contentY, width: revealWidth, height: labelHeight)
         x += revealWidth
 
-        let labelHeight = ceil(label.fittingSize.height)
         // Clamp to the room left inside the pill so the label truncates (it's
         // .byTruncatingTail) instead of being hard-clipped by the capsule when
         // the row frames the pill narrower than its intrinsic width.
         let availableLabelWidth = max(0, bounds.width - x - Metrics.paddingTrailing)
         let labelWidth = min(ceil(label.fittingSize.width), availableLabelWidth)
-        label.frame = NSRect(
-            x: x,
-            y: ((bounds.height - labelHeight) / 2).rounded(),
-            width: labelWidth,
-            height: labelHeight
-        )
+        label.frame = NSRect(x: x, y: contentY, width: labelWidth, height: labelHeight)
     }
 
     private func setup() {

--- a/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
@@ -147,7 +147,11 @@ final class MenuBarStatusPillView: NSView {
         x += revealWidth
 
         let labelHeight = ceil(label.fittingSize.height)
-        let labelWidth = ceil(label.fittingSize.width)
+        // Clamp to the room left inside the pill so the label truncates (it's
+        // .byTruncatingTail) instead of being hard-clipped by the capsule when
+        // the row frames the pill narrower than its intrinsic width.
+        let availableLabelWidth = max(0, bounds.width - x - Metrics.paddingTrailing)
+        let labelWidth = min(ceil(label.fittingSize.width), availableLabelWidth)
         label.frame = NSRect(
             x: x,
             y: ((bounds.height - labelHeight) / 2).rounded(),

--- a/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusPillView.swift
@@ -1,0 +1,203 @@
+import AppKit
+
+/// A tinted status pill for a menu-bar dropdown row: a rounded capsule (fill +
+/// border in the status hue) with a leading dot — or the hosted task-progress
+/// spinner while a task is running — followed by the status label. On hover it
+/// reveals the "N/M tasks" detail, matching the sidebar behavior.
+///
+/// Colors come from ``MenuBarStatusPalette`` resolved against the menu's
+/// appearance. The view lays its content out manually and reports an
+/// ``intrinsicContentSize`` so the row can right-align and size it.
+@MainActor
+final class MenuBarStatusPillView: NSView {
+    private enum Metrics {
+        static let height: CGFloat = 18
+        static let cornerRadius: CGFloat = 9
+        static let paddingLeading: CGFloat = 7
+        static let paddingTrailing: CGFloat = 9
+        static let dotSide: CGFloat = 6
+        static let spinnerSide = SidebarTaskProgressIndicatorMetrics.sideLength
+        static let leadingToContentGap: CGFloat = 5
+        static let borderWidth: CGFloat = 1
+    }
+
+    private let dotLayer = CALayer()
+    private let progressIndicator = SidebarTaskProgressIndicatorView()
+    private let revealView = SidebarTaskProgressRevealView()
+    private let label = NSTextField(labelWithString: "")
+
+    private var kind: MenuBarStatusKind = .idle
+    private var hasProgress = false
+    private var isRevealed = false
+
+    // Applied colors, retained for the debug snapshot / tests.
+    private var appliedLabelColor: NSColor?
+    private var appliedFillColor: NSColor?
+    private var appliedBorderColor: NSColor?
+    private var appliedDotColor: NSColor?
+
+    /// Forwarded so the row can drive hover-reveal of the progress detail.
+    var onProgressHoverEntered: (() -> Void)? {
+        get { progressIndicator.onHoverEntered }
+        set { progressIndicator.onHoverEntered = newValue }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Keep pill colors exact (no menu vibrancy graying the tinted hues).
+    override var allowsVibrancy: Bool { false }
+
+    override var intrinsicContentSize: NSSize {
+        let leadingWidth = hasProgress ? Metrics.spinnerSide : Metrics.dotSide
+        let revealWidth = (hasProgress && isRevealed) ? revealView.expandedWidth : 0
+        let width = Metrics.paddingLeading
+            + leadingWidth
+            + Metrics.leadingToContentGap
+            + revealWidth
+            + ceil(label.fittingSize.width)
+            + Metrics.paddingTrailing
+        return NSSize(width: ceil(width), height: Metrics.height)
+    }
+
+    func configure(
+        kind: MenuBarStatusKind,
+        text: String,
+        taskProgress: PaneAgentTaskProgress?,
+        appearance: NSAppearance?,
+        reduceTransparency: Bool
+    ) {
+        self.kind = kind
+        hasProgress = taskProgress != nil
+
+        let isDark = MenuBarStatusPalette.isDark(appearance)
+        let labelColor = MenuBarStatusPalette.labelColor(for: kind, isDark: isDark)
+        let fillColor = MenuBarStatusPalette.fillColor(for: kind, isDark: isDark, reduceTransparency: reduceTransparency)
+        let borderColor = MenuBarStatusPalette.borderColor(for: kind, isDark: isDark, reduceTransparency: reduceTransparency)
+        let dotColor = MenuBarStatusPalette.dotColor(for: kind, isDark: isDark)
+
+        appliedLabelColor = labelColor
+        appliedFillColor = fillColor
+        appliedBorderColor = borderColor
+        appliedDotColor = dotColor
+
+        label.stringValue = text
+        label.textColor = labelColor
+
+        layer?.backgroundColor = fillColor.cgColor
+        layer?.borderColor = borderColor.cgColor
+
+        dotLayer.isHidden = hasProgress
+        dotLayer.backgroundColor = dotColor.cgColor
+
+        // The spinner hides itself when taskProgress is nil. Tint it to match
+        // the dot/label so the running pill reads as one color.
+        progressIndicator.configure(
+            taskProgress: taskProgress,
+            color: dotColor,
+            animated: false,
+            reducedMotion: true
+        )
+        revealView.configure(
+            taskProgress: taskProgress,
+            color: labelColor,
+            font: .systemFont(ofSize: 11, weight: .regular)
+        )
+        revealView.setRevealed(isRevealed, animated: false, reducedMotion: true)
+
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    /// Reveal/hide the "N/M tasks" detail (driven by the row's hover state).
+    func setRevealed(_ revealed: Bool, animated: Bool, reducedMotion: Bool) {
+        guard isRevealed != revealed else { return }
+        isRevealed = revealed
+        revealView.setRevealed(revealed, animated: animated, reducedMotion: reducedMotion)
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+
+        var x = Metrics.paddingLeading
+
+        let leadingWidth = hasProgress ? Metrics.spinnerSide : Metrics.dotSide
+        let leadingY = ((bounds.height - leadingWidth) / 2).rounded()
+        if hasProgress {
+            progressIndicator.frame = NSRect(x: x, y: leadingY, width: Metrics.spinnerSide, height: Metrics.spinnerSide)
+        } else {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            dotLayer.frame = NSRect(x: x, y: leadingY, width: Metrics.dotSide, height: Metrics.dotSide)
+            CATransaction.commit()
+        }
+        x += leadingWidth + Metrics.leadingToContentGap
+
+        let revealWidth = (hasProgress && isRevealed) ? revealView.expandedWidth : 0
+        revealView.frame = NSRect(x: x, y: 0, width: revealWidth, height: bounds.height)
+        x += revealWidth
+
+        let labelHeight = ceil(label.fittingSize.height)
+        let labelWidth = ceil(label.fittingSize.width)
+        label.frame = NSRect(
+            x: x,
+            y: ((bounds.height - labelHeight) / 2).rounded(),
+            width: labelWidth,
+            height: labelHeight
+        )
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = Metrics.cornerRadius
+        layer?.borderWidth = Metrics.borderWidth
+        layer?.masksToBounds = true
+
+        dotLayer.cornerRadius = Metrics.dotSide / 2
+        layer?.addSublayer(dotLayer)
+
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.alignment = .left
+
+        progressIndicator.isHidden = true
+
+        [revealView, progressIndicator, label].forEach(addSubview)
+    }
+
+    // MARK: - Testing
+
+    struct DebugSnapshot {
+        let kind: MenuBarStatusKind
+        let labelText: String
+        let labelColor: NSColor?
+        let fillColor: NSColor?
+        let borderColor: NSColor?
+        let dotColor: NSColor?
+        let isProgressVisible: Bool
+        let intrinsicSize: NSSize
+    }
+
+    var debugSnapshotForTesting: DebugSnapshot {
+        DebugSnapshot(
+            kind: kind,
+            labelText: label.stringValue,
+            labelColor: appliedLabelColor,
+            fillColor: appliedFillColor,
+            borderColor: appliedBorderColor,
+            dotColor: appliedDotColor,
+            isProgressVisible: hasProgress && progressIndicator.isHidden == false,
+            intrinsicSize: intrinsicContentSize
+        )
+    }
+}

--- a/ZenttyLogicTests/MenuBarStatusKindTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusKindTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import Zentty
+
+final class MenuBarStatusKindTests: XCTestCase {
+    // MARK: resolve(fleetState:attentionState:)
+
+    /// Every attentionState value, including nil, that resolve must handle.
+    private let allAttentionStates: [WorklaneAttentionState?] = [
+        nil, .needsInput, .unresolvedStop, .ready, .running,
+    ]
+
+    func test_resolve_active_is_running_for_all_attention_states() {
+        for attention in allAttentionStates {
+            XCTAssertEqual(
+                MenuBarStatusKind.resolve(fleetState: .active, attentionState: attention),
+                .running,
+                "active should resolve to .running for attentionState \(String(describing: attention))"
+            )
+        }
+    }
+
+    func test_resolve_compacting_is_compacting_for_all_attention_states() {
+        for attention in allAttentionStates {
+            XCTAssertEqual(
+                MenuBarStatusKind.resolve(fleetState: .compacting, attentionState: attention),
+                .compacting,
+                "compacting should resolve to .compacting for attentionState \(String(describing: attention))"
+            )
+        }
+    }
+
+    func test_resolve_waiting_is_needsInput_for_all_attention_states() {
+        for attention in allAttentionStates {
+            XCTAssertEqual(
+                MenuBarStatusKind.resolve(fleetState: .waiting, attentionState: attention),
+                .needsInput,
+                "waiting should resolve to .needsInput for attentionState \(String(describing: attention))"
+            )
+        }
+    }
+
+    func test_resolve_stopped_is_stoppedEarly_for_all_attention_states() {
+        for attention in allAttentionStates {
+            XCTAssertEqual(
+                MenuBarStatusKind.resolve(fleetState: .stopped, attentionState: attention),
+                .stoppedEarly,
+                "stopped should resolve to .stoppedEarly for attentionState \(String(describing: attention))"
+            )
+        }
+    }
+
+    func test_resolve_idle_with_ready_is_ready() {
+        XCTAssertEqual(
+            MenuBarStatusKind.resolve(fleetState: .idle, attentionState: .ready),
+            .ready
+        )
+    }
+
+    func test_resolve_idle_with_nil_is_idle() {
+        XCTAssertEqual(
+            MenuBarStatusKind.resolve(fleetState: .idle, attentionState: nil),
+            .idle
+        )
+    }
+
+    func test_resolve_idle_with_needsInput_is_idle() {
+        // fleetState is authoritative: attentionState only promotes idle -> ready.
+        XCTAssertEqual(
+            MenuBarStatusKind.resolve(fleetState: .idle, attentionState: .needsInput),
+            .idle
+        )
+    }
+
+    func test_resolve_idle_with_unresolvedStop_is_idle() {
+        XCTAssertEqual(
+            MenuBarStatusKind.resolve(fleetState: .idle, attentionState: .unresolvedStop),
+            .idle
+        )
+    }
+
+    func test_resolve_idle_with_running_is_idle() {
+        XCTAssertEqual(
+            MenuBarStatusKind.resolve(fleetState: .idle, attentionState: .running),
+            .idle
+        )
+    }
+
+    /// Exhaustive 5 fleet states x 5 attentionState values = 25 assertions in one sweep,
+    /// guarding the full contract against any regression.
+    func test_resolve_full_matrix_is_exhaustive() {
+        for fleetState in MenuBarFleetState.allCases {
+            for attention in allAttentionStates {
+                let expected: MenuBarStatusKind
+                switch fleetState {
+                case .active:
+                    expected = .running
+                case .compacting:
+                    expected = .compacting
+                case .waiting:
+                    expected = .needsInput
+                case .stopped:
+                    expected = .stoppedEarly
+                case .idle:
+                    expected = attention == .ready ? .ready : .idle
+                }
+
+                XCTAssertEqual(
+                    MenuBarStatusKind.resolve(fleetState: fleetState, attentionState: attention),
+                    expected,
+                    "fleetState \(fleetState) + attentionState \(String(describing: attention))"
+                )
+            }
+        }
+    }
+
+    // MARK: init(snapshot:)
+
+    func test_init_snapshot_forwards_idle_with_ready_to_ready() {
+        let snapshot = makeSnapshot(fleetState: .idle, attentionState: .ready)
+        XCTAssertEqual(MenuBarStatusKind(snapshot: snapshot), .ready)
+    }
+
+    func test_init_snapshot_forwards_idle_with_nil_to_idle() {
+        let snapshot = makeSnapshot(fleetState: .idle, attentionState: nil)
+        XCTAssertEqual(MenuBarStatusKind(snapshot: snapshot), .idle)
+    }
+
+    func test_init_snapshot_forwards_idle_with_needsInput_to_idle() {
+        let snapshot = makeSnapshot(fleetState: .idle, attentionState: .needsInput)
+        XCTAssertEqual(MenuBarStatusKind(snapshot: snapshot), .idle)
+    }
+
+    func test_init_snapshot_forwards_active_to_running() {
+        // Proves init reads fleetState (not just attentionState): active wins over a
+        // .ready attentionState that would otherwise promote idle.
+        let snapshot = makeSnapshot(fleetState: .active, attentionState: .ready)
+        XCTAssertEqual(MenuBarStatusKind(snapshot: snapshot), .running)
+    }
+
+    // MARK: Helpers
+
+    private func makeSnapshot(
+        fleetState: MenuBarFleetState,
+        attentionState: WorklaneAttentionState?
+    ) -> MenuBarPaneSnapshot {
+        MenuBarPaneSnapshot(
+            windowID: WindowID("win-test"),
+            windowTitle: "Window 1",
+            worklaneID: WorklaneID("wl-test"),
+            paneID: PaneID("pn-test"),
+            agentTool: .claudeCode,
+            primaryText: "Claude Code",
+            contextText: "zentty · main",
+            statusLabel: "Status",
+            attentionState: attentionState,
+            fleetState: fleetState,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            taskProgress: nil,
+            sortPriority: 0
+        )
+    }
+}

--- a/ZenttyLogicTests/MenuBarStatusMenuBuilderTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusMenuBuilderTests.swift
@@ -74,63 +74,34 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
         )
     }
 
-    func test_status_label_uses_readable_badge_hue_for_waiting_rows() {
-        let menu = NSMenu()
-        menu.appearance = NSAppearance(named: .aqua)
-        let waiting = paneSnapshot(fleetState: .waiting, statusLabel: "Needs decision")
-
-        MenuBarStatusMenuBuilder.rebuild(
-            menu: menu,
-            snapshots: [waiting],
-            fleetSummary: MenuBarFleetSummary.from(snapshots: [waiting]),
-            target: nil,
-            rowAction: #selector(NSObject.description),
-            settingsAction: #selector(NSObject.description)
-        )
-
-        let row = try! XCTUnwrap(menu.items[1].view)
+    func test_status_pill_uses_palette_color_for_waiting_rows() {
+        let row = buildRow(for: paneSnapshot(fleetState: .waiting, statusLabel: "Needs decision"))
         let statusLabel = try! XCTUnwrap(textFields(in: row).first { $0.stringValue == "Needs decision" })
-        assertReadableStatusColor(statusLabel.textColor, fleetState: .waiting)
+        assertPillLabelColor(statusLabel.textColor, kind: .needsInput)
     }
 
-    func test_status_label_uses_readable_badge_hue_for_running_rows() {
-        let menu = NSMenu()
-        menu.appearance = NSAppearance(named: .aqua)
-        let running = paneSnapshot(fleetState: .active, statusLabel: "Running")
-
-        MenuBarStatusMenuBuilder.rebuild(
-            menu: menu,
-            snapshots: [running],
-            fleetSummary: MenuBarFleetSummary.from(snapshots: [running]),
-            target: nil,
-            rowAction: #selector(NSObject.description),
-            settingsAction: #selector(NSObject.description)
-        )
-
-        let row = try! XCTUnwrap(menu.items[1].view)
+    func test_status_pill_uses_palette_color_for_running_rows() {
+        let row = buildRow(for: paneSnapshot(fleetState: .active, statusLabel: "Running"))
         let statusLabel = try! XCTUnwrap(textFields(in: row).first { $0.stringValue == "Running" })
-        assertReadableStatusColor(statusLabel.textColor, fleetState: .active)
+        assertPillLabelColor(statusLabel.textColor, kind: .running)
     }
 
-    func test_status_label_uses_badge_color_for_idle_rows() {
-        let menu = NSMenu()
-        let idle = paneSnapshot(fleetState: .idle, statusLabel: "Idle")
-
-        MenuBarStatusMenuBuilder.rebuild(
-            menu: menu,
-            snapshots: [idle],
-            fleetSummary: MenuBarFleetSummary.from(snapshots: [idle]),
-            target: nil,
-            rowAction: #selector(NSObject.description),
-            settingsAction: #selector(NSObject.description)
-        )
-
-        let row = try! XCTUnwrap(menu.items[1].view)
+    func test_status_pill_uses_palette_color_for_idle_rows() {
+        let row = buildRow(for: paneSnapshot(fleetState: .idle, statusLabel: "Idle"))
         let statusLabel = try! XCTUnwrap(textFields(in: row).first { $0.stringValue == "Idle" })
-        XCTAssertEqual(
-            statusLabel.textColor?.srgbClamped,
-            MenuBarStatusIconRenderer.dotColor(for: .idle).srgbClamped
-        )
+        assertPillLabelColor(statusLabel.textColor, kind: .idle)
+    }
+
+    func test_status_pill_uses_ready_color_for_agent_ready_rows() {
+        // 'Agent ready' is fleetState .idle + attentionState .ready, and must
+        // read as the blue ready pill rather than plain idle gray.
+        let row = buildRow(for: paneSnapshot(
+            fleetState: .idle,
+            statusLabel: "Agent ready",
+            attentionState: .ready
+        ))
+        let statusLabel = try! XCTUnwrap(textFields(in: row).first { $0.stringValue == "Agent ready" })
+        assertPillLabelColor(statusLabel.textColor, kind: .ready)
     }
 
     func test_custom_rows_claim_cursor_updates_for_arrow_cursor() {
@@ -242,49 +213,35 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
         ceil(label.fittingSize.width)
     }
 
-    private func assertReadableStatusColor(
+    private func buildRow(
+        for snapshot: MenuBarPaneSnapshot,
+        appearance: NSAppearance? = NSAppearance(named: .aqua)
+    ) -> NSView {
+        let menu = NSMenu()
+        menu.appearance = appearance
+        MenuBarStatusMenuBuilder.rebuild(
+            menu: menu,
+            snapshots: [snapshot],
+            fleetSummary: MenuBarFleetSummary.from(snapshots: [snapshot]),
+            target: nil,
+            rowAction: #selector(NSObject.description),
+            settingsAction: #selector(NSObject.description)
+        )
+        return menu.items[1].view!
+    }
+
+    private func assertPillLabelColor(
         _ color: NSColor?,
-        fleetState: MenuBarFleetState,
+        kind: MenuBarStatusKind,
+        isDark: Bool = false,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let color = try! XCTUnwrap(color, file: file, line: line).srgbClamped
-        let dotColor = MenuBarStatusIconRenderer.dotColor(for: fleetState).srgbClamped
-        let translucentLightMenuBackground = NSColor(calibratedWhite: 0.74, alpha: 1)
-
-        XCTAssertNotEqual(color, dotColor, "Menu text should not use the raw badge fill color", file: file, line: line)
-        XCTAssertGreaterThanOrEqual(
-            color.contrastRatio(against: translucentLightMenuBackground),
-            4.5,
-            "Menu text should remain readable on the native light translucent menu background",
-            file: file,
-            line: line
-        )
-        XCTAssertLessThanOrEqual(
-            color.contrastRatio(against: translucentLightMenuBackground),
-            4.75,
-            "Menu text should stay close to the contrast threshold so the status hue remains vibrant in light mode",
-            file: file,
-            line: line
-        )
-        XCTAssertEqual(
-            hue(of: color),
-            hue(of: dotColor),
-            accuracy: 0.03,
-            "Menu text should preserve the badge hue while adjusting contrast",
-            file: file,
-            line: line
-        )
-    }
-
-    private func hue(of color: NSColor) -> CGFloat {
-        let rgb = color.usingColorSpace(.deviceRGB) ?? color
-        var hue: CGFloat = 0
-        var saturation: CGFloat = 0
-        var brightness: CGFloat = 0
-        var alpha: CGFloat = 0
-        rgb.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-        return hue
+        let actual = try! XCTUnwrap(color, file: file, line: line).srgbClamped
+        let expected = MenuBarStatusPalette.labelColor(for: kind, isDark: isDark).srgbClamped
+        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.001, file: file, line: line)
     }
 
     func test_itemTitle_uses_accessibility_summary() {
@@ -520,6 +477,7 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
     private func paneSnapshot(
         fleetState: MenuBarFleetState,
         statusLabel: String,
+        attentionState: WorklaneAttentionState? = nil,
         windowTitle: String = "Window 1",
         primaryText: String = "Claude Code"
     ) -> MenuBarPaneSnapshot {
@@ -532,7 +490,7 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
             primaryText: primaryText,
             contextText: "zentty · main",
             statusLabel: statusLabel,
-            attentionState: fleetState.menuAttentionState,
+            attentionState: attentionState ?? fleetState.menuAttentionState,
             fleetState: fleetState,
             updatedAt: Date(timeIntervalSince1970: 0),
             taskProgress: nil,

--- a/ZenttyLogicTests/MenuBarStatusPaletteTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusPaletteTests.swift
@@ -1,0 +1,194 @@
+import AppKit
+import XCTest
+@testable import Zentty
+
+final class MenuBarStatusPaletteTests: XCTestCase {
+    // (kind, lightTextHex, darkTextHex) — label + dot color.
+    private static let textExpectations: [(MenuBarStatusKind, UInt32, UInt32)] = [
+        (.running, 0x1B8A3E, 0x46E07E),
+        (.compacting, 0x1B8A3E, 0x46E07E),
+        (.needsInput, 0x9A6400, 0xFFC24B),
+        (.stoppedEarly, 0xC5372C, 0xFF7A6E),
+        (.ready, 0x0A66D6, 0x5AB0FF),
+        (.idle, 0x6B6B70, 0xA4A4AA),
+    ]
+
+    // (kind, lightTintHex, darkTintHex) — fill + border tint base.
+    private static let tintExpectations: [(MenuBarStatusKind, UInt32, UInt32)] = [
+        (.running, 0x30B450, 0x30C864),
+        (.compacting, 0x30B450, 0x30C864),
+        (.needsInput, 0xFFAA14, 0xFFB428),
+        (.stoppedEarly, 0xFF463C, 0xFF5A50),
+        (.ready, 0x007AFF, 0x288CFF),
+        (.idle, 0x787880, 0x969E9E),
+    ]
+
+    // MARK: - Label / dot color
+
+    func test_label_color_matches_expected_rgb_for_every_kind_and_appearance() {
+        for (kind, lightHex, darkHex) in Self.textExpectations {
+            assertColor(
+                MenuBarStatusPalette.labelColor(for: kind, isDark: false),
+                equals: lightHex,
+                "\(kind) light label"
+            )
+            assertColor(
+                MenuBarStatusPalette.labelColor(for: kind, isDark: true),
+                equals: darkHex,
+                "\(kind) dark label"
+            )
+        }
+    }
+
+    func test_dot_color_equals_label_color() {
+        for kind in [MenuBarStatusKind.running, .needsInput, .ready] {
+            for isDark in [false, true] {
+                let dot = MenuBarStatusPalette.dotColor(for: kind, isDark: isDark)
+                let label = MenuBarStatusPalette.labelColor(for: kind, isDark: isDark)
+                assertSameColor(dot, label, "\(kind) dark=\(isDark) dot vs label")
+            }
+        }
+    }
+
+    // MARK: - Fill / border RGB + alpha
+
+    func test_fill_color_matches_tint_rgb_and_normal_alpha() {
+        for (kind, lightHex, darkHex) in Self.tintExpectations {
+            assertColor(
+                MenuBarStatusPalette.fillColor(for: kind, isDark: false, reduceTransparency: false),
+                equals: lightHex,
+                alpha: 0.15,
+                "\(kind) light fill"
+            )
+            assertColor(
+                MenuBarStatusPalette.fillColor(for: kind, isDark: true, reduceTransparency: false),
+                equals: darkHex,
+                alpha: 0.18,
+                "\(kind) dark fill"
+            )
+        }
+    }
+
+    func test_fill_color_reduce_transparency_uses_opaque_alpha_in_both_modes() {
+        for (kind, lightHex, darkHex) in Self.tintExpectations {
+            assertColor(
+                MenuBarStatusPalette.fillColor(for: kind, isDark: false, reduceTransparency: true),
+                equals: lightHex,
+                alpha: 0.30,
+                "\(kind) light fill reduced"
+            )
+            assertColor(
+                MenuBarStatusPalette.fillColor(for: kind, isDark: true, reduceTransparency: true),
+                equals: darkHex,
+                alpha: 0.30,
+                "\(kind) dark fill reduced"
+            )
+        }
+    }
+
+    func test_border_color_matches_tint_rgb_and_normal_alpha() {
+        for (kind, lightHex, darkHex) in Self.tintExpectations {
+            assertColor(
+                MenuBarStatusPalette.borderColor(for: kind, isDark: false, reduceTransparency: false),
+                equals: lightHex,
+                alpha: 0.32,
+                "\(kind) light border"
+            )
+            assertColor(
+                MenuBarStatusPalette.borderColor(for: kind, isDark: true, reduceTransparency: false),
+                equals: darkHex,
+                alpha: 0.34,
+                "\(kind) dark border"
+            )
+        }
+    }
+
+    func test_border_color_reduce_transparency_uses_opaque_alpha_in_both_modes() {
+        for (kind, lightHex, darkHex) in Self.tintExpectations {
+            assertColor(
+                MenuBarStatusPalette.borderColor(for: kind, isDark: false, reduceTransparency: true),
+                equals: lightHex,
+                alpha: 0.55,
+                "\(kind) light border reduced"
+            )
+            assertColor(
+                MenuBarStatusPalette.borderColor(for: kind, isDark: true, reduceTransparency: true),
+                equals: darkHex,
+                alpha: 0.55,
+                "\(kind) dark border reduced"
+            )
+        }
+    }
+
+    // MARK: - Reduce-transparency monotonicity
+
+    func test_reduce_transparency_raises_fill_and_border_alpha_in_both_modes() {
+        let kind = MenuBarStatusKind.running
+        for isDark in [false, true] {
+            let fillNormal = MenuBarStatusPalette
+                .fillColor(for: kind, isDark: isDark, reduceTransparency: false)
+                .srgbClamped.alphaComponent
+            let fillReduced = MenuBarStatusPalette
+                .fillColor(for: kind, isDark: isDark, reduceTransparency: true)
+                .srgbClamped.alphaComponent
+            XCTAssertGreaterThan(fillReduced, fillNormal, "fill alpha dark=\(isDark)")
+
+            let borderNormal = MenuBarStatusPalette
+                .borderColor(for: kind, isDark: isDark, reduceTransparency: false)
+                .srgbClamped.alphaComponent
+            let borderReduced = MenuBarStatusPalette
+                .borderColor(for: kind, isDark: isDark, reduceTransparency: true)
+                .srgbClamped.alphaComponent
+            XCTAssertGreaterThan(borderReduced, borderNormal, "border alpha dark=\(isDark)")
+        }
+    }
+
+    // MARK: - isDark
+
+    func test_is_dark_resolves_appearance_variants() {
+        XCTAssertTrue(MenuBarStatusPalette.isDark(NSAppearance(named: .darkAqua)))
+        XCTAssertFalse(MenuBarStatusPalette.isDark(NSAppearance(named: .aqua)))
+        XCTAssertFalse(MenuBarStatusPalette.isDark(nil))
+    }
+
+    // MARK: - Helpers
+
+    /// Compares `actual` against a packed `0xRRGGBB` color (and optional alpha)
+    /// via their sRGB components, so the assertion is colorspace-stable.
+    private func assertColor(
+        _ actual: NSColor,
+        equals packedHex: UInt32,
+        alpha: CGFloat = 1,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expected = NSColor(
+            srgbRed: CGFloat((packedHex >> 16) & 0xFF) / 255.0,
+            green: CGFloat((packedHex >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(packedHex & 0xFF) / 255.0,
+            alpha: alpha
+        ).srgbClamped
+        let resolved = actual.srgbClamped
+
+        XCTAssertEqual(resolved.redComponent, expected.redComponent, accuracy: 0.001, "\(message) red", file: file, line: line)
+        XCTAssertEqual(resolved.greenComponent, expected.greenComponent, accuracy: 0.001, "\(message) green", file: file, line: line)
+        XCTAssertEqual(resolved.blueComponent, expected.blueComponent, accuracy: 0.001, "\(message) blue", file: file, line: line)
+        XCTAssertEqual(resolved.alphaComponent, expected.alphaComponent, accuracy: 0.001, "\(message) alpha", file: file, line: line)
+    }
+
+    private func assertSameColor(
+        _ actual: NSColor,
+        _ expected: NSColor,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let a = actual.srgbClamped
+        let b = expected.srgbClamped
+        XCTAssertEqual(a.redComponent, b.redComponent, accuracy: 0.001, "\(message) red", file: file, line: line)
+        XCTAssertEqual(a.greenComponent, b.greenComponent, accuracy: 0.001, "\(message) green", file: file, line: line)
+        XCTAssertEqual(a.blueComponent, b.blueComponent, accuracy: 0.001, "\(message) blue", file: file, line: line)
+        XCTAssertEqual(a.alphaComponent, b.alphaComponent, accuracy: 0.001, "\(message) alpha", file: file, line: line)
+    }
+}

--- a/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
@@ -161,6 +161,34 @@ final class MenuBarStatusPillViewTests: AppKitTestCase {
         XCTAssertLessThan(label.frame.width, intrinsicWidth)
     }
 
+    func test_reveal_detail_is_vertically_aligned_with_label() throws {
+        let aqua = NSAppearance(named: .aqua)
+        let pill = makePill()
+        let progress = try XCTUnwrap(PaneAgentTaskProgress(doneCount: 1, totalCount: 4))
+        pill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: progress,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+        pill.setRevealed(true, animated: false, reducedMotion: true)
+        pill.frame = NSRect(x: 0, y: 0, width: pill.intrinsicContentSize.width, height: 18)
+        pill.layoutSubtreeIfNeeded()
+
+        let label = try XCTUnwrap(
+            pill.subviews.compactMap { $0 as? NSTextField }.first { $0.stringValue == "Running" }
+        )
+        let reveal = try XCTUnwrap(pill.subviews.compactMap { $0 as? SidebarTaskProgressRevealView }.first)
+        XCTAssertGreaterThan(reveal.frame.width, 0, "reveal must be laid out with width when revealed")
+        XCTAssertEqual(
+            reveal.frame.midY,
+            label.frame.midY,
+            accuracy: 0.5,
+            "the hover-reveal detail must share the status label's vertical center"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makePill() -> MenuBarStatusPillView {

--- a/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
@@ -137,6 +137,30 @@ final class MenuBarStatusPillViewTests: AppKitTestCase {
         XCTAssertGreaterThan(reducedAlpha, normalAlpha)
     }
 
+    func test_label_truncates_when_pill_framed_narrower_than_intrinsic() throws {
+        let aqua = NSAppearance(named: .aqua)
+        let pill = makePill()
+        pill.configure(
+            kind: .running,
+            text: "An unusually long status that exceeds the pill",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+        let intrinsicWidth = pill.intrinsicContentSize.width
+
+        // Frame it much narrower than it wants; the label must stay inside the
+        // capsule (truncating) rather than overflowing into the row.
+        pill.frame = NSRect(x: 0, y: 0, width: 60, height: 18)
+        pill.layoutSubtreeIfNeeded()
+
+        let label = try XCTUnwrap(
+            pill.subviews.compactMap { $0 as? NSTextField }.first { $0.stringValue.contains("unusually") }
+        )
+        XCTAssertLessThanOrEqual(label.frame.maxX, pill.bounds.width)
+        XCTAssertLessThan(label.frame.width, intrinsicWidth)
+    }
+
     // MARK: - Helpers
 
     private func makePill() -> MenuBarStatusPillView {

--- a/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusPillViewTests.swift
@@ -1,0 +1,164 @@
+import AppKit
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class MenuBarStatusPillViewTests: AppKitTestCase {
+    func test_each_kind_resolves_palette_colors_for_light_appearance() {
+        let aqua = NSAppearance(named: .aqua)
+
+        for kind in MenuBarStatusKind.allCases {
+            let pill = makePill()
+            pill.configure(
+                kind: kind,
+                text: "Running",
+                taskProgress: nil,
+                appearance: aqua,
+                reduceTransparency: false
+            )
+
+            let snapshot = pill.debugSnapshotForTesting
+            XCTAssertEqual(snapshot.kind, kind)
+            XCTAssertEqual(snapshot.labelText, "Running")
+
+            assertColor(
+                snapshot.labelColor,
+                equals: MenuBarStatusPalette.labelColor(for: kind, isDark: false)
+            )
+            assertColor(
+                snapshot.fillColor,
+                equals: MenuBarStatusPalette.fillColor(for: kind, isDark: false, reduceTransparency: false)
+            )
+            assertColor(
+                snapshot.borderColor,
+                equals: MenuBarStatusPalette.borderColor(for: kind, isDark: false, reduceTransparency: false)
+            )
+            assertColor(
+                snapshot.dotColor,
+                equals: MenuBarStatusPalette.dotColor(for: kind, isDark: false)
+            )
+        }
+    }
+
+    func test_dark_appearance_resolves_dark_label_variant() {
+        let darkAqua = NSAppearance(named: .darkAqua)
+        let pill = makePill()
+
+        pill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: nil,
+            appearance: darkAqua,
+            reduceTransparency: false
+        )
+
+        assertColor(
+            pill.debugSnapshotForTesting.labelColor,
+            equals: MenuBarStatusPalette.labelColor(for: .running, isDark: true)
+        )
+    }
+
+    func test_progress_visibility_tracks_task_progress() throws {
+        let aqua = NSAppearance(named: .aqua)
+        let pill = makePill()
+
+        pill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+        XCTAssertFalse(pill.debugSnapshotForTesting.isProgressVisible)
+
+        let progress = try XCTUnwrap(PaneAgentTaskProgress(doneCount: 2, totalCount: 5))
+        pill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: progress,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+        XCTAssertTrue(pill.debugSnapshotForTesting.isProgressVisible)
+    }
+
+    func test_intrinsic_width_grows_with_label_length() {
+        let aqua = NSAppearance(named: .aqua)
+
+        let shortPill = makePill()
+        shortPill.configure(
+            kind: .running,
+            text: "Go",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+
+        let longPill = makePill()
+        longPill.configure(
+            kind: .running,
+            text: "Running a very long status label",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+
+        XCTAssertGreaterThan(shortPill.debugSnapshotForTesting.intrinsicSize.width, 0)
+        XCTAssertGreaterThan(
+            longPill.debugSnapshotForTesting.intrinsicSize.width,
+            shortPill.debugSnapshotForTesting.intrinsicSize.width
+        )
+    }
+
+    func test_reduce_transparency_bumps_fill_alpha() throws {
+        let aqua = NSAppearance(named: .aqua)
+
+        let normalPill = makePill()
+        normalPill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: false
+        )
+
+        let reducedPill = makePill()
+        reducedPill.configure(
+            kind: .running,
+            text: "Running",
+            taskProgress: nil,
+            appearance: aqua,
+            reduceTransparency: true
+        )
+
+        let normalAlpha = try XCTUnwrap(normalPill.debugSnapshotForTesting.fillColor).srgbClamped.alphaComponent
+        let reducedAlpha = try XCTUnwrap(reducedPill.debugSnapshotForTesting.fillColor).srgbClamped.alphaComponent
+
+        XCTAssertGreaterThan(reducedAlpha, normalAlpha)
+    }
+
+    // MARK: - Helpers
+
+    private func makePill() -> MenuBarStatusPillView {
+        MenuBarStatusPillView(frame: NSRect(x: 0, y: 0, width: 200, height: 18))
+    }
+
+    private func assertColor(
+        _ actual: NSColor?,
+        equals expected: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual else {
+            XCTFail("Expected a color but got nil", file: file, line: line)
+            return
+        }
+
+        let lhs = actual.srgbClamped
+        let rhs = expected.srgbClamped
+        XCTAssertEqual(lhs.redComponent, rhs.redComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(lhs.greenComponent, rhs.greenComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(lhs.blueComponent, rhs.blueComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(lhs.alphaComponent, rhs.alphaComponent, accuracy: 0.001, file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary

Agent status in the menu-bar dropdown now renders as clean tinted pills that stay legible in light and dark. Before, it was colored text run through a contrast algorithm that darkened `systemGreen` to hit 4.5:1 against an *assumed* flat-gray background. The real menu is translucent, so "Running" came out a muddy dark green that didn't even match its own status dot, and "Agent ready" looked disabled in gray. The pills replace both the colored text and the icon badge-dot, driven by a curated light/dark palette tuned for the menu.

## Palette

Each status has separate light and dark variants: a readable label color plus a softer tint for the pill fill and border.

| Status | Hue | Meaning |
|---|---|---|
| Running / Compacting | green | working |
| Needs input | amber | blocked on you |
| Stopped early | red | halted unexpectedly |
| Agent ready | blue | finished, your move |
| Idle | gray | dormant |

Amber replaces yellow for "Needs input"; true yellow is unreadable as a label on a light menu.

## Notable decisions

The menu uses a fixed, menu-native palette rather than the app's themed chips. The in-app sidebar and Task Manager chips take their colors from the active terminal theme, where "running" is blue. The dropdown is a standalone system surface, so it gets its own palette chosen for legibility on vibrancy, with "running" as the universal green. Two surfaces, two deliberate mappings.

Status is resolved from state, not text. A new `MenuBarStatusKind` derives from the snapshot's `fleetState` plus `attentionState`, so "Agent ready" (idle and ready) is told apart from plain idle without matching on label strings.

With the pill carrying status, the agent icon renders unbadged and the old contrast-darkening code (`statusTextColor`, `readableStatusTextColor`, `menuTextContrastBackground`) is deleted. `dotColor` stays for the top-bar status-item glyph, which is unchanged and out of scope here.

Reduce Transparency pushes the pill fill and border toward opaque, and the pill truncates its own label so a long agent-supplied status can't crowd out the title.

## Tests

New `ZenttyLogicTests`: `MenuBarStatusKindTests` covers every fleet-state and attention-state combination (especially ready vs idle), `MenuBarStatusPaletteTests` checks the per-status hex in each appearance plus the reduce-transparency bump, and `MenuBarStatusPillViewTests` checks pill colors, content sizing, label truncation, and reveal alignment. `MenuBarStatusMenuBuilderTests` now asserts pill colors instead of the old contrast behavior.
