### PR TITLE
feat(agent): consent gate and on/off control for agent hook integrations

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		C8AC887AB1E462D59D6619FF /* AgyHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AEBD7620888C77CB6FE423 /* AgyHooksInstaller.swift */; };
 		C9042A63C4AF443C0A4C8A55 /* NotificationPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6480DAD70FC01A0FD0A8908 /* NotificationPopoverView.swift */; };
 		C989D4E5646E700C8802CBD9 /* PassiveServerDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7109E246F70CEBB6CD34E13F /* PassiveServerDetection.swift */; };
+		C9ACF6200671CC901D3D0C6C /* CaretTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC8BA5388C2EC99E6DA4E4D /* CaretTooltip.swift */; };
 		C9B81248B5AA76BE4CD7129F /* ServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F7BA09CEEB123D53CB10C4 /* ServerRegistry.swift */; };
 		C9BCF024E2100C86C60ED966 /* WorkspaceRecipeColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79741EFBC870D776F45B8E7 /* WorkspaceRecipeColorTests.swift */; };
 		C9ED7FA8D89698D7E7644E36 /* LibghosttySelectionAutoscrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069DF835DCBC34EAFA18963 /* LibghosttySelectionAutoscrollController.swift */; };
@@ -1014,6 +1015,7 @@
 		FD08AC7A7561005FD819D5D4 /* CleanCopyPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanCopyPipelineTests.swift; sourceTree = "<group>"; };
 		FD6261C82AADF1EDAAA09BC9 /* PaneStripMotionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStripMotionController.swift; sourceTree = "<group>"; };
 		FD6F1935CE1012DD80C4954D /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
+		FDC8BA5388C2EC99E6DA4E4D /* CaretTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretTooltip.swift; sourceTree = "<group>"; };
 		FE8E85EADB93A2FE0E71BEA6 /* TerminalPaneHostViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneHostViewTests.swift; sourceTree = "<group>"; };
 		FEFFC2CAEA605772B62E73E5 /* PaneStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStripView.swift; sourceTree = "<group>"; };
 		FFA39255E836211E35CAFF5F /* WorklaneState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneState+Testing.swift"; sourceTree = "<group>"; };
@@ -1542,6 +1544,7 @@
 			isa = PBXGroup;
 			children = (
 				D0E4530192DE360F32303E65 /* AppearanceSettingsSectionViewController.swift */,
+				FDC8BA5388C2EC99E6DA4E4D /* CaretTooltip.swift */,
 				FA88E1E64FB65E4B800852D7 /* GeneralSettingsSectionViewController.swift */,
 				B1F616D86BF9A658C1E1A9D7 /* GhosttyAppearanceSettingsCoordinator.swift */,
 				74A553F140B785B8FE4755F8 /* KeyboardShortcutPreviewView.swift */,
@@ -2307,6 +2310,7 @@
 				FB0610B393299F59045FDD97 /* BookmarksPopoverMetrics.swift in Sources */,
 				EF0F88674C95591761ACB87B /* BookmarksPopoverView.swift in Sources */,
 				667A04C8CFE0127371DF68C6 /* BookmarksPopoverViewModel.swift in Sources */,
+				C9ACF6200671CC901D3D0C6C /* CaretTooltip.swift in Sources */,
 				6AF1CD2BF77470AF7368F0F5 /* ClaudeCodeTitleOverrideReducer.swift in Sources */,
 				720727A2DA0A0EA0C32EC86E /* ClaudeHookSessionStore.swift in Sources */,
 				ED27476E195CD5905EA8FE99 /* CleanCopyPipeline.swift in Sources */,

--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -30,11 +30,13 @@
 		0AAC15DA2853AA84E4CCF668 /* WorklaneStoreReorderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599A5796CE02C9D0701F88B7 /* WorklaneStoreReorderingTests.swift */; };
 		0BA5C3C6B04726C27411977B /* ServerMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1300B764962E64484AAB4256 /* ServerMenuModelTests.swift */; };
 		0C4C732372135F289434B09D /* ServerMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEF2D707AEBD4A19B9E62EE /* ServerMenuModel.swift */; };
+		0C598E3C54E30B5CC4466E2D /* AppConfigAgentIntegrationsTOMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288F2452125BCCDB961229C9 /* AppConfigAgentIntegrationsTOMLTests.swift */; };
 		0D118FCB36F18F809879411C /* AppKitTestDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CBABCE53556478CD451A01 /* AppKitTestDisplayTests.swift */; };
 		0D16861AE92EDD029878BCBA /* LibghosttyViewScrollRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0253BE7E0C15D8168A3491D /* LibghosttyViewScrollRoutingTests.swift */; };
 		0ED2C234E696C111255B212A /* LibghosttyAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2671C2153DB1DFA70522E94 /* LibghosttyAdapterTests.swift */; };
 		0F7546B851229BA46CC5DCFA /* TaskManagerRootPIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF50948B1AF143E418C8144 /* TaskManagerRootPIDTests.swift */; };
 		1041B5CDF3EA5C978F3580BC /* PanePresentationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017D80D8C20309A5F3A34381 /* PanePresentationStateTests.swift */; };
+		10495E193033CEF259528C11 /* AgentConsentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6960333F9BE4F448FCA1D1A5 /* AgentConsentCoordinator.swift */; };
 		105EFDDB2995F6500AE4DF21 /* BookmarkStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA071E0AD16A044F7C2F644 /* BookmarkStoreTests.swift */; };
 		1138CA064359EDBA85184C91 /* SidebarWindowRenderability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148ED833C80F99325F84B76D /* SidebarWindowRenderability.swift */; };
 		1139F5A8823B615631F1616C /* LibghosttyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */; };
@@ -52,6 +54,7 @@
 		169A250F3E725A718A9AFAEC /* PaneIPCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A65B5FE282DD307A732E81 /* PaneIPCHandler.swift */; };
 		16C2713E9DBD4C59A08E23C0 /* PaneDragZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF5222B4D0E69865759FBD /* PaneDragZoneView.swift */; };
 		16E1DE875672D6743DF1B86D /* WindowChromeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB71268537F60FF02894F12 /* WindowChromeViewTests.swift */; };
+		16F822122305BB7A1AE8DFF1 /* AgentIntegrationGrandfather.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2414DEC30C1A200BC42DD4 /* AgentIntegrationGrandfather.swift */; };
 		17245348FB36801D95C10395 /* ShellMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FEAF3CA4E96E1EB18692E8 /* ShellMetrics.swift */; };
 		173791FED7615617FAF34B05 /* CommandPaletteTaskRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D7092CD7460BABDBD68C6E /* CommandPaletteTaskRunnerTests.swift */; };
 		1831BA926C62620FC97C9D07 /* TaskManagerProcessSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B147E532F92E9849DAF51188 /* TaskManagerProcessSamplerTests.swift */; };
@@ -110,6 +113,7 @@
 		3614320FD38D24027DC4D136 /* TmuxCompatIPCHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD2AD71B143BD29FDAA48FF /* TmuxCompatIPCHandler.swift */; };
 		36227752A555BD401C021F8E /* WorklaneStore+AgentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67EAA92DF59DD9D42DF7FE4 /* WorklaneStore+AgentStatus.swift */; };
 		3650396E475C8F56AF61CB4C /* TaskRunnerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7E300A778738FA99DF6B1B /* TaskRunnerModels.swift */; };
+		369B3146B2FC3DD67A95906D /* AgentIntegrationConsentPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D88FB8E9B069D496016C8B /* AgentIntegrationConsentPanel.swift */; };
 		36DB4C0D9A73C37653285064 /* ShellEscaping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20147088C6EEA07145EA0961 /* ShellEscaping.swift */; };
 		371FB2F8A67CC747CF1FFD4F /* CommandPaletteResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1664363F6DAF16AD33EECA9D /* CommandPaletteResultRow.swift */; };
 		37683223FAC33E2284C333DB /* WorklaneStoreClosedPaneRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7DFA52E9F279C81A803C23 /* WorklaneStoreClosedPaneRestoreTests.swift */; };
@@ -162,6 +166,7 @@
 		4FE322E96C1A232404A28D38 /* PaneLayoutPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA052B6DDCA1EE9D9F58BC0 /* PaneLayoutPreferencesTests.swift */; };
 		50126121E0F0273501829F97 /* CommandTooltipFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0529815FA8F05D8F52601625 /* CommandTooltipFormatter.swift */; };
 		505E896AF0143A27234A8FD0 /* GhosttyAppearanceSettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F616D86BF9A658C1E1A9D7 /* GhosttyAppearanceSettingsCoordinator.swift */; };
+		50E494B39C06F67983331C3B /* AgentIntegrationGrandfatherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B5C7232C6BA07C385B052 /* AgentIntegrationGrandfatherTests.swift */; };
 		52278F4B3EDD364F309993FF /* AgentIPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D33B3653DD17B96C1CA6222 /* AgentIPC.swift */; };
 		522D0127F4CB6736F0E2AABF /* ServerRelevanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65C78F4319054821F694BC9 /* ServerRelevanceTests.swift */; };
 		522DDD2A865C44F69EA80545 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59013577D95CD9373F8802A /* AboutWindowController.swift */; };
@@ -172,6 +177,7 @@
 		55C1CC506BD2F0613AD94835 /* AgentStatusSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003771A9512A8005B0DCF7DE /* AgentStatusSupportTests.swift */; };
 		572A5497BE7EB5B571032AD2 /* SidebarWorklaneRowMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C498D4DFE603C6E5A408EAEC /* SidebarWorklaneRowMenuController.swift */; };
 		5767530C6A0E9285303A081D /* WorklaneDestinationCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F97C3054D1F1E57C716DCAB /* WorklaneDestinationCatalogTests.swift */; };
+		57AB67F85512042ACB976A79 /* AgentIntegrationConsentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B95C44923CD6F38E7D95D2F /* AgentIntegrationConsentTests.swift */; };
 		5879663760748654C74B3759 /* SidebarViewDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559F037FFC52BB9F8C9AE5EB /* SidebarViewDebugging.swift */; };
 		59082A59F09FC3C1D67F30E1 /* HermesHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F5891F160455B55F41BB5F /* HermesHooksInstaller.swift */; };
 		59D8562415BA0E40C383D6FD /* TmuxCompatArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1C35E3E3441C4C57051CA /* TmuxCompatArguments.swift */; };
@@ -237,6 +243,7 @@
 		7AB05C23149C9A7980629EC9 /* SidebarResizeHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07D99A780805BBF2EC8E2C /* SidebarResizeHandleView.swift */; };
 		7BD9A95F9A5AB07D78784765 /* ServerURLNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1353BE5798B0D53E409EEEB /* ServerURLNormalizer.swift */; };
 		7BDCC1EDF0CCD7C439A086D5 /* SidebarGlobalSearchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1950AE3041C1DC410E2DCD11 /* SidebarGlobalSearchButton.swift */; };
+		7C25A0942594D0EB8764DE8E /* AgentIntegrationConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86532A76726D9364B28994A8 /* AgentIntegrationConsent.swift */; };
 		7C269AA7741BA793A8DD4BD7 /* PaneNotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53055103EE2424B9E14A2878 /* PaneNotificationCoordinator.swift */; };
 		7C47C97F74DD168347F1CB2F /* ClosedPaneEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E9BE732833C02E123BA5AF /* ClosedPaneEntry.swift */; };
 		7CE41197B205C6CF70AFC9E6 /* WorkspaceRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771FEDEE47A531015097EFC7 /* WorkspaceRecipeTests.swift */; };
@@ -250,6 +257,7 @@
 		820A7E0C5B5B33F9FAA80699 /* AppearanceSettingsSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E4530192DE360F32303E65 /* AppearanceSettingsSectionViewController.swift */; };
 		823E76AAB26EB40EB60908ED /* MenuBarFleetSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE996639899C1B264848CE /* MenuBarFleetSummary.swift */; };
 		8245A5A1336710207AB3DD17 /* MenuBarStatusMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B761568FFEEF65421C52232 /* MenuBarStatusMenuBuilder.swift */; };
+		834B6339AE9EE794ED76CDF9 /* AgentConsentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B657E64F86B3DD0085CCD5E /* AgentConsentCoordinatorTests.swift */; };
 		83951F6CBB1AEE312F1A0D68 /* WorklaneStoreMetadataVolatileFastPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCEFAE8FF676F5051157D3E /* WorklaneStoreMetadataVolatileFastPathTests.swift */; };
 		83BF166AF639CD6444EC9DED /* SidebarWorklaneReorderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A414B0A7FAAB8464A6432C77 /* SidebarWorklaneReorderModel.swift */; };
 		840FDF34FA89D7BA5649AF0C /* PaneAuxiliaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */; };
@@ -596,6 +604,7 @@
 		25C38CE6BD2D5F5D24B1B7FE /* AppConfigTOML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTOML.swift; sourceTree = "<group>"; };
 		27305922B447A5738166829F /* TaskfileParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskfileParser.swift; sourceTree = "<group>"; };
 		286127859CC1D0E1D6E24ECE /* PaneDragPreviewSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragPreviewSizingTests.swift; sourceTree = "<group>"; };
+		288F2452125BCCDB961229C9 /* AppConfigAgentIntegrationsTOMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigAgentIntegrationsTOMLTests.swift; sourceTree = "<group>"; };
 		28B65FF8B847E8E743D485D4 /* GlassSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassSurfaceView.swift; sourceTree = "<group>"; };
 		28E15DDC0970C4214A4C9E5E /* PaneStripView+Transitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaneStripView+Transitions.swift"; sourceTree = "<group>"; };
 		290AC219C812A96036CA9061 /* AgentInteractionClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInteractionClassifier.swift; sourceTree = "<group>"; };
@@ -628,6 +637,7 @@
 		37FEDC5ACCE392A113BBE81E /* BookmarkRestoreBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRestoreBannerView.swift; sourceTree = "<group>"; };
 		38818AED458478BCB3C95168 /* WorklaneHeaderSummaryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneHeaderSummaryBuilderTests.swift; sourceTree = "<group>"; };
 		38C15EEBB2B6060FDC3C8A05 /* AgentIPCDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIPCDiscoveryTests.swift; sourceTree = "<group>"; };
+		3B1B5C7232C6BA07C385B052 /* AgentIntegrationGrandfatherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationGrandfatherTests.swift; sourceTree = "<group>"; };
 		3B2B4CFEFDD5D5985609F1BA /* WorklaneAttentionSummaryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionSummaryBuilderTests.swift; sourceTree = "<group>"; };
 		3BE9959CFC3168BC8324CC3C /* SessionRestoreStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestoreStoreTests.swift; sourceTree = "<group>"; };
 		3CD1D64075C9C26B40FA2C70 /* CodexTranscriptQuestionExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTranscriptQuestionExtractorTests.swift; sourceTree = "<group>"; };
@@ -721,6 +731,7 @@
 		664E62FC352B56CA7B035AC1 /* TaskManagerPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerPresentationTests.swift; sourceTree = "<group>"; };
 		677818B56188202E6289EC96 /* WorklaneColorMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorMenuItemView.swift; sourceTree = "<group>"; };
 		691FE92E923A9E00EC8B6063 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6960333F9BE4F448FCA1D1A5 /* AgentConsentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConsentCoordinator.swift; sourceTree = "<group>"; };
 		69E99517E9EAA4D99552859C /* WorkspaceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplate.swift; sourceTree = "<group>"; };
 		6BC138BE273ED92291124633 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		6C5489AD4C2AF3E168C216B4 /* WorklaneDestinationCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneDestinationCatalog.swift; sourceTree = "<group>"; };
@@ -748,8 +759,10 @@
 		783A3BBA14A7D266EEB43B31 /* ServerIPCCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerIPCCommandTests.swift; sourceTree = "<group>"; };
 		789E529A7E4C195C7F216396 /* PresentationDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationDraft.swift; sourceTree = "<group>"; };
 		7905A1748912E4A0FDCC9A9B /* LibghosttySurfaceKeyEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySurfaceKeyEventTests.swift; sourceTree = "<group>"; };
+		7B657E64F86B3DD0085CCD5E /* AgentConsentCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConsentCoordinatorTests.swift; sourceTree = "<group>"; };
 		7B93F46C5542A31805301C02 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
 		7B94B2DF866815028261F94B /* WorkspaceTemplateImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateImporterTests.swift; sourceTree = "<group>"; };
+		7B95C44923CD6F38E7D95D2F /* AgentIntegrationConsentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationConsentTests.swift; sourceTree = "<group>"; };
 		7C1BDFF2B71B2BDFF1DF60EA /* WorklaneAttentionSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionSummaryBuilder.swift; sourceTree = "<group>"; };
 		7CFD112F9402167A1785DB70 /* BookmarkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkStore.swift; sourceTree = "<group>"; };
 		7D19D665B0C99E8725E1E7AC /* ProjectIconResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconResolverTests.swift; sourceTree = "<group>"; };
@@ -769,6 +782,7 @@
 		84F4F997E86D364090463A67 /* GrokHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokHooksInstaller.swift; sourceTree = "<group>"; };
 		859E02462A30A35800CA0123 /* NotificationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStoreTests.swift; sourceTree = "<group>"; };
 		8626016D68E310751E9D7E91 /* ClosedPaneStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedPaneStack.swift; sourceTree = "<group>"; };
+		86532A76726D9364B28994A8 /* AgentIntegrationConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationConsent.swift; sourceTree = "<group>"; };
 		86917D1F9201725F12438AD5 /* WindowChromeRowLayoutPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeRowLayoutPlannerTests.swift; sourceTree = "<group>"; };
 		8747D7DA152CB73E2CF991C6 /* TmuxCompatArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatArgumentsTests.swift; sourceTree = "<group>"; };
 		880AC8A873636B3675457AAD /* SidebarTextMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTextMetrics.swift; sourceTree = "<group>"; };
@@ -796,6 +810,7 @@
 		9147BE310A4C4D3D61638835 /* CleanCopyPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanCopyPipeline.swift; sourceTree = "<group>"; };
 		916D215502518D8BAF3C3921 /* SidebarWorklaneRowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorklaneRowLayout.swift; sourceTree = "<group>"; };
 		91986D1792E0A3DD28D3A244 /* SidebarWorklaneRowDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorklaneRowDebugging.swift; sourceTree = "<group>"; };
+		91D88FB8E9B069D496016C8B /* AgentIntegrationConsentPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationConsentPanel.swift; sourceTree = "<group>"; };
 		932855A80F09B46E2143378A /* WorklaneStoreShellExitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreShellExitTests.swift; sourceTree = "<group>"; };
 		93AEBD7620888C77CB6FE423 /* AgyHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgyHooksInstaller.swift; sourceTree = "<group>"; };
 		93E9CA26FCDC9E619509598B /* GenericProgressReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProgressReducer.swift; sourceTree = "<group>"; };
@@ -965,6 +980,7 @@
 		E84313842197C75BCA9CE6E8 /* HermesTitleOverrideReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleOverrideReducer.swift; sourceTree = "<group>"; };
 		E89BAAA51D175EA4CC9174AA /* RecentCommandsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCommandsTracker.swift; sourceTree = "<group>"; };
 		EA5DD7A1968777DF9C77029D /* LibghosttySelectionAutoscrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySelectionAutoscrollControllerTests.swift; sourceTree = "<group>"; };
+		EB2414DEC30C1A200BC42DD4 /* AgentIntegrationGrandfather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationGrandfather.swift; sourceTree = "<group>"; };
 		EB3CF0787F91406CE385FEB3 /* PaneDragCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragCoordinator.swift; sourceTree = "<group>"; };
 		EB40B6883D6232A52132FA30 /* PresentationPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationPipeline.swift; sourceTree = "<group>"; };
 		EB869749410CBF86B97FA142 /* PaneAgentReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentReducer.swift; sourceTree = "<group>"; };
@@ -1345,8 +1361,11 @@
 		7F2110B46C3078BABC77C457 /* Agent */ = {
 			isa = PBXGroup;
 			children = (
+				6960333F9BE4F448FCA1D1A5 /* AgentConsentCoordinator.swift */,
 				5A2F1C3E75DEE37361D3D7CB /* AgentEventAdapters.swift */,
 				54776A43E504C15FF0D1AF56 /* AgentEventBridge.swift */,
+				86532A76726D9364B28994A8 /* AgentIntegrationConsent.swift */,
+				EB2414DEC30C1A200BC42DD4 /* AgentIntegrationGrandfather.swift */,
 				290AC219C812A96036CA9061 /* AgentInteractionClassifier.swift */,
 				2D33B3653DD17B96C1CA6222 /* AgentIPC.swift */,
 				A1762B3BE208D5BC1F3BDA20 /* AgentIPCProtocol.swift */,
@@ -1543,6 +1562,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		CEB5A269197978DEE22A0FA6 /* Agent */ = {
+			isa = PBXGroup;
+			children = (
+				91D88FB8E9B069D496016C8B /* AgentIntegrationConsentPanel.swift */,
+			);
+			path = Agent;
+			sourceTree = "<group>";
+		};
 		D11BB75179160944959BEF6F /* TaskManager */ = {
 			isa = PBXGroup;
 			children = (
@@ -1636,6 +1663,7 @@
 				16FEAF3CA4E96E1EB18692E8 /* ShellMetrics.swift */,
 				3E0AB398A3212751C553DAD6 /* WorklaneRenderCoordinator.swift */,
 				7A7A0E5823403E1ADEBAF14A /* About */,
+				CEB5A269197978DEE22A0FA6 /* Agent */,
 				6CA7086BC7A43381B11B2B71 /* Bookmarks */,
 				4A4B2BEA2DA770E96A563909 /* Canvas */,
 				C6FE1D6C93ADCAF5A6AD1364 /* Chrome */,
@@ -1681,12 +1709,16 @@
 			isa = PBXGroup;
 			children = (
 				9C9964E75CAB137C49B15001 /* AboutMetadataTests.swift */,
+				7B657E64F86B3DD0085CCD5E /* AgentConsentCoordinatorTests.swift */,
 				F564EFD678FB31CE540FBDEE /* AgentEventBridgeTests.swift */,
+				7B95C44923CD6F38E7D95D2F /* AgentIntegrationConsentTests.swift */,
+				3B1B5C7232C6BA07C385B052 /* AgentIntegrationGrandfatherTests.swift */,
 				38C15EEBB2B6060FDC3C8A05 /* AgentIPCDiscoveryTests.swift */,
 				C44EC40C277824843955668D /* AgentResumeCommandBuilderTests.swift */,
 				63B1DE306FB0DE066A552C2D /* AgentsSettingsSectionViewControllerTests.swift */,
 				003771A9512A8005B0DCF7DE /* AgentStatusSupportTests.swift */,
 				A2EE42F8FEB23D0CF10CA377 /* AgyHooksInstallerTests.swift */,
+				288F2452125BCCDB961229C9 /* AppConfigAgentIntegrationsTOMLTests.swift */,
 				3F4FEACEEB990E8008700659 /* AppConfigStoreTests.swift */,
 				2DD8525BB06D45D74C9E00C0 /* AppearanceSettingsSectionViewControllerTests.swift */,
 				48846247312C42A929369E20 /* AppKitTestCase.swift */,
@@ -2075,12 +2107,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				15B1CD25199B045107EB9EAA /* AboutMetadataTests.swift in Sources */,
+				834B6339AE9EE794ED76CDF9 /* AgentConsentCoordinatorTests.swift in Sources */,
 				641B941C78BEF72E157B5364 /* AgentEventBridgeTests.swift in Sources */,
 				701C39983F9037EC0FCFFEE4 /* AgentIPCDiscoveryTests.swift in Sources */,
+				57AB67F85512042ACB976A79 /* AgentIntegrationConsentTests.swift in Sources */,
+				50E494B39C06F67983331C3B /* AgentIntegrationGrandfatherTests.swift in Sources */,
 				28E673F10881B25E277F61A6 /* AgentResumeCommandBuilderTests.swift in Sources */,
 				55C1CC506BD2F0613AD94835 /* AgentStatusSupportTests.swift in Sources */,
 				D2BD827625AC63F83A22C7E8 /* AgentsSettingsSectionViewControllerTests.swift in Sources */,
 				73DF3F48A4FDC64C88FCBE2E /* AgyHooksInstallerTests.swift in Sources */,
+				0C598E3C54E30B5CC4466E2D /* AppConfigAgentIntegrationsTOMLTests.swift in Sources */,
 				1AC994B38934FF453310224A /* AppConfigStoreTests.swift in Sources */,
 				6EE8E68B18266DDCC31CD766 /* AppKitTestCase.swift in Sources */,
 				0D118FCB36F18F809879411C /* AppKitTestDisplayTests.swift in Sources */,
@@ -2234,10 +2270,14 @@
 				5CCCEA997B0C6BEA30A00A99 /* AboutMetadata.swift in Sources */,
 				C038C6FB8A7F9335CC3AFB1A /* AboutViewController.swift in Sources */,
 				522DDD2A865C44F69EA80545 /* AboutWindowController.swift in Sources */,
+				10495E193033CEF259528C11 /* AgentConsentCoordinator.swift in Sources */,
 				90051F9D3DECA1943ECDCB82 /* AgentEventAdapters.swift in Sources */,
 				6D5C3A48387A56D17DE5F06E /* AgentEventBridge.swift in Sources */,
 				52278F4B3EDD364F309993FF /* AgentIPC.swift in Sources */,
 				954386A2A2B7468FA9D1EA45 /* AgentIPCProtocol.swift in Sources */,
+				7C25A0942594D0EB8764DE8E /* AgentIntegrationConsent.swift in Sources */,
+				369B3146B2FC3DD67A95906D /* AgentIntegrationConsentPanel.swift in Sources */,
+				16F822122305BB7A1AE8DFF1 /* AgentIntegrationGrandfather.swift in Sources */,
 				8E2852FEAFC265DC3EC050BF /* AgentInteractionClassifier.swift in Sources */,
 				67EA47F52A1B60F0F570A8DE /* AgentLaunchBootstrap.swift in Sources */,
 				E6D0CAB78E81B81367E2F583 /* AgentStatus.swift in Sources */,

--- a/Zentty/AppDelegate.swift
+++ b/Zentty/AppDelegate.swift
@@ -115,6 +115,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         UNUserNotificationCenter.current().delegate = self
         applyMenuBarStatusConfig(configStore.current)
 
+        // Grandfather existing on-disk hook installs into the consent model
+        // before any restore spawns agents, so upgrading users are not prompted
+        // for hooks they already have. Skip when the config file couldn't be
+        // parsed: the migration persists, and we must not overwrite a config we
+        // couldn't read (it self-heals once the file is valid again).
+        if configStore.didLoadFromValidFile {
+            AgentIntegrationGrandfather.migrateIfNeeded(configStore: configStore)
+        }
+
+        // Wire the consent coordinator so the IPC handshake can prompt before a
+        // persistent agent's hooks are written to the user's config.
+        AgentConsentCoordinator.shared.configure(configStore: configStore) { tool, completion in
+            AgentIntegrationConsentPanel.present(tool: tool, completion: completion)
+        }
+
         guard shouldOpenMainWindow else { return }
 
         if isSessionRestoreEnabled {

--- a/Zentty/AppState/Agent/AgentConsentCoordinator.swift
+++ b/Zentty/AppState/Agent/AgentConsentCoordinator.swift
@@ -1,0 +1,127 @@
+import Foundation
+import os
+
+/// Coordinates the first-run integration-consent handshake between the IPC
+/// server — which blocks an agent launch on a background thread — and the
+/// MainActor consent panel.
+///
+/// Concurrent consent requests for the SAME agent coalesce onto a single panel
+/// and share its decision (so a workspace that launches two of the same agent
+/// shows one prompt, not two). The chosen state is persisted to AppConfig so
+/// later launches and the Settings UI reflect it.
+@MainActor
+final class AgentConsentCoordinator {
+    static let shared = AgentConsentCoordinator()
+
+    /// Presents the consent panel for `tool`, invoking `completion` exactly once
+    /// with the user's choice (`.on` to install hooks, `.off` to skip). Wired at
+    /// app startup.
+    typealias Presenter = @MainActor (_ tool: AgentBootstrapTool, _ completion: @escaping (AgentIntegrationState) -> Void) -> Void
+
+    private var configStore: AppConfigStore?
+    private var presenter: Presenter?
+    private var waiters: [AgentBootstrapTool: [(AgentIntegrationState) -> Void]] = [:]
+
+    /// Internal (not private) so tests can exercise coalescing on an isolated
+    /// instance rather than the shared singleton.
+    init() {}
+
+    /// Wire the live config store and the panel presenter. Called once at
+    /// startup. Until wired, consent requests resolve to `.off` without
+    /// persisting, so a headless or not-yet-initialized app runs degraded
+    /// rather than hanging — and the state stays `ask` for a later prompt.
+    func configure(configStore: AppConfigStore, presenter: @escaping Presenter) {
+        self.configStore = configStore
+        self.presenter = presenter
+    }
+
+    /// Request a consent decision. Coalesces concurrent requests for the same
+    /// tool onto one panel. `completion` fires (on the main actor) with the
+    /// resolved state once the user answers.
+    func requestDecision(
+        tool: AgentBootstrapTool,
+        completion: @escaping (AgentIntegrationState) -> Void
+    ) {
+        // Join an in-flight panel for the same tool instead of opening a second.
+        if waiters[tool] != nil {
+            waiters[tool]?.append(completion)
+            return
+        }
+        waiters[tool] = [completion]
+
+        guard let presenter else {
+            // No panel wired: decline WITHOUT persisting, leaving the state at
+            // `ask` so a later launch (with the panel wired) can still prompt.
+            resolve(tool: tool, state: .off, persist: false)
+            return
+        }
+        presenter(tool) { [weak self] state in
+            self?.resolve(tool: tool, state: state, persist: true)
+        }
+    }
+
+    private func resolve(tool: AgentBootstrapTool, state: AgentIntegrationState, persist: Bool) {
+        if persist {
+            do {
+                try configStore?.update { config in
+                    config.agentIntegrations.states[tool.rawValue] = state
+                }
+            } catch {
+                agentIntegrationLogger.error(
+                    "Failed to persist \(tool.rawValue, privacy: .public) consent decision: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        let completions = waiters[tool] ?? []
+        waiters[tool] = nil
+        for completion in completions {
+            completion(state)
+        }
+    }
+}
+
+extension AgentConsentCoordinator {
+    /// Blocks the calling (non-main) thread until the consent panel resolves,
+    /// returning the chosen state. The IPC server's per-connection handler runs
+    /// on a utility queue, so blocking it here is safe. MUST NOT be called on
+    /// the main thread — it would deadlock against the panel.
+    ///
+    /// On timeout, returns `.off`; the panel may still resolve later and persist
+    /// the real choice for the next launch (the wrapper has already fallen back
+    /// to a degraded launch by then).
+    nonisolated static func awaitDecisionBlocking(
+        tool: AgentBootstrapTool,
+        timeout: TimeInterval = TimeInterval(
+            AgentIPCProtocol.awaitConsentTimeoutSeconds - AgentIPCProtocol.consentPanelTimeoutMargin
+        )
+    ) -> AgentIntegrationState {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = ConsentResultBox()
+        Task { @MainActor in
+            shared.requestDecision(tool: tool) { state in
+                box.set(state)
+                semaphore.signal()
+            }
+        }
+        _ = semaphore.wait(timeout: .now() + timeout)
+        return box.value ?? .off
+    }
+}
+
+/// Thread-safe one-shot holder for the resolved consent state, written on the
+/// main actor and read on the IPC worker thread after the semaphore signals.
+private final class ConsentResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: AgentIntegrationState?
+
+    var value: AgentIntegrationState? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func set(_ newValue: AgentIntegrationState) {
+        lock.lock()
+        stored = newValue
+        lock.unlock()
+    }
+}

--- a/Zentty/AppState/Agent/AgentIPC.swift
+++ b/Zentty/AppState/Agent/AgentIPC.swift
@@ -857,6 +857,7 @@ final class AgentIPCServer: @unchecked Sendable {
                 fileManager: .default,
                 integrationDecision: decision
             )
+            notifyHooksDidChangeIfPersistent(decision: decision, tool: request.tool)
             guard request.expectsResponse else { return nil }
             return AgentIPCResponse(
                 id: request.id,
@@ -903,7 +904,7 @@ final class AgentIPCServer: @unchecked Sendable {
         } else {
             decision = .proceed
         }
-        return try AgentLaunchBootstrap.makePlan(
+        let plan = try AgentLaunchBootstrap.makePlan(
             request: request,
             target: target,
             runtimeDirectoryURL: runtimeDirectoryURL,
@@ -911,6 +912,26 @@ final class AgentIPCServer: @unchecked Sendable {
             fileManager: .default,
             integrationDecision: decision
         )
+        notifyHooksDidChangeIfPersistent(decision: decision, tool: request.tool)
+        return plan
+    }
+
+    /// Signal the Agents settings panel to re-check on-disk hook status after a
+    /// launch may have (re)installed hooks. Only `.proceed` reaches the per-tool
+    /// installer switch in `makePlan`, and only persistent tools write disk hooks,
+    /// so we gate on both — ephemeral and disabled/suppressed launches never post.
+    /// The disk write inside `makePlan` is synchronous and already done by the time
+    /// we post. We hop to the main thread because the observer (a `@MainActor`
+    /// settings panel) is selector-based and runs on the posting thread, and this
+    /// runs on a background IPC connection / consent thread.
+    private static func notifyHooksDidChangeIfPersistent(
+        decision: AgentIntegrationDecision,
+        tool: AgentBootstrapTool?
+    ) {
+        guard decision == .proceed, tool?.integrationClass == .persistent else { return }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .agentIntegrationHooksDidChange, object: nil)
+        }
     }
 
     private static func readRequestData(from fileDescriptor: Int32) throws -> Data {

--- a/Zentty/AppState/Agent/AgentIPC.swift
+++ b/Zentty/AppState/Agent/AgentIPC.swift
@@ -199,6 +199,12 @@ enum AgentIPCBridge {
             throw AgentIPCError.unsupportedSubcommand("server (must be handled by server)")
         case .tmuxCompat:
             throw AgentIPCError.unsupportedSubcommand("tmux_compat (must be handled by server)")
+        case .awaitConsent:
+            // The integration-consent handshake is resolved by the IPC server's
+            // per-connection handler, which shows the consent panel and answers
+            // with the resolved plan. It never falls through to this generic
+            // dispatch (same contract as discover/pane/server).
+            throw AgentIPCError.unsupportedSubcommand("await_consent (must be handled by server)")
         }
     }
 
@@ -406,6 +412,15 @@ final class AgentIPCServer: @unchecked Sendable {
     private var socketPath: String?
     private var runtimeDirectoryURL: URL?
     private var readSource: DispatchSourceRead?
+    /// Pane IDs whose first agent bootstrap should skip the integration-consent
+    /// prompt because the pane was spawned by a workspace restore/import (the
+    /// user did not actively launch it). Populated on the main actor during
+    /// restore and consumed exactly once per pane by the bootstrap gate, so a
+    /// *later* manual launch in the same pane prompts as usual. Replaces the old
+    /// `ZENTTY_RESTORE_LAUNCH` env var, which leaked into the pane's persistent
+    /// shell environment and suppressed every subsequent launch. Confined to
+    /// `queue`, like the socket/runtime-dir state above.
+    private var restorePendingPaneIDs: Set<String> = []
 
     init(
         fileManager: FileManager = .default,
@@ -417,6 +432,23 @@ final class AgentIPCServer: @unchecked Sendable {
         self.authentication = authentication
         self.instanceID = instanceID
         self.diagnosticsEnabled = diagnosticsEnabled
+    }
+
+    /// Mark a pane so its first agent bootstrap skips the consent prompt (see
+    /// `restorePendingPaneIDs`). Called from the restore path on the main actor.
+    func registerRestorePendingPane(_ paneID: String) {
+        queue.sync { restorePendingPaneIDs.insert(paneID) }
+    }
+
+    /// Returns `true` once if the pane was registered as restore-pending,
+    /// removing it so only the first bootstrap is suppressed. Called by the
+    /// bootstrap gate on a connection-handler thread.
+    func consumeRestorePendingPane(_ paneID: String) -> Bool {
+        queue.sync {
+            guard restorePendingPaneIDs.contains(paneID) else { return false }
+            restorePendingPaneIDs.remove(paneID)
+            return true
+        }
     }
 
     deinit {
@@ -646,7 +678,11 @@ final class AgentIPCServer: @unchecked Sendable {
         post: @escaping (AgentStatusPayload) -> Void,
         writeError: @escaping (String) -> Void
     ) {
-        defer { close(fileDescriptor) }
+        // The consent (`awaitConsent`) path hands this descriptor off to a
+        // dedicated thread that closes it once the panel resolves, so it must
+        // not be closed here when ownership has been transferred.
+        var fileDescriptorOwnedByHandler = true
+        defer { if fileDescriptorOwnedByHandler { close(fileDescriptor) } }
         var requestForErrorResponse: AgentIPCRequest?
 
         do {
@@ -719,26 +755,75 @@ final class AgentIPCServer: @unchecked Sendable {
                 return
             }
 
+            if canonicalRequest.kind == .bootstrap {
+                guard let runtimeDirectoryURL else {
+                    throw AgentIPCError.invalidMessage
+                }
+                let response = try resolveConsentedBootstrap(
+                    request: canonicalRequest,
+                    target: target,
+                    runtimeDirectoryURL: runtimeDirectoryURL,
+                    bundle: bundle
+                )
+                if let response {
+                    try writeResponse(response, to: fileDescriptor)
+                }
+                return
+            }
+
+            if canonicalRequest.kind == .awaitConsent {
+                guard let runtimeDirectoryURL else {
+                    throw AgentIPCError.invalidMessage
+                }
+                // Hand the descriptor to a dedicated thread for the (up to ~270s)
+                // consent wait, so it never parks a shared GCD pool thread and
+                // starves unrelated IPC (hooks, pane, discovery). The thread owns
+                // and closes the descriptor once the panel resolves.
+                fileDescriptorOwnedByHandler = false
+                let descriptor = fileDescriptor
+                let request = canonicalRequest
+                Thread.detachNewThread {
+                    defer { close(descriptor) }
+                    do {
+                        let plan = try awaitConsentPlan(
+                            request: request,
+                            target: target,
+                            runtimeDirectoryURL: runtimeDirectoryURL,
+                            bundle: bundle
+                        )
+                        if request.expectsResponse {
+                            try writeResponse(
+                                AgentIPCResponse(
+                                    id: request.id,
+                                    ok: true,
+                                    result: AgentIPCResponseResult(launchPlan: plan)
+                                ),
+                                to: descriptor
+                            )
+                        }
+                    } catch {
+                        if request.expectsResponse {
+                            try? writeResponse(errorResponse(for: request, error: error), to: descriptor)
+                        }
+                    }
+                }
+                return
+            }
+
+            // Only `.ipc` requests reach here: discover/pane/server/tmuxCompat,
+            // `.bootstrap`, and `.awaitConsent` are all handled and returned
+            // above. So no `bootstrap:` closure is needed — the default (which
+            // throws `unsupportedSubcommand`) documents that there is a single
+            // bootstrap path, in `resolveConsentedBootstrap`.
             let response = try AgentIPCBridge.handle(
                 request: canonicalRequest,
                 post: post,
-                bootstrap: { request in
-                    guard let runtimeDirectoryURL else {
-                        throw AgentIPCError.invalidMessage
+                writeError: { error in
+                    if diagnosticsEnabled {
+                        writeError("IPC bridge error: \(error.localizedDescription)")
                     }
-                    return try AgentLaunchBootstrap.makePlan(
-                        request: request,
-                        target: target,
-                        runtimeDirectoryURL: runtimeDirectoryURL,
-                        bundle: bundle,
-                        fileManager: .default
-                    )
                 }
-            ) { error in
-                if diagnosticsEnabled {
-                    writeError("IPC bridge error: \(error.localizedDescription)")
-                }
-            }
+            )
             if let response {
                 try writeResponse(response, to: fileDescriptor)
             }
@@ -751,6 +836,81 @@ final class AgentIPCServer: @unchecked Sendable {
                 writeError("Malformed IPC request: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Phase 1 of the consent handshake (`bootstrap`): a decided agent — or one
+    /// suppressed during restore — gets its plan immediately (≤2s, the wrapper's
+    /// timeout); an undecided persistent agent gets a `consentRequired` response
+    /// so the wrapper re-issues an `awaitConsent` request (phase 2).
+    private static func resolveConsentedBootstrap(
+        request: AgentIPCRequest,
+        target: AgentIPCTarget,
+        runtimeDirectoryURL: URL,
+        bundle: Bundle
+    ) throws -> AgentIPCResponse? {
+        func planResponse(decision: AgentIntegrationDecision) throws -> AgentIPCResponse? {
+            let plan = try AgentLaunchBootstrap.makePlan(
+                request: request,
+                target: target,
+                runtimeDirectoryURL: runtimeDirectoryURL,
+                bundle: bundle,
+                fileManager: .default,
+                integrationDecision: decision
+            )
+            guard request.expectsResponse else { return nil }
+            return AgentIPCResponse(
+                id: request.id,
+                ok: true,
+                result: AgentIPCResponseResult(launchPlan: plan)
+            )
+        }
+
+        // No tool (or no gate): behave exactly as before — a normal plan.
+        guard let gate = AgentLaunchBootstrap.integrationGate(for: request) else {
+            return try planResponse(decision: .proceed)
+        }
+
+        if let immediate = gate.immediateDecision {
+            return try planResponse(decision: immediate)
+        }
+        guard request.expectsResponse else { return nil }
+        return AgentIPCResponse(
+            id: request.id,
+            ok: true,
+            result: AgentIPCResponseResult(consentRequired: true)
+        )
+    }
+
+    /// Phase 2 of the consent handshake (`awaitConsent`): block on the consent
+    /// panel (re-checking in case the state was decided via Settings between the
+    /// phases), persist the answer, and build the resolved launch plan. Runs on
+    /// a dedicated thread (see the handoff in `handleConnection`), never a shared
+    /// GCD pool thread.
+    private static func awaitConsentPlan(
+        request: AgentIPCRequest,
+        target: AgentIPCTarget,
+        runtimeDirectoryURL: URL,
+        bundle: Bundle
+    ) throws -> AgentLaunchPlan {
+        let decision: AgentIntegrationDecision
+        if let tool = request.tool, let gate = AgentLaunchBootstrap.integrationGate(for: request) {
+            if let immediate = gate.immediateDecision {
+                decision = immediate
+            } else {
+                let state = AgentConsentCoordinator.awaitDecisionBlocking(tool: tool)
+                decision = AgentIntegrationConsent.decision(forConsentAnswer: state)
+            }
+        } else {
+            decision = .proceed
+        }
+        return try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: target,
+            runtimeDirectoryURL: runtimeDirectoryURL,
+            bundle: bundle,
+            fileManager: .default,
+            integrationDecision: decision
+        )
     }
 
     private static func readRequestData(from fileDescriptor: Int32) throws -> Data {

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -63,9 +63,106 @@ enum AgentBootstrapTool: String, Codable, Equatable, CaseIterable {
     /// so a restored pane is treated as an "agent pane" iff its command would
     /// actually trip the wrapper.
     static func wrappedAgent(forCommand command: String) -> AgentBootstrapTool? {
-        guard let firstToken = command.split(separator: " ").first else { return nil }
-        let binaryName = (String(firstToken) as NSString).lastPathComponent
+        guard let binaryName = wrappedAgentBinaryName(forCommand: command) else { return nil }
         return allCases.first { $0.realBinaryNames.contains(binaryName) }
+    }
+
+    private static func wrappedAgentBinaryName(forCommand command: String) -> String? {
+        let words = shellWords(from: command)
+        guard var executable = words.first else { return nil }
+
+        if (executable as NSString).lastPathComponent == "env" {
+            guard let envExecutable = words.dropFirst().first(where: { !isEnvironmentAssignment($0) }) else {
+                return nil
+            }
+            executable = envExecutable
+        }
+
+        return (executable as NSString).lastPathComponent
+    }
+
+    private static func isEnvironmentAssignment(_ word: String) -> Bool {
+        guard let equalsIndex = word.firstIndex(of: "="),
+              equalsIndex > word.startIndex
+        else { return false }
+
+        let name = word[..<equalsIndex]
+        guard let first = name.first,
+              first == "_" || first.isLetter
+        else { return false }
+
+        return name.allSatisfy { $0 == "_" || $0.isLetter || $0.isNumber }
+    }
+
+    /// Minimal shell-word splitting for restored launch commands. It is not a full
+    /// shell parser; it only preserves quoted whitespace well enough to skip
+    /// `env NAME=value` prefixes and inspect the real executable token.
+    private static func shellWords(from command: String) -> [String] {
+        enum Quote {
+            case none
+            case single
+            case double
+        }
+
+        var words: [String] = []
+        var current = ""
+        var hasCurrentWord = false
+        var quote: Quote = .none
+        var isEscaped = false
+
+        for character in command {
+            if isEscaped {
+                current.append(character)
+                hasCurrentWord = true
+                isEscaped = false
+                continue
+            }
+
+            switch quote {
+            case .none:
+                if character == "\\" {
+                    isEscaped = true
+                    hasCurrentWord = true
+                } else if character == "'" {
+                    quote = .single
+                    hasCurrentWord = true
+                } else if character == "\"" {
+                    quote = .double
+                    hasCurrentWord = true
+                } else if character.isWhitespace {
+                    if hasCurrentWord {
+                        words.append(current)
+                        current = ""
+                        hasCurrentWord = false
+                    }
+                } else {
+                    current.append(character)
+                    hasCurrentWord = true
+                }
+            case .single:
+                if character == "'" {
+                    quote = .none
+                } else {
+                    current.append(character)
+                }
+            case .double:
+                if character == "\"" {
+                    quote = .none
+                } else if character == "\\" {
+                    isEscaped = true
+                } else {
+                    current.append(character)
+                }
+            }
+        }
+
+        if isEscaped {
+            current.append("\\")
+        }
+        if hasCurrentWord {
+            words.append(current)
+        }
+        return words
     }
 }
 

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -3,6 +3,14 @@ import Foundation
 enum AgentIPCProtocol {
     static let version = 1
     static let selfPIDPlaceholder = "__ZENTTY_SELF_PID__"
+    /// Read timeout (seconds) the wrapper uses while blocked on the phase-2
+    /// `awaitConsent` response. The app must resolve the consent panel and write
+    /// its reply strictly before this elapses; the app-side wait stays below it
+    /// by `consentPanelTimeoutMargin`. Shared so the two values can't drift into
+    /// an inverted ordering across the app/CLI targets.
+    static let awaitConsentTimeoutSeconds = 300
+    /// Seconds the app-side consent wait stays below the wrapper timeout.
+    static let consentPanelTimeoutMargin = 30
 }
 
 enum AgentIPCRequestKind: String, Codable, Equatable {
@@ -12,9 +20,15 @@ enum AgentIPCRequestKind: String, Codable, Equatable {
     case discover
     case server
     case tmuxCompat = "tmux_compat"
+    /// Second phase of the integration-consent handshake. After a `bootstrap`
+    /// response carries `consentRequired`, the wrapper re-issues an
+    /// `awaitConsent` request (with a long read timeout) that the app holds
+    /// open while the consent panel is shown, then answers with the resolved
+    /// launch plan. See AgentIntegrationConsent + the IPC handler.
+    case awaitConsent = "await_consent"
 }
 
-enum AgentBootstrapTool: String, Codable, Equatable {
+enum AgentBootstrapTool: String, Codable, Equatable, CaseIterable {
     case amp
     case claude
     case codex
@@ -41,6 +55,17 @@ enum AgentBootstrapTool: String, Codable, Equatable {
         case .kimi:
             return [rawValue, "kimi-cli"]
         }
+    }
+
+    /// The wrapped agent whose real binary matches the leading token of a shell
+    /// command, or `nil` if the command isn't one of our agent CLIs. Mirrors how
+    /// the PATH wrapper itself decides a command is an agent (binary-name match),
+    /// so a restored pane is treated as an "agent pane" iff its command would
+    /// actually trip the wrapper.
+    static func wrappedAgent(forCommand command: String) -> AgentBootstrapTool? {
+        guard let firstToken = command.split(separator: " ").first else { return nil }
+        let binaryName = (String(firstToken) as NSString).lastPathComponent
+        return allCases.first { $0.realBinaryNames.contains(binaryName) }
     }
 }
 
@@ -172,6 +197,12 @@ struct AgentIPCResponseResult: Codable, Equatable {
     /// `capture-pane`, `list-panes`, `display-message`. The CLI writes this
     /// directly to stdout.
     let stdout: String?
+    /// Set on a `bootstrap` response when the agent's integration needs
+    /// first-run consent before its hooks may be written to the user's config.
+    /// The wrapper, on seeing this, re-issues an `awaitConsent` request that
+    /// blocks (long timeout) until the user answers the consent panel. Optional
+    /// for decode tolerance across version-skewed app/CLI pairs.
+    let consentRequired: Bool?
 
     init(
         launchPlan: AgentLaunchPlan? = nil,
@@ -180,7 +211,8 @@ struct AgentIPCResponseResult: Codable, Equatable {
         discoveredWorklanes: [DiscoveredWorklane]? = nil,
         discoveredPanes: [DiscoveredPane]? = nil,
         serverState: ServerListResult? = nil,
-        stdout: String? = nil
+        stdout: String? = nil,
+        consentRequired: Bool? = nil
     ) {
         self.launchPlan = launchPlan
         self.paneList = paneList
@@ -189,6 +221,7 @@ struct AgentIPCResponseResult: Codable, Equatable {
         self.discoveredPanes = discoveredPanes
         self.serverState = serverState
         self.stdout = stdout
+        self.consentRequired = consentRequired
     }
 }
 

--- a/Zentty/AppState/Agent/AgentIntegrationConsent.swift
+++ b/Zentty/AppState/Agent/AgentIntegrationConsent.swift
@@ -247,3 +247,11 @@ enum AgentIntegrationHooks {
         try handlers(for: tool)?.uninstall()
     }
 }
+
+extension Notification.Name {
+    /// Posted (in-process) when a persistent agent's on-disk hooks may have just
+    /// changed — e.g. a pane launch reinstalled them via `AgentLaunchBootstrap`.
+    /// The Agents settings panel observes this to re-check `isInstalled` and clear
+    /// a stale "Hooks missing" warning while it is already open.
+    static let agentIntegrationHooksDidChange = Notification.Name("AgentIntegrationHooksDidChange")
+}

--- a/Zentty/AppState/Agent/AgentIntegrationConsent.swift
+++ b/Zentty/AppState/Agent/AgentIntegrationConsent.swift
@@ -1,0 +1,249 @@
+import Foundation
+import os
+
+/// Shared logger for agent-integration consent/persistence paths. These are
+/// best-effort in-app operations that must log and continue rather than crash
+/// (see AGENTS.md error handling).
+let agentIntegrationLogger = Logger(subsystem: "be.zenjoy.zentty", category: "AgentIntegration")
+
+/// User-facing state of an agent's Zentty integration.
+///
+/// - `ask`: undecided. Only meaningful for *persistent* (config-modifying) agents
+///   that have never been consented; their first interactive launch shows the
+///   consent panel. Ephemeral agents are never `ask` (their default is `on`).
+/// - `on`: integration enabled. Persistent agents have their hooks installed;
+///   ephemeral agents get their per-launch shim/overlay.
+/// - `off`: integration disabled. The agent launches with no Zentty hooks at all
+///   (direct passthrough). Persistent agents have had their on-disk hooks removed.
+enum AgentIntegrationState: String, Codable, Equatable, Sendable, CaseIterable {
+    case ask
+    case on
+    case off
+}
+
+/// How an agent's integration is delivered, which determines its consent rules.
+///
+/// - `persistent`: Zentty writes hook entries into the user's on-disk config.
+///   These are consent-gated (tri-state, default `ask`).
+/// - `ephemeral`: hooks are passed via CLI args or a per-pane runtime overlay;
+///   the user's config is never touched. Enabled by default (binary on/off).
+enum AgentIntegrationClass: Equatable, Sendable {
+    case persistent
+    case ephemeral
+}
+
+/// What `AgentLaunchBootstrap.makePlan` should do for an agent once consent
+/// (if any) has been resolved.
+enum AgentIntegrationDecision: Equatable, Sendable {
+    /// Install / inject hooks as normal (the historical behavior).
+    case proceed
+    /// Integration disabled — produce a direct passthrough plan, no hooks.
+    case off
+    /// Unconsented persistent agent spawned during a workspace restore. Launch
+    /// degraded (no hooks) but leave the stored state at `ask` so the next
+    /// *manual* launch still prompts.
+    case suppressedByRestore
+}
+
+/// Handler-level resolution of an agent's launch gate from its stored state,
+/// computed before `makePlan` runs.
+enum AgentIntegrationGate: Equatable, Sendable {
+    case proceed
+    case off
+    case suppressedByRestore
+    /// Persistent + `ask` + interactive (non-restore) launch: the IPC handler
+    /// must respond `consentRequired` and show the consent panel before it can
+    /// resolve a `makePlan` decision.
+    case needsConsent
+
+    /// The `makePlan` decision for gates that bypass the consent panel.
+    /// `needsConsent` returns `nil` — it must first resolve via the panel.
+    var immediateDecision: AgentIntegrationDecision? {
+        switch self {
+        case .proceed: return .proceed
+        case .off: return .off
+        case .suppressedByRestore: return .suppressedByRestore
+        case .needsConsent: return nil
+        }
+    }
+}
+
+extension AgentBootstrapTool {
+    /// Whether this agent's integration writes to the user's on-disk config.
+    ///
+    /// Persistent agents install hooks inside `AgentLaunchBootstrap.makePlan`
+    /// (amp/cursor/droid/grok/agy/hermes). Everything else uses CLI args or a
+    /// per-pane overlay and leaves the user's config untouched.
+    var integrationClass: AgentIntegrationClass {
+        switch self {
+        case .amp, .cursor, .droid, .grok, .agy, .hermes:
+            return .persistent
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi:
+            return .ephemeral
+        }
+    }
+
+    /// The state used when the user has never configured this agent: persistent
+    /// agents start `ask` (prompt on first use), ephemeral agents start `on`.
+    var defaultIntegrationState: AgentIntegrationState {
+        integrationClass == .persistent ? .ask : .on
+    }
+
+    /// The display/icon counterpart in `AgentTool` (used by Settings + the
+    /// consent panel for the agent name and menu-bar-style icon).
+    var agentTool: AgentTool {
+        switch self {
+        case .amp: return .amp
+        case .claude: return .claudeCode
+        case .codex: return .codex
+        case .copilot: return .copilot
+        case .cursor: return .cursor
+        case .droid: return .droid
+        case .gemini: return .gemini
+        case .kimi: return .kimi
+        case .opencode: return .openCode
+        case .pi: return .pi
+        case .grok: return .grok
+        case .agy: return .agy
+        case .hermes: return .hermes
+        }
+    }
+
+    /// Human-readable name, e.g. "Claude Code", "Antigravity".
+    var integrationDisplayName: String { agentTool.displayName }
+
+    /// The config file/dir Zentty modifies for this agent — used by the consent
+    /// panel and the Settings "Reveal in Finder" recovery action. `nil` for
+    /// ephemeral agents, which never touch the user's config.
+    var integrationConfigURL: URL? {
+        switch self {
+        case .amp:
+            return AmpPluginInstaller
+                .defaultUserConfigHomeURL(environment: ProcessInfo.processInfo.environment)
+                .appendingPathComponent("amp/plugins/\(AmpPluginInstaller.pluginFileName)")
+        case .cursor: return CursorHooksInstaller.defaultUserHooksURL()
+        case .droid: return DroidHooksInstaller.defaultUserSettingsURL()
+        case .grok: return GrokHooksInstaller.defaultUserHooksURL()
+        case .agy: return AgyHooksInstaller.defaultUserHooksFileURL()
+        case .hermes: return HermesHooksInstaller.defaultConfigURL()
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi:
+            return nil
+        }
+    }
+
+    /// User-facing, tilde-abbreviated path of `integrationConfigURL` — shown in
+    /// the consent panel. `nil` for ephemeral agents.
+    var integrationConfigPathDisplay: String? {
+        integrationConfigURL.map { ($0.path as NSString).abbreviatingWithTildeInPath }
+    }
+}
+
+/// Pure, I/O-free resolution of integration consent. The IPC handler and tests
+/// both drive this; persistence and UI live elsewhere.
+enum AgentIntegrationConsent {
+    /// Persistent (config-modifying) agents, in Settings display order.
+    static let persistentTools: [AgentBootstrapTool] = [.amp, .cursor, .droid, .grok, .agy, .hermes]
+    /// Ephemeral (built-in) agents, in Settings display order.
+    static let ephemeralTools: [AgentBootstrapTool] = [.claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi]
+    /// All known agents, persistent group first.
+    static let allTools: [AgentBootstrapTool] = persistentTools + ephemeralTools
+
+    /// The effective state for a tool given what's stored in config (or its
+    /// class default when unset).
+    static func effectiveState(
+        for tool: AgentBootstrapTool,
+        storedState: AgentIntegrationState?
+    ) -> AgentIntegrationState {
+        storedState ?? tool.defaultIntegrationState
+    }
+
+    /// Resolve the launch gate for a tool from its stored state and whether this
+    /// launch is part of a workspace restore.
+    static func gate(
+        for tool: AgentBootstrapTool,
+        storedState: AgentIntegrationState?,
+        isRestore: Bool
+    ) -> AgentIntegrationGate {
+        switch effectiveState(for: tool, storedState: storedState) {
+        case .on:
+            return .proceed
+        case .off:
+            return .off
+        case .ask:
+            // Ephemeral agents default to `on`, so a stray `ask` on one is a
+            // data anomaly; treat it as proceed rather than blocking on a panel
+            // that has nothing to install.
+            guard tool.integrationClass == .persistent else { return .proceed }
+            return isRestore ? .suppressedByRestore : .needsConsent
+        }
+    }
+
+    /// Map a user's consent-panel answer (or a Settings toggle that runs the
+    /// same panel) to the `makePlan` decision.
+    static func decision(forConsentAnswer state: AgentIntegrationState) -> AgentIntegrationDecision {
+        state == .on ? .proceed : .off
+    }
+}
+
+/// The single place that maps a persistent agent to its on-disk install
+/// detector and remover. The grandfather migration and the Settings toggle both
+/// route through here, so adding a new persistent agent means touching exactly
+/// one switch — and `AgentIntegrationConsentTests` asserts every persistent tool
+/// resolves handlers (and every ephemeral tool does not), turning a forgotten
+/// branch into a test failure rather than a silent on-disk no-op.
+enum AgentIntegrationHooks {
+    struct Handlers {
+        let isInstalled: () -> Bool
+        let uninstall: () throws -> Void
+    }
+
+    /// On-disk handlers for a persistent agent, or `nil` for ephemeral agents
+    /// (which write nothing to the user's config).
+    static func handlers(for tool: AgentBootstrapTool) -> Handlers? {
+        switch tool {
+        case .amp:
+            return Handlers(
+                isInstalled: { AmpPluginInstaller.isInstalled() },
+                uninstall: { try AmpPluginInstaller.uninstall() }
+            )
+        case .cursor:
+            return Handlers(
+                isInstalled: { CursorHooksInstaller.isInstalled() },
+                uninstall: { try CursorHooksInstaller.uninstall(at: CursorHooksInstaller.defaultUserHooksURL()) }
+            )
+        case .droid:
+            return Handlers(
+                isInstalled: { DroidHooksInstaller.isInstalled() },
+                uninstall: { try DroidHooksInstaller.uninstall(at: DroidHooksInstaller.defaultUserSettingsURL()) }
+            )
+        case .grok:
+            return Handlers(
+                isInstalled: { GrokHooksInstaller.isInstalled() },
+                uninstall: { try GrokHooksInstaller.uninstall() }
+            )
+        case .agy:
+            return Handlers(
+                isInstalled: { AgyHooksInstaller.isInstalled() },
+                uninstall: { try AgyHooksInstaller.uninstall() }
+            )
+        case .hermes:
+            return Handlers(
+                isInstalled: { HermesHooksInstaller.isInstalled() },
+                uninstall: { try HermesHooksInstaller.uninstall() }
+            )
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi:
+            return nil
+        }
+    }
+
+    /// Whether the tool's hooks are currently installed on disk. Ephemeral
+    /// agents are never installed.
+    static func isInstalled(_ tool: AgentBootstrapTool) -> Bool {
+        handlers(for: tool)?.isInstalled() ?? false
+    }
+
+    /// Remove the tool's hooks from disk. No-op for ephemeral agents.
+    static func uninstall(_ tool: AgentBootstrapTool) throws {
+        try handlers(for: tool)?.uninstall()
+    }
+}

--- a/Zentty/AppState/Agent/AgentIntegrationGrandfather.swift
+++ b/Zentty/AppState/Agent/AgentIntegrationGrandfather.swift
@@ -1,0 +1,39 @@
+import Foundation
+import os
+
+/// One-time migration that marks already-installed persistent agents as `on`
+/// so users upgrading to the consent feature are never re-prompted for hooks
+/// they already have on disk. Runs once, guarded by `grandfatheredV1`.
+///
+/// Ephemeral agents are on by default and never need grandfathering. Persistent
+/// agents the user has never installed stay at their `ask` default, so their
+/// next manual launch prompts as intended for new installs.
+enum AgentIntegrationGrandfather {
+    /// Detect existing on-disk installs and record them as `on`, then set the
+    /// migration flag. A no-op after the first successful run. Call once at
+    /// startup, before any workspace restore spawns agents.
+    static func migrateIfNeeded(
+        configStore: AppConfigStore,
+        isInstalled: (AgentBootstrapTool) -> Bool = AgentIntegrationHooks.isInstalled
+    ) {
+        guard !configStore.current.agentIntegrations.grandfatheredV1 else { return }
+
+        var detected: [String: AgentIntegrationState] = [:]
+        for tool in AgentIntegrationConsent.persistentTools where isInstalled(tool) {
+            detected[tool.rawValue] = .on
+        }
+
+        do {
+            try configStore.update { config in
+                // Don't clobber any state the user has already set explicitly.
+                for (agentID, state) in detected where config.agentIntegrations.states[agentID] == nil {
+                    config.agentIntegrations.states[agentID] = state
+                }
+                config.agentIntegrations.grandfatheredV1 = true
+            }
+        } catch {
+            agentIntegrationLogger.error(
+                "Failed to persist grandfather migration: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -16,7 +16,8 @@ enum AgentLaunchBootstrap {
         runtimeDirectoryURL: URL,
         bundle: Bundle = .main,
         fileManager: FileManager = .default,
-        appConfigProvider: () -> AppConfig = loadAppConfig
+        appConfigProvider: () -> AppConfig = loadAppConfig,
+        integrationDecision: AgentIntegrationDecision = .proceed
     ) throws -> AgentLaunchPlan {
         guard request.version == AgentIPCProtocol.version else {
             throw AgentIPCError.invalidMessage
@@ -28,6 +29,24 @@ enum AgentLaunchBootstrap {
         let environment = request.environment
         guard let executablePath = environment["ZENTTY_REAL_BINARY"]?.nilIfBlank else {
             throw AgentIPCError.invalidMessage
+        }
+
+        // Integration-consent gate (resolved by the IPC handler before this
+        // call). A disabled agent — or an unconsented persistent agent spawned
+        // during a workspace restore — launches the real binary with no Zentty
+        // hooks at all. This is the single uniform off-switch for every agent;
+        // the per-tool `ZENTTY_*_HOOKS_DISABLED` checks below remain for the
+        // legacy env-var path and passthrough subcommands. Only Claude needs
+        // CLAUDECODE cleared so a nested launch still behaves.
+        switch integrationDecision {
+        case .proceed:
+            break
+        case .off, .suppressedByRestore:
+            return directPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                unsetEnvironment: tool == .claude ? ["CLAUDECODE"] : []
+            )
         }
 
         switch tool {
@@ -142,6 +161,28 @@ enum AgentLaunchBootstrap {
                 fileManager: fileManager
             )
         }
+    }
+
+    /// Resolve the integration gate for a bootstrap-style request: reads the
+    /// stored per-agent consent state from disk and the restore signal for this
+    /// pane. Returns `nil` when the request carries no tool. Used by the IPC
+    /// handler to decide between proceeding, passthrough, and prompting for
+    /// consent before calling `makePlan`.
+    ///
+    /// The restore signal is a one-shot, per-pane token consumed from the IPC
+    /// server (`consumeRestorePending`, injectable for tests). Consuming it here
+    /// means a restore-spawned launch is suppressed but the *next* launch in the
+    /// same pane prompts. The gate is resolved once per bootstrap connection, so
+    /// the single consume is safe: a suppressed (restore) launch never reaches
+    /// the phase-2 `awaitConsent` re-resolution.
+    static func integrationGate(
+        for request: AgentIPCRequest,
+        consumeRestorePending: (String) -> Bool = { AgentIPCServer.shared.consumeRestorePendingPane($0) }
+    ) -> AgentIntegrationGate? {
+        guard let tool = request.tool else { return nil }
+        let storedState = loadAppConfig().agentIntegrations.states[tool.rawValue]
+        let isRestore = request.environment["ZENTTY_PANE_ID"].map(consumeRestorePending) ?? false
+        return AgentIntegrationConsent.gate(for: tool, storedState: storedState, isRestore: isRestore)
     }
 
     private static func ampPlan(

--- a/Zentty/AppState/Agent/AgyHooksInstaller.swift
+++ b/Zentty/AppState/Agent/AgyHooksInstaller.swift
@@ -247,6 +247,24 @@ enum AgyHooksInstaller {
         try newData.write(to: resolvedURL, options: .atomic)
     }
 
+    /// True when `hooks.json` currently carries a Zentty-owned `zentty` group.
+    /// Mirrors the recognition guard `uninstall` uses, so the grandfather
+    /// migration only marks agents whose hooks we would actually remove.
+    static func isInstalled(
+        hooksFileURL: URL = defaultUserHooksFileURL(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let resolvedURL = resolvedHooksFileURL(hooksFileURL, fileManager: fileManager)
+        guard
+            let data = try? Data(contentsOf: resolvedURL), !data.isEmpty,
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let group = parsed[groupKey]
+        else {
+            return false
+        }
+        return groupLooksOwnedByZentty(group)
+    }
+
     /// Ensures Zentty's Antigravity status hooks exist for the current user,
     /// installing them on first launch and keeping them current thereafter.
     /// Called from `AgentLaunchBootstrap.agyPlan` on every agy launch, so it

--- a/Zentty/AppState/Agent/AmpPluginInstaller.swift
+++ b/Zentty/AppState/Agent/AmpPluginInstaller.swift
@@ -81,6 +81,23 @@ enum AmpPluginInstaller {
         try fileManager.removeItem(at: destinationURL)
     }
 
+    /// True when the bundled Zentty plugin is present and carries our ownership
+    /// marker — the same guard `uninstall` requires before removing it. Used by
+    /// the grandfather migration to recognize pre-existing installs.
+    static func isInstalled(
+        destinationConfigHomeURL: URL = defaultUserConfigHomeURL(environment: ProcessInfo.processInfo.environment),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let destinationURL = bundledPluginDestinationURL(destinationConfigHomeURL: destinationConfigHomeURL)
+        guard
+            fileManager.fileExists(atPath: destinationURL.path),
+            let existing = try? String(contentsOf: destinationURL, encoding: .utf8)
+        else {
+            return false
+        }
+        return existing.contains(ownershipMarker)
+    }
+
     static func defaultUserConfigHomeURL(environment: [String: String]) -> URL {
         if let configRoot = nonBlank(environment["XDG_CONFIG_HOME"]) {
             return URL(fileURLWithPath: configRoot, isDirectory: true)

--- a/Zentty/AppState/Agent/CursorHooksInstaller.swift
+++ b/Zentty/AppState/Agent/CursorHooksInstaller.swift
@@ -163,6 +163,30 @@ enum CursorHooksInstaller {
         try newData.write(to: hooksURL, options: .atomic)
     }
 
+    /// True when the user's hooks file currently carries a Zentty-managed
+    /// entry — the same predicate `uninstall` uses to find our entries. Used by
+    /// the grandfather migration to recognize pre-existing installs.
+    static func isInstalled(
+        at hooksURL: URL = defaultUserHooksURL(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard
+            fileManager.isReadableFile(atPath: hooksURL.path),
+            let data = try? Data(contentsOf: hooksURL), !data.isEmpty,
+            let jsonObject = parsePermissive(data),
+            let hooks = jsonObject["hooks"] as? [String: Any]
+        else {
+            return false
+        }
+        for event in managedEvents {
+            guard let entries = hooks[event] as? [[String: Any]] else { continue }
+            if entries.contains(where: { ($0["command"] as? String)?.contains(hookMarker) == true }) {
+                return true
+            }
+        }
+        return false
+    }
+
     /// Run `install` with environment-derived paths, logging the outcome.
     /// Used by the auto-install path during `zentty launch cursor`.
     static func installIfPossible(

--- a/Zentty/AppState/Agent/DroidHooksInstaller.swift
+++ b/Zentty/AppState/Agent/DroidHooksInstaller.swift
@@ -173,6 +173,32 @@ enum DroidHooksInstaller {
         try newData.write(to: settingsURL, options: .atomic)
     }
 
+    /// True when the user's settings file currently carries a Zentty-managed
+    /// hook entry — mirrors the nested predicate `uninstall` uses. Used by the
+    /// grandfather migration to recognize pre-existing installs.
+    static func isInstalled(
+        at settingsURL: URL = defaultUserSettingsURL(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard
+            fileManager.isReadableFile(atPath: settingsURL.path),
+            let data = try? Data(contentsOf: settingsURL), !data.isEmpty,
+            let jsonObject = parsePermissive(data),
+            let hooks = jsonObject["hooks"] as? [String: Any]
+        else {
+            return false
+        }
+        for event in managedEvents {
+            guard let entries = hooks[event] as? [[String: Any]] else { continue }
+            let owned = entries.contains { entry in
+                guard let nestedHooks = entry["hooks"] as? [[String: Any]] else { return false }
+                return nestedHooks.contains { ($0["command"] as? String)?.contains(hookMarker) == true }
+            }
+            if owned { return true }
+        }
+        return false
+    }
+
     /// URL for `~/.factory/hooks/hooks.json` where Droid persists hook-level
     /// settings like `showHookOutput`.
     static func defaultHooksConfigURL(

--- a/Zentty/AppState/Agent/GrokHooksInstaller.swift
+++ b/Zentty/AppState/Agent/GrokHooksInstaller.swift
@@ -77,6 +77,31 @@ enum GrokHooksInstaller {
             .appendingPathComponent("hooks", isDirectory: true)
     }
 
+    /// True when the Zentty forwarder script is present and carries our marker
+    /// — the ownership signal `uninstall` keys off for the current layout. Used
+    /// by the grandfather migration to recognize pre-existing installs.
+    ///
+    /// Note: this detects only the current `zentty-status/01-zentty-status.sh`
+    /// layout. `uninstall` additionally cleans up legacy artifacts (per-event
+    /// scripts, `user-settings.json` entries, plugin manifests); a user who has
+    /// ONLY a legacy install and never re-ran grok since the layout change is
+    /// not detected here and is re-prompted once on next launch (self-healing).
+    static func isInstalled(
+        hooksRoot: URL = defaultUserHooksURL(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let forwarderURL = hooksRoot
+            .appendingPathComponent(forwarderSubdirName, isDirectory: true)
+            .appendingPathComponent(forwarderScriptName, isDirectory: false)
+        guard
+            fileManager.isReadableFile(atPath: forwarderURL.path),
+            let script = try? String(contentsOf: forwarderURL, encoding: .utf8)
+        else {
+            return false
+        }
+        return script.contains(hookMarker)
+    }
+
     /// Ensures Zentty-managed Grok status hooks exist for the current user.
     /// Idempotent and cheap — only writes if our content has drifted.
     /// Returns true if this was the first install we noticed.

--- a/Zentty/AppState/Agent/HermesHooksInstaller.swift
+++ b/Zentty/AppState/Agent/HermesHooksInstaller.swift
@@ -133,6 +133,33 @@ enum HermesHooksInstaller {
         }
     }
 
+    /// True when the Hermes config currently contains a well-formed Zentty
+    /// managed block. Mirrors `removeManagedBlock` exactly — a standalone
+    /// (trimmed) begin-marker line followed by a matching end-marker line — so a
+    /// corrupted or commented-out marker isn't mistaken for a live install (a
+    /// false positive would wrongly grandfather the agent `on`). Used by the
+    /// grandfather migration to recognize pre-existing installs.
+    static func isInstalled(
+        configURL: URL = defaultConfigURL(),
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard
+            fileManager.isReadableFile(atPath: configURL.path),
+            let config = try? String(contentsOf: configURL, encoding: .utf8)
+        else {
+            return false
+        }
+        let lines = config.components(separatedBy: "\n")
+        guard let start = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == hookMarker
+        }) else {
+            return false
+        }
+        return lines[start...].contains {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == hookEndMarker
+        }
+    }
+
     @discardableResult
     static func ensureInstalledForCurrentUser(
         cliPath: String,

--- a/Zentty/Config/AppConfig.swift
+++ b/Zentty/Config/AppConfig.swift
@@ -174,6 +174,26 @@ struct AppConfig: Equatable, Sendable {
         )
     }
 
+    /// Per-agent enable/disable state for Zentty's CLI integrations. Persistent
+    /// (config-modifying) agents are tri-state and consent-gated; ephemeral
+    /// agents are on by default. See `AgentIntegrationConsent`.
+    struct AgentIntegrations: Equatable, Sendable {
+        /// State keyed by `AgentBootstrapTool.rawValue`. Absent keys fall back to
+        /// the tool's class default (`AgentBootstrapTool.defaultIntegrationState`).
+        var states: [String: AgentIntegrationState]
+        /// True once the one-time grandfather migration has run, marking
+        /// already-installed persistent agents `on` so upgrading users are not
+        /// re-prompted for consent.
+        var grandfatheredV1: Bool
+
+        static let `default` = AgentIntegrations(states: [:], grandfatheredV1: false)
+
+        /// Effective state for a tool, applying the class default when unset.
+        func state(for tool: AgentBootstrapTool) -> AgentIntegrationState {
+            AgentIntegrationConsent.effectiveState(for: tool, storedState: states[tool.rawValue])
+        }
+    }
+
     var sidebar: Sidebar
     var paneLayout: PaneLayoutPreferences
     var panes: Panes
@@ -190,6 +210,7 @@ struct AppConfig: Equatable, Sendable {
     var agentTeams: AgentTeams
     var agentCaffeination: AgentCaffeination
     var menuBar: MenuBar
+    var agentIntegrations: AgentIntegrations
 
     static let `default` = AppConfig(
         sidebar: Sidebar(
@@ -210,7 +231,8 @@ struct AppConfig: Equatable, Sendable {
         restore: .default,
         agentTeams: .default,
         agentCaffeination: .default,
-        menuBar: .default
+        menuBar: .default,
+        agentIntegrations: .default
     )
 
     static func migrated(
@@ -237,7 +259,8 @@ struct AppConfig: Equatable, Sendable {
             restore: .default,
             agentTeams: .default,
             agentCaffeination: .default,
-            menuBar: .default
+            menuBar: .default,
+            agentIntegrations: .default
         )
     }
 

--- a/Zentty/Config/AppConfigStore.swift
+++ b/Zentty/Config/AppConfigStore.swift
@@ -74,6 +74,12 @@ final class AppConfigStore: @unchecked Sendable {
     let fileURL: URL
 
     private(set) var current: AppConfig
+    /// `false` only when an on-disk config file existed but could not be parsed
+    /// (the `.invalid` case): `current` then falls back to defaults but the file
+    /// is deliberately left untouched. Startup migrations that would persist
+    /// (e.g. `AgentIntegrationGrandfather`) should skip in that state so they
+    /// don't overwrite a config we couldn't read (e.g. a forward-version file).
+    let didLoadFromValidFile: Bool
     private let fileWatcher = FileWatcher()
     private var changeHandlers: [UUID: ChangeHandler] = [:]
 
@@ -96,11 +102,14 @@ final class AppConfigStore: @unchecked Sendable {
         switch Self.load(fileURL: resolvedFileURL) {
         case .loaded(let persisted):
             current = persisted.normalized()
+            didLoadFromValidFile = true
         case .missing:
             current = migrated.normalized()
             try? Self.persist(config: current, to: resolvedFileURL, fileManager: fileManager)
+            didLoadFromValidFile = true
         case .invalid:
             current = AppConfig.default.normalized()
+            didLoadFromValidFile = false
             appConfigLogger.error("Ignoring invalid config file at \(resolvedFileURL.path, privacy: .public)")
         }
 

--- a/Zentty/Config/AppConfigTOML.swift
+++ b/Zentty/Config/AppConfigTOML.swift
@@ -28,6 +28,8 @@ enum AppConfigTOML {
         case agentTeams
         case agentCaffeination
         case menuBar
+        case agentIntegrations
+        case agentIntegrationStates
     }
 
     static func encode(_ config: AppConfig) -> String {
@@ -169,6 +171,19 @@ enum AppConfigTOML {
         lines.append("[menu_bar]")
         lines.append("show_status_item = \(config.menuBar.showStatusItem)")
 
+        lines.append("")
+        lines.append("[agent_integrations]")
+        lines.append("grandfathered_v1 = \(config.agentIntegrations.grandfatheredV1)")
+
+        let sortedAgentStates = config.agentIntegrations.states.sorted { $0.key < $1.key }
+        if !sortedAgentStates.isEmpty {
+            lines.append("")
+            lines.append("[agent_integrations.states]")
+            for (agentID, state) in sortedAgentStates {
+                lines.append("\(agentID) = \(encode(string: state.rawValue))")
+            }
+        }
+
         return lines.joined(separator: "\n") + "\n"
     }
 
@@ -266,6 +281,14 @@ enum AppConfigTOML {
                 section = .menuBar
                 continue
             }
+            if line == "[agent_integrations]" {
+                section = .agentIntegrations
+                continue
+            }
+            if line == "[agent_integrations.states]" {
+                section = .agentIntegrationStates
+                continue
+            }
             guard let assignment = parseAssignment(line) else {
                 return nil
             }
@@ -352,6 +375,14 @@ enum AppConfigTOML {
                 }
             case .menuBar:
                 guard decodeMenuBarAssignment(assignment, into: &config) else {
+                    return nil
+                }
+            case .agentIntegrations:
+                guard decodeAgentIntegrationsAssignment(assignment, into: &config) else {
+                    return nil
+                }
+            case .agentIntegrationStates:
+                guard decodeAgentIntegrationStatesAssignment(assignment, into: &config) else {
                     return nil
                 }
             case .root:
@@ -795,6 +826,35 @@ enum AppConfigTOML {
         default:
             return true
         }
+        return true
+    }
+
+    private static func decodeAgentIntegrationsAssignment(
+        _ assignment: (key: String, value: String),
+        into config: inout AppConfig
+    ) -> Bool {
+        switch assignment.key {
+        case "grandfathered_v1":
+            guard let value = decodeBool(assignment.value) else { return false }
+            config.agentIntegrations.grandfatheredV1 = value
+        default:
+            return true
+        }
+        return true
+    }
+
+    private static func decodeAgentIntegrationStatesAssignment(
+        _ assignment: (key: String, value: String),
+        into config: inout AppConfig
+    ) -> Bool {
+        // key = agent id (`AgentBootstrapTool.rawValue`); value = quoted state.
+        guard let raw = decodeString(assignment.value) else { return false }
+        // Unknown/future state values are skipped (not stored) so an older app
+        // reading a newer config never discards the whole file; recognized
+        // values are stored under the raw agent key, which keeps the section
+        // forward-compatible with agents this build doesn't know yet.
+        guard let state = AgentIntegrationState(rawValue: raw) else { return true }
+        config.agentIntegrations.states[assignment.key] = state
         return true
     }
 

--- a/Zentty/Restore/PaneRestorationBuilder.swift
+++ b/Zentty/Restore/PaneRestorationBuilder.swift
@@ -26,7 +26,8 @@ enum PaneRestorationBuilder {
         _ inputs: PaneInputs,
         windowID: WindowID,
         worklaneID: WorklaneID,
-        processEnvironment: [String: String]
+        processEnvironment: [String: String],
+        registerRestorePending: (PaneID) -> Void = { AgentIPCServer.shared.registerRestorePendingPane($0.rawValue) }
     ) -> Result {
         let homeDirectory = defaultWorkingDirectory(processEnvironment: processEnvironment)
         let requestedDirectory = trimmed(inputs.requestedWorkingDirectory)
@@ -68,6 +69,21 @@ enum PaneRestorationBuilder {
         )
         for (key, value) in WorklaneSessionEnvironment.templateSafeOverrides(from: inputs.environmentOverrides) {
             environment[key] = value
+        }
+        // Mark restore/import-spawned panes that actually auto-launch an agent CLI
+        // so the integration-consent gate launches an unconsented persistent agent
+        // degraded instead of halting the restore with a prompt. The mark is a
+        // one-shot, per-pane token (not a persistent env var), so the next manual
+        // launch in this pane prompts as usual.
+        //
+        // Only a pane whose restored `command` is an agent gets the token: a plain
+        // shell pane must NOT pre-consume it, or the user's first *manual* agent
+        // launch in that restored pane would be silently suppressed instead of
+        // prompting. `prefillText` is ignored on purpose — it is prefilled, not
+        // auto-run, so executing it later is a genuine manual launch.
+        if let command = trimmed(inputs.command),
+           AgentBootstrapTool.wrappedAgent(forCommand: command) != nil {
+            registerRestorePending(inputs.id)
         }
 
         let pane = PaneState(

--- a/Zentty/UI/Agent/AgentIntegrationConsentPanel.swift
+++ b/Zentty/UI/Agent/AgentIntegrationConsentPanel.swift
@@ -4,223 +4,120 @@ import AppKit
 /// such an agent launches, or when enabling one from Settings. Explains what
 /// Zentty will write to the user's config and offers Enable / Not Now.
 ///
-/// The panel floats centered above the app; it does not run a nested modal loop,
-/// so the rest of Zentty stays usable while the agent itself stays halted (its
-/// launch is blocked on the IPC handshake until this resolves). `completion`
-/// fires exactly once with `.on` (install hooks) or `.off` (skip).
+/// It is a genuine `NSAlert` (same idiom as the Quit confirmation and the
+/// uninstall-failure warning) so the buttons are exactly native. It is presented
+/// as a sheet on the key window when there is one, so the rest of Zentty stays
+/// usable while the agent itself stays halted (its launch is blocked on the IPC
+/// handshake until this resolves); it falls back to a modal run only when no host
+/// window is available. `completion` fires exactly once with `.on` (install hooks)
+/// or `.off` (skip).
 @MainActor
 enum AgentIntegrationConsentPanel {
+    /// Per-tool in-flight registry. Concurrent prompts for the SAME agent (e.g. a
+    /// launch-time prompt and a Settings toggle) coalesce onto one alert instead of
+    /// stacking; all queued completions fire once on resolve.
+    private static var pending: [AgentBootstrapTool: [(AgentIntegrationState) -> Void]] = [:]
+
+    /// Present the consent alert for `tool`, or attach `completion` to the one
+    /// already in flight for it.
     static func present(
         tool: AgentBootstrapTool,
         completion: @escaping (AgentIntegrationState) -> Void
     ) {
-        AgentIntegrationConsentWindowController.present(tool: tool, completion: completion)
-    }
-}
-
-@MainActor
-private final class AgentIntegrationConsentWindowController: NSWindowController, NSWindowDelegate {
-    /// Live controller per tool. Concurrent prompts for the same agent (e.g. a
-    /// launch-time prompt and a Settings toggle) coalesce onto one window
-    /// instead of stacking; all queued completions fire once on resolve. The
-    /// dictionary also keeps the controller alive until its window closes.
-    private static var live: [AgentBootstrapTool: AgentIntegrationConsentWindowController] = [:]
-
-    /// Open the panel for `tool`, or attach `completion` to the one already
-    /// open for it.
-    static func present(
-        tool: AgentBootstrapTool,
-        completion: @escaping (AgentIntegrationState) -> Void
-    ) {
-        if let existing = live[tool] {
-            existing.completions.append(completion)
-            existing.bringToFront()
+        if pending[tool] != nil {
+            pending[tool]?.append(completion)
             return
         }
-        let controller = AgentIntegrationConsentWindowController(tool: tool, completion: completion)
-        live[tool] = controller
-        controller.bringToFront()
+        pending[tool] = [completion]
+        show(tool: tool)
     }
 
-    private let tool: AgentBootstrapTool
-    private var completions: [(AgentIntegrationState) -> Void]
-    private var hasResolved = false
-    private let detailsLabel = NSTextField(wrappingLabelWithString: "")
-    private var detailsVisible = false
+    // MARK: - Presentation
 
-    init(tool: AgentBootstrapTool, completion: @escaping (AgentIntegrationState) -> Void) {
-        self.tool = tool
-        self.completions = [completion]
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 200),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        window.isReleasedWhenClosed = false
-        window.level = .floating
-        window.titlebarAppearsTransparent = true
-        window.title = ""
-        super.init(window: window)
-        window.delegate = self
-        window.contentView = makeContentView()
-        window.setContentSize(window.contentView?.fittingSize ?? NSSize(width: 460, height: 240))
-    }
+    private static func show(tool: AgentBootstrapTool) {
+        let name = tool.integrationDisplayName
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Enable \(name) status in Zentty?"
+        alert.informativeText = informativeText(name: name)
+        // No icon: presented as a sheet, NSAlert renders without one (same as the Quit
+        // confirmation, which also sets none). The app icon only shows on the rare
+        // modal fallback below.
+        if let path = tool.integrationConfigPathDisplay {
+            alert.accessoryView = makePathBox(path: path)
+        }
 
-    private func bringToFront() {
-        window?.center()
+        // First button added is the rightmost / default one (prominent blue).
+        let enable = alert.addButton(withTitle: "Enable")
+        enable.keyEquivalent = "\r"
+        let notNow = alert.addButton(withTitle: "Not Now")
+        notNow.keyEquivalent = "\u{1b}" // Escape
+
         NSApp.activate(ignoringOtherApps: true)
-        window?.makeKeyAndOrderFront(nil)
+        // Attach to the key window, or the main window when the app isn't frontmost
+        // (e.g. an agent launching in the background). Only when there is no visible
+        // host at all do we fall back to a modal run.
+        let host = NSApp.keyWindow ?? NSApp.mainWindow
+        if let host, host.isVisible {
+            alert.beginSheetModal(for: host) { response in
+                resolve(tool: tool, state: state(for: response))
+            }
+        } else {
+            resolve(tool: tool, state: state(for: alert.runModal()))
+        }
+    }
+
+    private static func state(for response: NSApplication.ModalResponse) -> AgentIntegrationState {
+        // Enable is the first button; anything else (Not Now, Escape) declines.
+        response == .alertFirstButtonReturn ? .on : .off
+    }
+
+    /// Fire all queued completions once and drop the per-tool registration.
+    private static func resolve(tool: AgentBootstrapTool, state: AgentIntegrationState) {
+        let completions = pending[tool] ?? []
+        pending[tool] = nil
+        for completion in completions {
+            completion(state)
+        }
     }
 
     // MARK: - Content
 
-    private func makeContentView() -> NSView {
-        let name = tool.integrationDisplayName
+    /// Two short paragraphs — why the hooks are needed, then what changes and how to
+    /// undo it — so the prompt scans quickly. NSAlert renders `\n\n` as a paragraph
+    /// break.
+    private static func informativeText(name: String) -> String {
+        let why = "On its own, Zentty can't tell what \(name) is doing. Status hooks let \(name) report "
+            + "that, so Zentty can show its status in the sidebar and notify you when it needs input."
 
-        let icon = NSImageView()
-        icon.image = MenuBarStatusIconRenderer.agentIconTemplateImage(for: tool.agentTool)
-        icon.image?.isTemplate = true
-        icon.contentTintColor = .controlAccentColor
-        icon.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            icon.widthAnchor.constraint(equalToConstant: 38),
-            icon.heightAnchor.constraint(equalToConstant: 38),
-        ])
+        let change = "Zentty adds these hooks to your \(name) config, tagged so it can remove them again "
+            + "when you turn this off or run `zentty uninstall`. You can change this anytime in "
+            + "Settings › Agents."
 
-        let title = NSTextField(labelWithString: "Enable \(name) status in Zentty?")
-        title.font = .systemFont(ofSize: 15, weight: .semibold)
-        title.lineBreakMode = .byWordWrapping
-        title.maximumNumberOfLines = 0
-
-        let header = NSStackView(views: [icon, title])
-        header.orientation = .horizontal
-        header.alignment = .centerY
-        header.spacing = 12
-
-        let body = NSTextField(wrappingLabelWithString:
-            "Zentty can show \(name)'s live status in the sidebar and notify you when it needs input. "
-            + "This requires installing status hooks in your \(name) configuration.")
-        body.font = .systemFont(ofSize: 13)
-        body.textColor = .secondaryLabelColor
-
-        let stack = NSStackView(views: [header, body])
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = 12
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        if let path = tool.integrationConfigPathDisplay {
-            stack.addArrangedSubview(makePathBox(path: path))
-
-            let disclosure = NSButton(title: "Show what changes", target: self, action: #selector(toggleDetails))
-            disclosure.bezelStyle = .inline
-            disclosure.isBordered = false
-            disclosure.contentTintColor = .controlAccentColor
-            disclosure.font = .systemFont(ofSize: 12)
-            stack.addArrangedSubview(disclosure)
-
-            detailsLabel.stringValue =
-                "Zentty adds its status-hook entries to the file above (marked so they can be found again) "
-                + "and changes nothing else. They are removed when you turn this off, or via `zentty uninstall`."
-            detailsLabel.font = .systemFont(ofSize: 12)
-            detailsLabel.textColor = .secondaryLabelColor
-            detailsLabel.isHidden = true
-            stack.addArrangedSubview(detailsLabel)
-        }
-
-        let reversibility = NSTextField(wrappingLabelWithString: "You can turn this off anytime in Settings › Agents.")
-        reversibility.font = .systemFont(ofSize: 12)
-        reversibility.textColor = .tertiaryLabelColor
-        stack.addArrangedSubview(reversibility)
-
-        let notNow = NSButton(title: "Not Now", target: self, action: #selector(declineTapped))
-        notNow.bezelStyle = .rounded
-        notNow.keyEquivalent = "\u{1b}" // Escape
-        let enable = NSButton(title: "Enable", target: self, action: #selector(enableTapped))
-        enable.bezelStyle = .rounded
-        enable.keyEquivalent = "\r" // Return — default button
-        let spacer = NSView()
-        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        let buttons = NSStackView(views: [spacer, notNow, enable])
-        buttons.orientation = .horizontal
-        buttons.spacing = 10
-        stack.addArrangedSubview(buttons)
-        buttons.leadingAnchor.constraint(equalTo: stack.leadingAnchor).isActive = true
-        buttons.trailingAnchor.constraint(equalTo: stack.trailingAnchor).isActive = true
-
-        let container = NSView()
-        container.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 24),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -24),
-            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
-            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -20),
-            stack.widthAnchor.constraint(equalToConstant: 412),
-        ])
-        return container
+        return why + "\n\n" + change
     }
 
-    private func makePathBox(path: String) -> NSView {
+    /// A fixed-size rounded box showing the config path, used as the alert's
+    /// accessory view. NSAlert sizes an accessory view from its frame, so the box
+    /// keeps an explicit frame and constrains the label within it.
+    private static func makePathBox(path: String) -> NSView {
         let label = NSTextField(labelWithString: path)
         label.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
         label.textColor = .labelColor
         label.lineBreakMode = .byTruncatingMiddle
         label.translatesAutoresizingMaskIntoConstraints = false
 
-        let box = NSView()
+        let box = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 30))
         box.wantsLayer = true
         box.layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.12).cgColor
         box.layer?.cornerRadius = 6
-        box.translatesAutoresizingMaskIntoConstraints = false
         box.addSubview(label)
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 10),
             label.trailingAnchor.constraint(equalTo: box.trailingAnchor, constant: -10),
-            label.topAnchor.constraint(equalTo: box.topAnchor, constant: 7),
-            label.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -7),
+            label.centerYAnchor.constraint(equalTo: box.centerYAnchor),
         ])
         return box
-    }
-
-    // MARK: - Actions
-
-    @objc private func toggleDetails() {
-        detailsVisible.toggle()
-        detailsLabel.isHidden = !detailsVisible
-        if let window, let content = window.contentView {
-            window.setContentSize(content.fittingSize)
-            window.center()
-        }
-    }
-
-    @objc private func enableTapped() { finish(.on) }
-    @objc private func declineTapped() { finish(.off) }
-
-    private func finish(_ state: AgentIntegrationState) {
-        deliver(state)
-        window?.close()
-    }
-
-    /// Fire all queued completions once and drop the per-tool registration.
-    /// Idempotent: `finish` calls this then `window.close()`, which re-enters
-    /// through `windowWillClose`.
-    private func deliver(_ state: AgentIntegrationState) {
-        guard !hasResolved else { return }
-        hasResolved = true
-        if Self.live[tool] === self { Self.live[tool] = nil }
-        let pending = completions
-        completions = []
-        for completion in pending { completion(state) }
-    }
-
-    // MARK: - NSWindowDelegate
-
-    func windowWillClose(_ notification: Notification) {
-        // Closing without choosing is a decline.
-        deliver(.off)
     }
 }

--- a/Zentty/UI/Agent/AgentIntegrationConsentPanel.swift
+++ b/Zentty/UI/Agent/AgentIntegrationConsentPanel.swift
@@ -1,0 +1,226 @@
+import AppKit
+
+/// First-run consent prompt for a persistent-config agent. Shown the first time
+/// such an agent launches, or when enabling one from Settings. Explains what
+/// Zentty will write to the user's config and offers Enable / Not Now.
+///
+/// The panel floats centered above the app; it does not run a nested modal loop,
+/// so the rest of Zentty stays usable while the agent itself stays halted (its
+/// launch is blocked on the IPC handshake until this resolves). `completion`
+/// fires exactly once with `.on` (install hooks) or `.off` (skip).
+@MainActor
+enum AgentIntegrationConsentPanel {
+    static func present(
+        tool: AgentBootstrapTool,
+        completion: @escaping (AgentIntegrationState) -> Void
+    ) {
+        AgentIntegrationConsentWindowController.present(tool: tool, completion: completion)
+    }
+}
+
+@MainActor
+private final class AgentIntegrationConsentWindowController: NSWindowController, NSWindowDelegate {
+    /// Live controller per tool. Concurrent prompts for the same agent (e.g. a
+    /// launch-time prompt and a Settings toggle) coalesce onto one window
+    /// instead of stacking; all queued completions fire once on resolve. The
+    /// dictionary also keeps the controller alive until its window closes.
+    private static var live: [AgentBootstrapTool: AgentIntegrationConsentWindowController] = [:]
+
+    /// Open the panel for `tool`, or attach `completion` to the one already
+    /// open for it.
+    static func present(
+        tool: AgentBootstrapTool,
+        completion: @escaping (AgentIntegrationState) -> Void
+    ) {
+        if let existing = live[tool] {
+            existing.completions.append(completion)
+            existing.bringToFront()
+            return
+        }
+        let controller = AgentIntegrationConsentWindowController(tool: tool, completion: completion)
+        live[tool] = controller
+        controller.bringToFront()
+    }
+
+    private let tool: AgentBootstrapTool
+    private var completions: [(AgentIntegrationState) -> Void]
+    private var hasResolved = false
+    private let detailsLabel = NSTextField(wrappingLabelWithString: "")
+    private var detailsVisible = false
+
+    init(tool: AgentBootstrapTool, completion: @escaping (AgentIntegrationState) -> Void) {
+        self.tool = tool
+        self.completions = [completion]
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.level = .floating
+        window.titlebarAppearsTransparent = true
+        window.title = ""
+        super.init(window: window)
+        window.delegate = self
+        window.contentView = makeContentView()
+        window.setContentSize(window.contentView?.fittingSize ?? NSSize(width: 460, height: 240))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func bringToFront() {
+        window?.center()
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    // MARK: - Content
+
+    private func makeContentView() -> NSView {
+        let name = tool.integrationDisplayName
+
+        let icon = NSImageView()
+        icon.image = MenuBarStatusIconRenderer.agentIconTemplateImage(for: tool.agentTool)
+        icon.image?.isTemplate = true
+        icon.contentTintColor = .controlAccentColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 38),
+            icon.heightAnchor.constraint(equalToConstant: 38),
+        ])
+
+        let title = NSTextField(labelWithString: "Enable \(name) status in Zentty?")
+        title.font = .systemFont(ofSize: 15, weight: .semibold)
+        title.lineBreakMode = .byWordWrapping
+        title.maximumNumberOfLines = 0
+
+        let header = NSStackView(views: [icon, title])
+        header.orientation = .horizontal
+        header.alignment = .centerY
+        header.spacing = 12
+
+        let body = NSTextField(wrappingLabelWithString:
+            "Zentty can show \(name)'s live status in the sidebar and notify you when it needs input. "
+            + "This requires installing status hooks in your \(name) configuration.")
+        body.font = .systemFont(ofSize: 13)
+        body.textColor = .secondaryLabelColor
+
+        let stack = NSStackView(views: [header, body])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        if let path = tool.integrationConfigPathDisplay {
+            stack.addArrangedSubview(makePathBox(path: path))
+
+            let disclosure = NSButton(title: "Show what changes", target: self, action: #selector(toggleDetails))
+            disclosure.bezelStyle = .inline
+            disclosure.isBordered = false
+            disclosure.contentTintColor = .controlAccentColor
+            disclosure.font = .systemFont(ofSize: 12)
+            stack.addArrangedSubview(disclosure)
+
+            detailsLabel.stringValue =
+                "Zentty adds its status-hook entries to the file above (marked so they can be found again) "
+                + "and changes nothing else. They are removed when you turn this off, or via `zentty uninstall`."
+            detailsLabel.font = .systemFont(ofSize: 12)
+            detailsLabel.textColor = .secondaryLabelColor
+            detailsLabel.isHidden = true
+            stack.addArrangedSubview(detailsLabel)
+        }
+
+        let reversibility = NSTextField(wrappingLabelWithString: "You can turn this off anytime in Settings › Agents.")
+        reversibility.font = .systemFont(ofSize: 12)
+        reversibility.textColor = .tertiaryLabelColor
+        stack.addArrangedSubview(reversibility)
+
+        let notNow = NSButton(title: "Not Now", target: self, action: #selector(declineTapped))
+        notNow.bezelStyle = .rounded
+        notNow.keyEquivalent = "\u{1b}" // Escape
+        let enable = NSButton(title: "Enable", target: self, action: #selector(enableTapped))
+        enable.bezelStyle = .rounded
+        enable.keyEquivalent = "\r" // Return — default button
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let buttons = NSStackView(views: [spacer, notNow, enable])
+        buttons.orientation = .horizontal
+        buttons.spacing = 10
+        stack.addArrangedSubview(buttons)
+        buttons.leadingAnchor.constraint(equalTo: stack.leadingAnchor).isActive = true
+        buttons.trailingAnchor.constraint(equalTo: stack.trailingAnchor).isActive = true
+
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -24),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -20),
+            stack.widthAnchor.constraint(equalToConstant: 412),
+        ])
+        return container
+    }
+
+    private func makePathBox(path: String) -> NSView {
+        let label = NSTextField(labelWithString: path)
+        label.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        label.textColor = .labelColor
+        label.lineBreakMode = .byTruncatingMiddle
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let box = NSView()
+        box.wantsLayer = true
+        box.layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.12).cgColor
+        box.layer?.cornerRadius = 6
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 10),
+            label.trailingAnchor.constraint(equalTo: box.trailingAnchor, constant: -10),
+            label.topAnchor.constraint(equalTo: box.topAnchor, constant: 7),
+            label.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -7),
+        ])
+        return box
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggleDetails() {
+        detailsVisible.toggle()
+        detailsLabel.isHidden = !detailsVisible
+        if let window, let content = window.contentView {
+            window.setContentSize(content.fittingSize)
+            window.center()
+        }
+    }
+
+    @objc private func enableTapped() { finish(.on) }
+    @objc private func declineTapped() { finish(.off) }
+
+    private func finish(_ state: AgentIntegrationState) {
+        deliver(state)
+        window?.close()
+    }
+
+    /// Fire all queued completions once and drop the per-tool registration.
+    /// Idempotent: `finish` calls this then `window.close()`, which re-enters
+    /// through `windowWillClose`.
+    private func deliver(_ state: AgentIntegrationState) {
+        guard !hasResolved else { return }
+        hasResolved = true
+        if Self.live[tool] === self { Self.live[tool] = nil }
+        let pending = completions
+        completions = []
+        for completion in pending { completion(state) }
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        // Closing without choosing is a decline.
+        deliver(.off)
+    }
+}

--- a/Zentty/UI/Settings/CaretTooltip.swift
+++ b/Zentty/UI/Settings/CaretTooltip.swift
@@ -1,0 +1,294 @@
+import AppKit
+
+/// An `NSImageView` that reports mouse enter/exit immediately and carries the text
+/// its tooltip should show. Used by the agent-integration status glyphs to drive the
+/// custom `CaretTooltip` instead of the slow, unstyleable system tooltip.
+@MainActor
+final class HoverImageView: NSImageView {
+    /// Text shown by the caret tooltip on hover. `nil` means no tooltip (the glyph is
+    /// hidden, or the row has nothing to explain).
+    var tooltipText: String?
+    var onEnter: ((HoverImageView) -> Void)?
+    var onExit: (() -> Void)?
+
+    private var hoverTrackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        // `.activeInKeyWindow` keeps the tracking tied to the focused Settings window
+        // and fires the moment the pointer enters — no native tooltip delay.
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        guard tooltipText != nil else { return }
+        onEnter?(self)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onExit?()
+    }
+}
+
+/// A lightweight, instant hover tooltip rendered as a borderless child panel: a
+/// rounded bubble with a caret pointing at the anchor. Built as a custom panel (not
+/// `NSPopover`) so it can appear instantly, sit to the *left* of its anchor with the
+/// caret on the right, and wear a flat look that matches `SettingsCardView` rather
+/// than the translucent popover chrome.
+@MainActor
+final class CaretTooltip {
+    private var panel: NSPanel?
+    private let bubble = CaretTooltipBubbleView()
+
+    /// Layout constants. `gap` is the breathing room between the caret tip and the
+    /// anchor; `maxTextWidth` bounds wrapping so long paths don't make a wide bubble.
+    private enum Layout {
+        static let gap: CGFloat = 7
+        static let caretWidth: CGFloat = 7
+        static let maxTextWidth: CGFloat = 260
+        static let screenMargin: CGFloat = 8
+    }
+
+    /// Show the tooltip for `text`, positioned relative to `anchor` (typically the
+    /// status glyph). Reuses the same panel across calls so hovering row-to-row just
+    /// repositions one window.
+    func show(text: String, relativeTo anchor: NSView, in window: NSWindow) {
+        bubble.text = text
+
+        let textSize = bubble.measure(maxTextWidth: Layout.maxTextWidth)
+        let bubbleSize = bubble.bubbleSize(forTextSize: textSize)
+        let panelSize = CGSize(width: bubbleSize.width + Layout.caretWidth, height: bubbleSize.height)
+
+        let panel = panel ?? makePanel(in: window)
+        self.panel = panel
+        panel.appearance = window.effectiveAppearance
+        panel.setContentSize(panelSize)
+        bubble.frame = CGRect(origin: .zero, size: panelSize)
+
+        // Anchor centre in screen space.
+        let anchorInWindow = anchor.convert(anchor.bounds, to: nil)
+        let anchorOnScreen = window.convertToScreen(anchorInWindow)
+        let anchorCenterY = anchorOnScreen.midY
+
+        let visible = (anchor.window?.screen ?? window.screen ?? NSScreen.main)?.visibleFrame
+            ?? window.frame
+
+        // Preferred: left of the anchor, caret on the right edge pointing right.
+        var caretOnRight = true
+        var originX = anchorOnScreen.minX - panelSize.width - Layout.gap
+        // Flip to the right side if there's no room on the left.
+        if originX < visible.minX + Layout.screenMargin {
+            caretOnRight = false
+            originX = anchorOnScreen.maxX + Layout.gap
+        }
+
+        // Vertically centre on the anchor, then clamp into the visible screen.
+        var originY = anchorCenterY - panelSize.height / 2
+        originY = max(
+            visible.minY + Layout.screenMargin,
+            min(originY, visible.maxY - panelSize.height - Layout.screenMargin)
+        )
+
+        // The caret tip tracks the anchor centre even after the bubble was clamped,
+        // so it keeps pointing at the icon near the screen edges. Clamp it away from
+        // the rounded corners.
+        let rawCaretY = anchorCenterY - originY
+        bubble.configureCaret(onRight: caretOnRight, tipY: rawCaretY)
+
+        panel.setFrameOrigin(CGPoint(x: originX, y: originY))
+        if panel.parent == nil {
+            window.addChildWindow(panel, ordered: .above)
+        }
+        panel.orderFront(nil)
+    }
+
+    func hide() {
+        panel?.orderOut(nil)
+    }
+
+    private func makePanel(in window: NSWindow) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.hidesOnDeactivate = true
+        panel.ignoresMouseEvents = true
+        panel.contentView = bubble
+        return panel
+    }
+}
+
+/// Draws the tooltip bubble: a rounded rect plus a triangular caret on one side.
+@MainActor
+final class CaretTooltipBubbleView: NSView {
+    private enum Layout {
+        static let cornerRadius: CGFloat = 7
+        static let caretWidth: CGFloat = 7
+        static let caretHeight: CGFloat = 12
+        static let textInsetX: CGFloat = 10
+        static let textInsetY: CGFloat = 7
+    }
+
+    var text: String = "" {
+        didSet {
+            label.stringValue = text
+            needsDisplay = true
+        }
+    }
+
+    private var caretOnRight = true
+    private var caretTipY: CGFloat = 0
+
+    private let label: NSTextField = {
+        let field = NSTextField(labelWithString: "")
+        field.font = .systemFont(ofSize: 12)
+        field.textColor = .labelColor
+        field.lineBreakMode = .byWordWrapping
+        field.maximumNumberOfLines = 0
+        // Laid out manually via `frame` in `layoutLabel()`, so keep autoresizing.
+        field.translatesAutoresizingMaskIntoConstraints = true
+        field.isSelectable = false
+        return field
+    }()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isFlipped: Bool { false }
+
+    /// Size the wrapped text occupies, capped at `maxTextWidth`. Uses the field's
+    /// intrinsic size under a bounded wrap width (the AppKit-reliable path; NSTextField
+    /// has no `sizeThatFits`).
+    func measure(maxTextWidth: CGFloat) -> CGSize {
+        label.preferredMaxLayoutWidth = maxTextWidth
+        label.invalidateIntrinsicContentSize()
+        let fitting = label.intrinsicContentSize
+        return CGSize(width: ceil(min(fitting.width, maxTextWidth)), height: ceil(fitting.height))
+    }
+
+    /// Bubble size (excluding caret) for a measured text size.
+    func bubbleSize(forTextSize textSize: CGSize) -> CGSize {
+        CGSize(
+            width: textSize.width + Layout.textInsetX * 2,
+            height: textSize.height + Layout.textInsetY * 2
+        )
+    }
+
+    func configureCaret(onRight: Bool, tipY rawTipY: CGFloat) {
+        caretOnRight = onRight
+        let half = Layout.caretHeight / 2
+        let minY = Layout.cornerRadius + half
+        let maxY = bounds.height - Layout.cornerRadius - half
+        caretTipY = minY <= maxY ? min(max(rawTipY, minY), maxY) : bounds.midY
+        layoutLabel()
+        needsDisplay = true
+    }
+
+    override func layout() {
+        super.layout()
+        layoutLabel()
+    }
+
+    private func layoutLabel() {
+        // The bubble occupies all of `bounds` except the caret column on one side.
+        let bubbleX = caretOnRight ? 0 : Layout.caretWidth
+        let bubbleWidth = bounds.width - Layout.caretWidth
+        label.frame = CGRect(
+            x: bubbleX + Layout.textInsetX,
+            y: Layout.textInsetY,
+            width: max(0, bubbleWidth - Layout.textInsetX * 2),
+            height: max(0, bounds.height - Layout.textInsetY * 2)
+        )
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let fill: NSColor = isDark
+            ? NSColor(calibratedWhite: 0.18, alpha: 1)
+            : .white
+        let border = isDark
+            ? NSColor.white.withAlphaComponent(0.12)
+            : NSColor.black.withAlphaComponent(0.14)
+
+        let path = bubblePath()
+        fill.setFill()
+        path.fill()
+        border.setStroke()
+        path.lineWidth = 1
+        path.stroke()
+    }
+
+    /// A single continuous rounded-rect-plus-caret outline. Tracing it as one path
+    /// (detouring out to the caret tip along the relevant edge) avoids the seam a
+    /// separate triangle would leave where its base meets the bubble — for both fill
+    /// and stroke. Inset by 0.5 keeps the 1pt stroke crisp.
+    private func bubblePath() -> NSBezierPath {
+        let r = Layout.cornerRadius
+        let caretW = Layout.caretWidth
+        let half = Layout.caretHeight / 2
+
+        let minX = (caretOnRight ? 0.5 : caretW + 0.5)
+        let maxX = bounds.width - (caretOnRight ? caretW + 0.5 : 0.5)
+        let minY: CGFloat = 0.5
+        let maxY = bounds.height - 0.5
+
+        let path = NSBezierPath()
+        path.move(to: NSPoint(x: minX + r, y: maxY))            // top edge start
+        path.line(to: NSPoint(x: maxX - r, y: maxY))            // → along top
+        path.appendArc(                                         // top-right corner
+            withCenter: NSPoint(x: maxX - r, y: maxY - r),
+            radius: r, startAngle: 90, endAngle: 0, clockwise: true
+        )
+        if caretOnRight {                                       // ↓ right edge w/ caret
+            path.line(to: NSPoint(x: maxX, y: caretTipY + half))
+            path.line(to: NSPoint(x: maxX + caretW, y: caretTipY))
+            path.line(to: NSPoint(x: maxX, y: caretTipY - half))
+        }
+        path.line(to: NSPoint(x: maxX, y: minY + r))
+        path.appendArc(                                         // bottom-right corner
+            withCenter: NSPoint(x: maxX - r, y: minY + r),
+            radius: r, startAngle: 0, endAngle: -90, clockwise: true
+        )
+        path.line(to: NSPoint(x: minX + r, y: minY))           // ← along bottom
+        path.appendArc(                                         // bottom-left corner
+            withCenter: NSPoint(x: minX + r, y: minY + r),
+            radius: r, startAngle: 270, endAngle: 180, clockwise: true
+        )
+        if !caretOnRight {                                      // ↑ left edge w/ caret
+            path.line(to: NSPoint(x: minX, y: caretTipY - half))
+            path.line(to: NSPoint(x: minX - caretW, y: caretTipY))
+            path.line(to: NSPoint(x: minX, y: caretTipY + half))
+        }
+        path.line(to: NSPoint(x: minX, y: maxY - r))
+        path.appendArc(                                         // top-left corner
+            withCenter: NSPoint(x: minX + r, y: maxY - r),
+            radius: r, startAngle: 180, endAngle: 90, clockwise: true
+        )
+        path.close()
+        return path
+    }
+}

--- a/Zentty/UI/Settings/GeneralSettingsSectionViewController.swift
+++ b/Zentty/UI/Settings/GeneralSettingsSectionViewController.swift
@@ -319,12 +319,14 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
     private struct IntegrationRow {
         let tool: AgentBootstrapTool
         let toggle: NSSwitch
-        let statusLabel: NSTextField
-        let askPill: NSView?
+        let statusGlyph: HoverImageView
+        let askLabel: NSTextField
     }
 
     private var integrationRows: [IntegrationRow] = []
     private var toolForToggle: [NSSwitch: AgentBootstrapTool] = [:]
+    /// One reused caret tooltip shown when hovering a status glyph.
+    private let statusTooltip = CaretTooltip()
     /// Presents the consent panel; injectable for tests. Mirrors the launch-time
     /// consent panel so enabling here is gated by the same prompt.
     private let consentPresenter: @MainActor (AgentBootstrapTool, @escaping (AgentIntegrationState) -> Void) -> Void
@@ -424,6 +426,55 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         menuBarStatusSwitch.state = currentMenuBar.showStatusItem ? .on : .off
         agentTeamsSwitch.state = currentAgentTeams.enabled ? .on : .off
         agentCaffeinationSwitch.state = currentAgentCaffeination.enabled ? .on : .off
+        refreshIntegrationControls()
+
+        // Re-check on-disk hook status when a pane launch (re)installs hooks while
+        // this panel is already open, so a stale "Hooks missing" warning clears
+        // live. The post is delivered on the main thread (see AgentIPC), so a plain
+        // selector observer is safe; `removeObserver(self)` in deinit cleans it up.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleHooksDidChange),
+            name: .agentIntegrationHooksDidChange,
+            object: nil
+        )
+
+        // Dismiss the status tooltip on scroll so it never floats away from its glyph
+        // (a trackpad scroll while hovering won't fire mouseExited).
+        let clipView = scrollView.contentView
+        clipView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(hideStatusTooltip),
+            name: NSView.boundsDidChangeNotification,
+            object: clipView
+        )
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        statusTooltip.hide()
+    }
+
+    @objc
+    private func hideStatusTooltip() {
+        statusTooltip.hide()
+    }
+
+    @objc
+    private func handleHooksDidChange() {
+        refreshIntegrationControls()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Re-check on-disk hook status each time the panel is presented (reopened or
+    /// switched back to), so the green/amber glyph reflects hooks installed by an
+    /// agent launch since the last time this section was shown.
+    override func prepareForPresentation() {
+        super.prepareForPresentation()
         refreshIntegrationControls()
     }
 
@@ -736,13 +787,22 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
             view.widthAnchor.constraint(equalTo: cardStack.widthAnchor).isActive = true
         }
 
+        // Display order is a view concern: sort each group alphabetically by name
+        // so the list stays scannable regardless of the registry's array order.
+        func sortedByName(_ tools: [AgentBootstrapTool]) -> [AgentBootstrapTool] {
+            tools.sorted {
+                $0.integrationDisplayName.localizedCaseInsensitiveCompare($1.integrationDisplayName)
+                    == .orderedAscending
+            }
+        }
+
         appendRow(makeIntegrationGroupHeader("MODIFIES YOUR CONFIG"), separatorBefore: false)
-        for tool in AgentIntegrationConsent.persistentTools {
+        for tool in sortedByName(AgentIntegrationConsent.persistentTools) {
             appendRow(makeIntegrationRow(tool: tool), separatorBefore: true)
         }
 
-        appendRow(makeIntegrationGroupHeader("BUILT-IN"), separatorBefore: true)
-        for tool in AgentIntegrationConsent.ephemeralTools {
+        appendRow(makeIntegrationGroupHeader("AUTOMATIC"), separatorBefore: true)
+        for tool in sortedByName(AgentIntegrationConsent.ephemeralTools) {
             appendRow(makeIntegrationRow(tool: tool), separatorBefore: true)
         }
 
@@ -761,11 +821,13 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         label.textColor = .tertiaryLabelColor
         label.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(label)
+        // Symmetric band so the uppercase label sits vertically centered, not pinned
+        // to the top. The fixed height keeps the band's overall footprint stable.
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
             label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
-            label.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
-            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            container.heightAnchor.constraint(equalToConstant: 34),
         ])
         return container
     }
@@ -779,33 +841,41 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         icon.image?.isTemplate = true
         icon.contentTintColor = .secondaryLabelColor
         icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.setContentHuggingPriority(.required, for: .horizontal)
         NSLayoutConstraint.activate([
             icon.widthAnchor.constraint(equalToConstant: 18),
             icon.heightAnchor.constraint(equalToConstant: 18),
         ])
 
         let nameLabel = makeLabel(text: tool.integrationDisplayName, font: .systemFont(ofSize: 13, weight: .semibold))
+        nameLabel.maximumNumberOfLines = 1
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        let nameRow = NSStackView(views: [nameLabel])
-        nameRow.orientation = .horizontal
-        nameRow.alignment = .centerY
-        nameRow.spacing = 8
-        if tool.integrationClass == .persistent {
-            nameRow.addArrangedSubview(makeIntegrationBadge("Modifies config"))
+        // Trailing status: a quiet glyph (installed / needs-reinstall) or, for the
+        // first-launch consent state, a compact amber label. Detail lives in the
+        // glyph's hover tooltip so the row stays a single scannable line. Built-in
+        // agents show neither — their toggle says everything.
+        let statusGlyph = HoverImageView()
+        statusGlyph.translatesAutoresizingMaskIntoConstraints = false
+        statusGlyph.imageScaling = .scaleProportionallyUpOrDown
+        statusGlyph.setContentHuggingPriority(.required, for: .horizontal)
+        statusGlyph.onEnter = { [weak self] glyph in
+            guard let self, let window = self.view.window, let text = glyph.tooltipText else { return }
+            self.statusTooltip.show(text: text, relativeTo: glyph, in: window)
         }
-
-        let statusLabel = makeLabel(text: "", font: .systemFont(ofSize: 12))
-        statusLabel.textColor = .secondaryLabelColor
-
-        let askPill: NSView? = tool.integrationClass == .persistent ? makeAskPill() : nil
-
-        let infoStack = NSStackView(views: [nameRow, statusLabel])
-        if let askPill {
-            infoStack.addArrangedSubview(askPill)
+        statusGlyph.onExit = { [weak self] in
+            self?.statusTooltip.hide()
         }
-        infoStack.orientation = .vertical
-        infoStack.alignment = .leading
-        infoStack.spacing = 3
+        NSLayoutConstraint.activate([
+            statusGlyph.widthAnchor.constraint(equalToConstant: 15),
+            statusGlyph.heightAnchor.constraint(equalToConstant: 15),
+        ])
+
+        let askLabel = makeLabel(text: "Asks on first launch", font: .systemFont(ofSize: 11, weight: .medium))
+        askLabel.maximumNumberOfLines = 1
+        askLabel.textColor = .systemOrange
+        askLabel.setContentHuggingPriority(.required, for: .horizontal)
 
         let toggle = NSSwitch()
         toggle.target = self
@@ -813,60 +883,44 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         toggle.translatesAutoresizingMaskIntoConstraints = false
         toolForToggle[toggle] = tool
 
-        let leftStack = NSStackView(views: [icon, infoStack])
+        let leftStack = NSStackView(views: [icon, nameLabel])
         leftStack.orientation = .horizontal
         leftStack.alignment = .centerY
         leftStack.spacing = 10
         leftStack.translatesAutoresizingMaskIntoConstraints = false
 
+        let statusStack = NSStackView(views: [askLabel, statusGlyph])
+        statusStack.orientation = .horizontal
+        statusStack.alignment = .centerY
+        statusStack.spacing = 6
+        statusStack.translatesAutoresizingMaskIntoConstraints = false
+        statusStack.setContentHuggingPriority(.required, for: .horizontal)
+        statusStack.setContentCompressionResistancePriority(.required, for: .horizontal)
+
         container.addSubview(leftStack)
+        container.addSubview(statusStack)
         container.addSubview(toggle)
         NSLayoutConstraint.activate([
-            leftStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            leftStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 11),
             leftStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
-            leftStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12),
+            leftStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -11),
+
+            statusStack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            statusStack.leadingAnchor.constraint(greaterThanOrEqualTo: leftStack.trailingAnchor, constant: 12),
 
             toggle.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            toggle.leadingAnchor.constraint(greaterThanOrEqualTo: leftStack.trailingAnchor, constant: 12),
+            toggle.leadingAnchor.constraint(equalTo: statusStack.trailingAnchor, constant: 12),
             toggle.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
         ])
 
         integrationRows.append(
-            IntegrationRow(tool: tool, toggle: toggle, statusLabel: statusLabel, askPill: askPill)
+            IntegrationRow(tool: tool, toggle: toggle, statusGlyph: statusGlyph, askLabel: askLabel)
         )
         return container
     }
 
-    private func makeIntegrationBadge(_ text: String) -> NSView {
-        let label = NSTextField(labelWithString: text)
-        label.font = .systemFont(ofSize: 10, weight: .semibold)
-        label.textColor = .secondaryLabelColor
-        label.alignment = .center
-        label.wantsLayer = true
-        label.layer?.cornerRadius = 5
-        label.layer?.cornerCurve = .continuous
-        label.layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.18).cgColor
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.setContentHuggingPriority(.required, for: .horizontal)
-        label.heightAnchor.constraint(equalToConstant: 16).isActive = true
-        label.widthAnchor.constraint(greaterThanOrEqualToConstant: CGFloat(text.count) * 7 + 12).isActive = true
-        return label
-    }
-
-    private func makeAskPill() -> NSView {
-        let label = NSTextField(labelWithString: "Asks on first launch")
-        label.font = .systemFont(ofSize: 11, weight: .medium)
-        label.textColor = .systemOrange
-        label.alignment = .center
-        label.wantsLayer = true
-        label.layer?.cornerRadius = 6
-        label.layer?.cornerCurve = .continuous
-        label.layer?.backgroundColor = NSColor.systemOrange.withAlphaComponent(0.14).cgColor
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.setContentHuggingPriority(.required, for: .horizontal)
-        label.heightAnchor.constraint(equalToConstant: 18).isActive = true
-        label.widthAnchor.constraint(greaterThanOrEqualToConstant: 150).isActive = true
-        return label
+    private func friendlyPath(_ url: URL) -> String {
+        (url.path as NSString).abbreviatingWithTildeInPath
     }
 
     func refreshIntegrationControls() {
@@ -875,40 +929,69 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         for row in integrationRows {
             let state = integrations.state(for: row.tool)
             row.toggle.state = (state == .on) ? .on : .off
-            let isAsk = (state == .ask)
-            row.askPill?.isHidden = !isAsk
-            row.statusLabel.isHidden = isAsk
-            let status = statusDisplay(for: state, tool: row.tool)
-            row.statusLabel.stringValue = status.text
-            row.statusLabel.textColor = status.color
+            applyStatusIndicator(statusIndicator(for: state, tool: row.tool), to: row)
         }
     }
 
-    private struct IntegrationStatus {
-        let text: String
-        let color: NSColor
+    private func applyStatusIndicator(_ indicator: IntegrationStatusIndicator, to row: IntegrationRow) {
+        switch indicator {
+        case let .glyph(symbol, color, tooltip):
+            let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+            row.statusGlyph.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)?
+                .withSymbolConfiguration(config)
+            row.statusGlyph.contentTintColor = color
+            row.statusGlyph.tooltipText = tooltip
+            row.statusGlyph.setAccessibilityLabel(tooltip)
+            row.statusGlyph.isHidden = false
+            row.askLabel.isHidden = true
+        case let .ask(text):
+            row.askLabel.stringValue = text
+            row.askLabel.isHidden = false
+            row.statusGlyph.isHidden = true
+            row.statusGlyph.image = nil
+            row.statusGlyph.tooltipText = nil
+        case .none:
+            row.statusGlyph.isHidden = true
+            row.statusGlyph.image = nil
+            row.statusGlyph.tooltipText = nil
+            row.askLabel.isHidden = true
+        }
     }
 
-    /// Resolves the status line's text and color together so they never drift.
-    /// For an `.on` persistent agent we read disk once: hooks the user expects
-    /// can be removed outside Zentty (manual edit of the agent's config), and a
-    /// missing install must read as a warning, not as a pristine fresh state.
-    private func statusDisplay(for state: AgentIntegrationState, tool: AgentBootstrapTool) -> IntegrationStatus {
+    private enum IntegrationStatusIndicator {
+        case glyph(symbol: String, color: NSColor, tooltip: String)
+        case ask(text: String)
+        case none
+    }
+
+    /// Resolves a row's trailing treatment. Persistent agents that wrote hooks to
+    /// disk show a green check; an `.on` agent whose hooks vanished (a manual edit
+    /// of the agent's config) shows an amber warning so it doesn't read as pristine.
+    /// The `.ask` first-launch state keeps a visible amber label. Built-in agents
+    /// rely on the toggle alone.
+    private func statusIndicator(
+        for state: AgentIntegrationState,
+        tool: AgentBootstrapTool
+    ) -> IntegrationStatusIndicator {
+        guard tool.integrationClass == .persistent else { return .none }
         switch state {
         case .ask:
-            return IntegrationStatus(text: "Asks on first launch", color: .systemOrange)
+            return .ask(text: "Asks on first launch")
         case .off:
-            return IntegrationStatus(text: "Disabled", color: .tertiaryLabelColor)
+            return .none
         case .on:
-            guard tool.integrationClass == .persistent else {
-                return IntegrationStatus(text: "Enabled", color: .secondaryLabelColor)
-            }
             if AgentIntegrationHooks.isInstalled(tool) {
-                return IntegrationStatus(text: "Hooks installed", color: .secondaryLabelColor)
+                let location = tool.integrationConfigURL.map { " in \(friendlyPath($0))" } ?? ""
+                return .glyph(
+                    symbol: "checkmark.circle.fill",
+                    color: .systemGreen,
+                    tooltip: "Hooks installed\(location). Zentty added these — turn the integration off to remove them."
+                )
             }
-            return IntegrationStatus(
-                text: "Hooks missing — reinstalls on next launch",
-                color: .systemOrange
+            return .glyph(
+                symbol: "exclamationmark.triangle.fill",
+                color: .systemOrange,
+                tooltip: "Hooks missing — Zentty reinstalls them on next launch."
             )
         }
     }
@@ -1004,5 +1087,35 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         guard let row = integrationRows.first(where: { $0.tool == tool }) else { return }
         row.toggle.state = on ? .on : .off
         handleIntegrationToggle(row.toggle)
+    }
+
+    /// Snapshot of a row's trailing status treatment, for tests.
+    func integrationStatusForTesting(
+        _ tool: AgentBootstrapTool
+    ) -> (glyphVisible: Bool, askVisible: Bool, tooltipText: String?)? {
+        guard let row = integrationRows.first(where: { $0.tool == tool }) else { return nil }
+        return (!row.statusGlyph.isHidden, !row.askLabel.isHidden, row.statusGlyph.tooltipText)
+    }
+
+    /// Vertical offset of a group header's label from its band centre, for tests.
+    /// ~0 means the uppercase title is vertically centered in its band.
+    func groupHeaderCenterYOffsetForTesting(title: String) -> CGFloat? {
+        guard isViewLoaded,
+              let label = firstLabel(in: view, withString: title),
+              let container = label.superview
+        else { return nil }
+        return label.frame.midY - container.bounds.midY
+    }
+
+    private func firstLabel(in view: NSView, withString string: String) -> NSTextField? {
+        for subview in view.subviews {
+            if let field = subview as? NSTextField, field.stringValue == string {
+                return field
+            }
+            if let found = firstLabel(in: subview, withString: string) {
+                return found
+            }
+        }
+        return nil
     }
 }

--- a/Zentty/UI/Settings/GeneralSettingsSectionViewController.swift
+++ b/Zentty/UI/Settings/GeneralSettingsSectionViewController.swift
@@ -1,4 +1,9 @@
 import AppKit
+import os
+
+/// Logs best-effort config-write failures from the settings UI. These persist
+/// paths must log and continue rather than crash (see AGENTS.md error handling).
+private let settingsLogger = Logger(subsystem: "be.zenjoy.zentty", category: "Settings")
 
 @MainActor
 final class GeneralSettingsSectionViewController: SettingsScrollableSectionViewController {
@@ -309,13 +314,42 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
     private let experimentalBadgeLabel = NSTextField(labelWithString: "EXPERIMENTAL")
     private weak var agentTeamsTitleLabel: NSTextField?
 
+    /// Live controls for one agent-integration row, so toggles and status can
+    /// be refreshed when config changes (or a toggle is reverted).
+    private struct IntegrationRow {
+        let tool: AgentBootstrapTool
+        let toggle: NSSwitch
+        let statusLabel: NSTextField
+        let askPill: NSView?
+    }
+
+    private var integrationRows: [IntegrationRow] = []
+    private var toolForToggle: [NSSwitch: AgentBootstrapTool] = [:]
+    /// Presents the consent panel; injectable for tests. Mirrors the launch-time
+    /// consent panel so enabling here is gated by the same prompt.
+    private let consentPresenter: @MainActor (AgentBootstrapTool, @escaping (AgentIntegrationState) -> Void) -> Void
+    /// Removes a persistent agent's on-disk hooks; injectable so tests can force a
+    /// failure without touching disk. Defaults to the real remover.
+    private let performUninstall: (AgentBootstrapTool) throws -> Void
+    /// Surfaces an uninstall failure (default: a warning NSAlert); injectable for
+    /// tests. Receives the host window (nil in headless tests), the tool, and the error.
+    private let uninstallFailurePresenter: @MainActor (NSWindow?, AgentBootstrapTool, Error) -> Void
+
     init(
         configStore: AppConfigStore,
         agentTeamsEnableWarningPresenter: @escaping AgentTeamsEnableWarningPresenter =
-            AgentTeamsEnableWarning.present
+            AgentTeamsEnableWarning.present,
+        consentPresenter: @escaping @MainActor (AgentBootstrapTool, @escaping (AgentIntegrationState) -> Void) -> Void =
+            AgentIntegrationConsentPanel.present,
+        performUninstall: @escaping (AgentBootstrapTool) throws -> Void = AgentIntegrationHooks.uninstall,
+        uninstallFailurePresenter: @escaping @MainActor (NSWindow?, AgentBootstrapTool, Error) -> Void =
+            AgentIntegrationUninstallFailureAlert.present
     ) {
         self.configStore = configStore
         self.agentTeamsEnableWarningPresenter = agentTeamsEnableWarningPresenter
+        self.consentPresenter = consentPresenter
+        self.performUninstall = performUninstall
+        self.uninstallFailurePresenter = uninstallFailurePresenter
         self.currentAgentTeams = configStore.current.agentTeams
         self.currentAgentCaffeination = configStore.current.agentCaffeination
         self.currentMenuBar = configStore.current.menuBar
@@ -369,6 +403,14 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         stackView.addArrangedSubview(card)
         card.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
 
+        let integrationsHeader = makeIntegrationsSectionHeader()
+        stackView.addArrangedSubview(integrationsHeader)
+        integrationsHeader.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        let integrationsCard = makeIntegrationsCard()
+        stackView.addArrangedSubview(integrationsCard)
+        integrationsCard.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -382,6 +424,7 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         menuBarStatusSwitch.state = currentMenuBar.showStatusItem ? .on : .off
         agentTeamsSwitch.state = currentAgentTeams.enabled ? .on : .off
         agentCaffeinationSwitch.state = currentAgentCaffeination.enabled ? .on : .off
+        refreshIntegrationControls()
     }
 
     func apply(
@@ -396,6 +439,7 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         menuBarStatusSwitch.state = menuBar.showStatusItem ? .on : .off
         agentTeamsSwitch.state = agentTeams.enabled ? .on : .off
         agentCaffeinationSwitch.state = agentCaffeination.enabled ? .on : .off
+        refreshIntegrationControls()
     }
 
     private func makeMenuBarStatusRow() -> NSView {
@@ -568,8 +612,13 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
 
     @objc
     private func handleMenuBarStatusSwitchChanged(_ sender: NSSwitch) {
-        try? configStore.update { config in
-            config.menuBar.showStatusItem = sender.state == .on
+        do {
+            try configStore.update { config in
+                config.menuBar.showStatusItem = sender.state == .on
+            }
+        } catch {
+            settingsLogger.error(
+                "Failed to persist menu-bar status-item visibility: \(error.localizedDescription, privacy: .public)")
         }
         currentMenuBar = configStore.current.menuBar
         menuBarStatusSwitch.state = currentMenuBar.showStatusItem ? .on : .off
@@ -613,16 +662,26 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
     }
 
     private func persistAgentTeamsEnabled(_ enabled: Bool) {
-        try? configStore.update { config in
-            config.agentTeams.enabled = enabled
+        do {
+            try configStore.update { config in
+                config.agentTeams.enabled = enabled
+            }
+        } catch {
+            settingsLogger.error(
+                "Failed to persist agent-teams enabled state: \(error.localizedDescription, privacy: .public)")
         }
         currentAgentTeams = configStore.current.agentTeams
         agentTeamsSwitch.state = currentAgentTeams.enabled ? .on : .off
     }
 
     private func persistAgentCaffeinationEnabled(_ enabled: Bool) {
-        try? configStore.update { config in
-            config.agentCaffeination.enabled = enabled
+        do {
+            try configStore.update { config in
+                config.agentCaffeination.enabled = enabled
+            }
+        } catch {
+            settingsLogger.error(
+                "Failed to persist agent-caffeination enabled state: \(error.localizedDescription, privacy: .public)")
         }
         currentAgentCaffeination = configStore.current.agentCaffeination
         agentCaffeinationSwitch.state = currentAgentCaffeination.enabled ? .on : .off
@@ -634,6 +693,273 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
         label.lineBreakMode = .byWordWrapping
         label.maximumNumberOfLines = 0
         return label
+    }
+
+    // MARK: - Agent integrations
+
+    private func makeIntegrationsSectionHeader() -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = makeLabel(text: "Agent integrations", font: .systemFont(ofSize: 13, weight: .semibold))
+        let subtitle = makeLabel(
+            text: "Enable or disable each agent's Zentty integration. Agents that modify your "
+                + "configuration ask before installing hooks; turn any integration off if it misbehaves.",
+            font: .systemFont(ofSize: 12)
+        )
+        subtitle.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(title)
+        stack.addArrangedSubview(subtitle)
+        return stack
+    }
+
+    private func makeIntegrationsCard() -> NSView {
+        integrationRows = []
+        toolForToggle = [:]
+
+        let card = SettingsCardView()
+        let cardStack = NSStackView()
+        cardStack.orientation = .vertical
+        cardStack.alignment = .leading
+        cardStack.spacing = 0
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+
+        func appendRow(_ view: NSView, separatorBefore: Bool) {
+            if separatorBefore {
+                addSeparator(to: cardStack)
+            }
+            cardStack.addArrangedSubview(view)
+            view.widthAnchor.constraint(equalTo: cardStack.widthAnchor).isActive = true
+        }
+
+        appendRow(makeIntegrationGroupHeader("MODIFIES YOUR CONFIG"), separatorBefore: false)
+        for tool in AgentIntegrationConsent.persistentTools {
+            appendRow(makeIntegrationRow(tool: tool), separatorBefore: true)
+        }
+
+        appendRow(makeIntegrationGroupHeader("BUILT-IN"), separatorBefore: true)
+        for tool in AgentIntegrationConsent.ephemeralTools {
+            appendRow(makeIntegrationRow(tool: tool), separatorBefore: true)
+        }
+
+        NSLayoutConstraint.activate([
+            cardStack.topAnchor.constraint(equalTo: card.topAnchor),
+            cardStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            cardStack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            cardStack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+        ])
+        return card
+    }
+
+    private func makeIntegrationGroupHeader(_ title: String) -> NSView {
+        let container = NSView()
+        let label = makeLabel(text: title, font: .systemFont(ofSize: 11, weight: .semibold))
+        label.textColor = .tertiaryLabelColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+            label.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+        ])
+        return container
+    }
+
+    private func makeIntegrationRow(tool: AgentBootstrapTool) -> NSView {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let icon = NSImageView()
+        icon.image = MenuBarStatusIconRenderer.agentIconTemplateImage(for: tool.agentTool)
+        icon.image?.isTemplate = true
+        icon.contentTintColor = .secondaryLabelColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 18),
+            icon.heightAnchor.constraint(equalToConstant: 18),
+        ])
+
+        let nameLabel = makeLabel(text: tool.integrationDisplayName, font: .systemFont(ofSize: 13, weight: .semibold))
+
+        let nameRow = NSStackView(views: [nameLabel])
+        nameRow.orientation = .horizontal
+        nameRow.alignment = .centerY
+        nameRow.spacing = 8
+        if tool.integrationClass == .persistent {
+            nameRow.addArrangedSubview(makeIntegrationBadge("Modifies config"))
+        }
+
+        let statusLabel = makeLabel(text: "", font: .systemFont(ofSize: 12))
+        statusLabel.textColor = .secondaryLabelColor
+
+        let askPill: NSView? = tool.integrationClass == .persistent ? makeAskPill() : nil
+
+        let infoStack = NSStackView(views: [nameRow, statusLabel])
+        if let askPill {
+            infoStack.addArrangedSubview(askPill)
+        }
+        infoStack.orientation = .vertical
+        infoStack.alignment = .leading
+        infoStack.spacing = 3
+
+        let toggle = NSSwitch()
+        toggle.target = self
+        toggle.action = #selector(handleIntegrationToggle(_:))
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        toolForToggle[toggle] = tool
+
+        let leftStack = NSStackView(views: [icon, infoStack])
+        leftStack.orientation = .horizontal
+        leftStack.alignment = .centerY
+        leftStack.spacing = 10
+        leftStack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(leftStack)
+        container.addSubview(toggle)
+        NSLayoutConstraint.activate([
+            leftStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            leftStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            leftStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12),
+
+            toggle.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            toggle.leadingAnchor.constraint(greaterThanOrEqualTo: leftStack.trailingAnchor, constant: 12),
+            toggle.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+        ])
+
+        integrationRows.append(
+            IntegrationRow(tool: tool, toggle: toggle, statusLabel: statusLabel, askPill: askPill)
+        )
+        return container
+    }
+
+    private func makeIntegrationBadge(_ text: String) -> NSView {
+        let label = NSTextField(labelWithString: text)
+        label.font = .systemFont(ofSize: 10, weight: .semibold)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.wantsLayer = true
+        label.layer?.cornerRadius = 5
+        label.layer?.cornerCurve = .continuous
+        label.layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.18).cgColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        label.widthAnchor.constraint(greaterThanOrEqualToConstant: CGFloat(text.count) * 7 + 12).isActive = true
+        return label
+    }
+
+    private func makeAskPill() -> NSView {
+        let label = NSTextField(labelWithString: "Asks on first launch")
+        label.font = .systemFont(ofSize: 11, weight: .medium)
+        label.textColor = .systemOrange
+        label.alignment = .center
+        label.wantsLayer = true
+        label.layer?.cornerRadius = 6
+        label.layer?.cornerCurve = .continuous
+        label.layer?.backgroundColor = NSColor.systemOrange.withAlphaComponent(0.14).cgColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.heightAnchor.constraint(equalToConstant: 18).isActive = true
+        label.widthAnchor.constraint(greaterThanOrEqualToConstant: 150).isActive = true
+        return label
+    }
+
+    func refreshIntegrationControls() {
+        guard isViewLoaded else { return }
+        let integrations = configStore.current.agentIntegrations
+        for row in integrationRows {
+            let state = integrations.state(for: row.tool)
+            row.toggle.state = (state == .on) ? .on : .off
+            let isAsk = (state == .ask)
+            row.askPill?.isHidden = !isAsk
+            row.statusLabel.isHidden = isAsk
+            let status = statusDisplay(for: state, tool: row.tool)
+            row.statusLabel.stringValue = status.text
+            row.statusLabel.textColor = status.color
+        }
+    }
+
+    private struct IntegrationStatus {
+        let text: String
+        let color: NSColor
+    }
+
+    /// Resolves the status line's text and color together so they never drift.
+    /// For an `.on` persistent agent we read disk once: hooks the user expects
+    /// can be removed outside Zentty (manual edit of the agent's config), and a
+    /// missing install must read as a warning, not as a pristine fresh state.
+    private func statusDisplay(for state: AgentIntegrationState, tool: AgentBootstrapTool) -> IntegrationStatus {
+        switch state {
+        case .ask:
+            return IntegrationStatus(text: "Asks on first launch", color: .systemOrange)
+        case .off:
+            return IntegrationStatus(text: "Disabled", color: .tertiaryLabelColor)
+        case .on:
+            guard tool.integrationClass == .persistent else {
+                return IntegrationStatus(text: "Enabled", color: .secondaryLabelColor)
+            }
+            if AgentIntegrationHooks.isInstalled(tool) {
+                return IntegrationStatus(text: "Hooks installed", color: .secondaryLabelColor)
+            }
+            return IntegrationStatus(
+                text: "Hooks missing — reinstalls on next launch",
+                color: .systemOrange
+            )
+        }
+    }
+
+    @objc
+    private func handleIntegrationToggle(_ sender: NSSwitch) {
+        guard let tool = toolForToggle[sender] else { return }
+        let wantsOn = sender.state == .on
+
+        if tool.integrationClass == .ephemeral {
+            setIntegrationState(tool, wantsOn ? .on : .off)
+            return
+        }
+
+        if wantsOn {
+            // Any disk write is gated by the same consent panel as first launch;
+            // only persist On if the user confirms, otherwise revert the switch.
+            consentPresenter(tool) { [weak self] decision in
+                guard let self else { return }
+                if decision == .on {
+                    self.setIntegrationState(tool, .on)
+                } else {
+                    self.refreshIntegrationControls()
+                }
+            }
+        } else {
+            // Turning off removes our hooks from disk (parity with `zentty
+            // uninstall`), then records the choice. The state is recorded as off
+            // regardless of the disk outcome — but if removal fails we log and
+            // warn the user, so stale hooks don't keep reporting status silently.
+            do {
+                try performUninstall(tool)
+            } catch {
+                settingsLogger.error(
+                    "Failed to uninstall \(tool.rawValue, privacy: .public) hooks: \(error.localizedDescription, privacy: .public)")
+                uninstallFailurePresenter(view.window, tool, error)
+            }
+            setIntegrationState(tool, .off)
+        }
+    }
+
+    private func setIntegrationState(_ tool: AgentBootstrapTool, _ state: AgentIntegrationState) {
+        do {
+            try configStore.update { config in
+                config.agentIntegrations.states[tool.rawValue] = state
+            }
+        } catch {
+            settingsLogger.error(
+                "Failed to persist \(tool.rawValue, privacy: .public) integration state: \(error.localizedDescription, privacy: .public)")
+        }
+        refreshIntegrationControls()
     }
 
     var isAgentTeamsSwitchOn: Bool {
@@ -670,5 +996,13 @@ final class AgentsSettingsSectionViewController: SettingsScrollableSectionViewCo
     func setAgentCaffeinationEnabledForTesting(_ enabled: Bool) {
         agentCaffeinationSwitch.state = enabled ? .on : .off
         persistAgentCaffeinationEnabled(enabled)
+    }
+
+    /// Drives an integration row's toggle and runs the same handler the real
+    /// switch would, so tests can exercise enable/disable + consent/uninstall.
+    func simulateIntegrationToggleForTesting(_ tool: AgentBootstrapTool, on: Bool) {
+        guard let row = integrationRows.first(where: { $0.tool == tool }) else { return }
+        row.toggle.state = on ? .on : .off
+        handleIntegrationToggle(row.toggle)
     }
 }

--- a/Zentty/UI/Settings/SettingsWindowController.swift
+++ b/Zentty/UI/Settings/SettingsWindowController.swift
@@ -191,6 +191,44 @@ enum AgentTeamsEnableWarning {
 }
 
 @MainActor
+enum AgentIntegrationUninstallFailureAlert {
+    /// Warn that Zentty recorded the integration as off but couldn't remove its
+    /// on-disk hooks, and offer to reveal the config so the user can finish the
+    /// job manually. No-ops without a host window (e.g. headless tests); the
+    /// failure has already been logged by the caller.
+    static func present(window: NSWindow?, tool: AgentBootstrapTool, error: Error) {
+        guard let window else { return }
+        let name = tool.integrationDisplayName
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn't fully disable \(name)"
+        if let path = tool.integrationConfigPathDisplay {
+            alert.informativeText = """
+            \(name) is now off in Zentty, but its status hooks couldn't be removed from \
+            \(path). Remove them there — or run `zentty uninstall` — if \(name) keeps \
+            reporting status.
+            """
+        } else {
+            alert.informativeText = """
+            \(name) is now off in Zentty, but its status hooks couldn't be removed. Run \
+            `zentty uninstall` if \(name) keeps reporting status.
+            """
+        }
+
+        let canReveal = tool.integrationConfigURL != nil
+        if canReveal {
+            alert.addButton(withTitle: "Reveal in Finder")
+        }
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window) { response in
+            if canReveal, response == .alertFirstButtonReturn, let url = tool.integrationConfigURL {
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            }
+        }
+    }
+}
+
+@MainActor
 protocol SettingsPaneMeasuring: AnyObject {
     func preferredViewportHeight(for width: CGFloat) -> CGFloat
 }

--- a/ZenttyCLI/AgentIPCClient.swift
+++ b/ZenttyCLI/AgentIPCClient.swift
@@ -12,14 +12,18 @@ enum AgentIPCClient {
     private static let maxResponseBytes = 256 * 1024
     private static let timeoutSeconds: Int = 2
 
-    static func send(request: AgentIPCRequest, socketPath: String) throws -> AgentIPCResponse? {
+    static func send(
+        request: AgentIPCRequest,
+        socketPath: String,
+        timeoutSeconds: Int = timeoutSeconds
+    ) throws -> AgentIPCResponse? {
         let fileDescriptor = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fileDescriptor >= 0 else {
             throw POSIXError(.init(rawValue: errno) ?? .EIO)
         }
         defer { close(fileDescriptor) }
 
-        configure(fileDescriptor)
+        configure(fileDescriptor, timeoutSeconds: timeoutSeconds)
         try connect(fileDescriptor, socketPath: socketPath)
         try write(request: request, to: fileDescriptor)
 
@@ -34,7 +38,7 @@ enum AgentIPCClient {
         return response
     }
 
-    private static func configure(_ fileDescriptor: Int32) {
+    private static func configure(_ fileDescriptor: Int32, timeoutSeconds: Int = timeoutSeconds) {
         let descriptorFlags = fcntl(fileDescriptor, F_GETFD)
         _ = fcntl(fileDescriptor, F_SETFD, descriptorFlags | FD_CLOEXEC)
 

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -47,8 +47,39 @@ struct AgentToolLauncher {
                 trace("bootstrap IPC returned nil response; exec real binary directly (NO STATUS EMITTED)")
                 try exec(executablePath: executablePath, arguments: arguments, environmentPatch: directEnvironment)
             }
-            guard let launchPlan = response.result?.launchPlan else {
-                trace("bootstrap response ok=\(response.ok) error=\(String(describing: response.error)) has no launchPlan; exec real binary directly (NO STATUS EMITTED)")
+
+            // Phase 2 of the consent handshake: the app asked for first-run
+            // consent before writing hooks. Tell the user, then block on a
+            // second request with a long timeout while they answer the dialog.
+            let resolved: AgentIPCResponse
+            if response.result?.consentRequired == true {
+                FileHandle.standardError.write(Data(
+                    "[Zentty] Waiting for permission to enable \(tool.rawValue) status — respond in the dialog in Zentty…\n".utf8
+                ))
+                trace("consent required; re-issuing awaitConsent with long timeout")
+                let consentRequest = AgentIPCRequest(
+                    kind: .awaitConsent,
+                    arguments: arguments,
+                    standardInput: nil,
+                    environment: bootstrapEnvironment(realBinaryPath: executablePath),
+                    expectsResponse: true,
+                    tool: tool
+                )
+                guard let consentResponse = try AgentIPCClient.send(
+                    request: consentRequest,
+                    socketPath: socketPath,
+                    timeoutSeconds: AgentIPCProtocol.awaitConsentTimeoutSeconds
+                ) else {
+                    trace("awaitConsent returned nil; exec real binary directly (NO STATUS EMITTED)")
+                    try exec(executablePath: executablePath, arguments: arguments, environmentPatch: directEnvironment)
+                }
+                resolved = consentResponse
+            } else {
+                resolved = response
+            }
+
+            guard let launchPlan = resolved.result?.launchPlan else {
+                trace("bootstrap response ok=\(resolved.ok) error=\(String(describing: resolved.error)) has no launchPlan; exec real binary directly (NO STATUS EMITTED)")
                 try exec(executablePath: executablePath, arguments: arguments, environmentPatch: directEnvironment)
             }
             trace("bootstrap launchPlan received executable=\(launchPlan.executablePath) preLaunchActions=\(launchPlan.preLaunchActions.count)")

--- a/ZenttyLogicTests/AgentConsentCoordinatorTests.swift
+++ b/ZenttyLogicTests/AgentConsentCoordinatorTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class AgentConsentCoordinatorTests: XCTestCase {
+    private var tempDirs: [URL] = []
+    private var suiteNames: [String] = []
+
+    override func tearDown() {
+        for dir in tempDirs { try? FileManager.default.removeItem(at: dir) }
+        for name in suiteNames { UserDefaults.standard.removePersistentDomain(forName: name) }
+        tempDirs = []
+        suiteNames = []
+        super.tearDown()
+    }
+
+    func test_concurrent_requests_for_same_tool_coalesce_to_one_panel() throws {
+        let store = try makeConfigStore()
+        let coordinator = AgentConsentCoordinator()
+        var presenterCalls = 0
+        var capturedCompletion: ((AgentIntegrationState) -> Void)?
+        coordinator.configure(configStore: store) { _, completion in
+            presenterCalls += 1
+            capturedCompletion = completion
+        }
+
+        var results: [AgentIntegrationState] = []
+        coordinator.requestDecision(tool: .agy) { results.append($0) }
+        coordinator.requestDecision(tool: .agy) { results.append($0) }
+
+        XCTAssertEqual(presenterCalls, 1, "the second request must join the first panel, not open another")
+
+        capturedCompletion?(.on)
+        XCTAssertEqual(results, [.on, .on], "both waiters resolve with the same decision")
+        XCTAssertEqual(store.current.agentIntegrations.states["agy"], .on, "the decision is persisted")
+    }
+
+    func test_resolve_clears_waiters_so_a_later_request_opens_a_fresh_panel() throws {
+        let store = try makeConfigStore()
+        let coordinator = AgentConsentCoordinator()
+        var presenterCalls = 0
+        var capturedCompletion: ((AgentIntegrationState) -> Void)?
+        coordinator.configure(configStore: store) { _, completion in
+            presenterCalls += 1
+            capturedCompletion = completion
+        }
+
+        coordinator.requestDecision(tool: .grok) { _ in }
+        capturedCompletion?(.off)
+        XCTAssertEqual(store.current.agentIntegrations.states["grok"], .off)
+
+        coordinator.requestDecision(tool: .grok) { _ in }
+        XCTAssertEqual(presenterCalls, 2, "after a decision resolves, a new request opens a fresh panel")
+    }
+
+    func test_without_presenter_declines_without_persisting() throws {
+        let store = try makeConfigStore()
+        let coordinator = AgentConsentCoordinator()
+        // Not configured: no presenter.
+        var result: AgentIntegrationState?
+        coordinator.requestDecision(tool: .agy) { result = $0 }
+        XCTAssertEqual(result, .off, "an unconfigured coordinator declines")
+        XCTAssertNil(store.current.agentIntegrations.states["agy"], "but does not persist, so state stays ask")
+    }
+
+    private func makeConfigStore() throws -> AppConfigStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentConsentCoordinatorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempDirs.append(dir)
+        func defaults(_ suffix: String) -> UserDefaults {
+            let name = "ZenttyTests.ConsentCoordinator.\(suffix).\(UUID().uuidString)"
+            suiteNames.append(name)
+            return UserDefaults(suiteName: name) ?? .standard
+        }
+        return AppConfigStore(
+            fileURL: dir.appendingPathComponent("config.toml"),
+            sidebarWidthDefaults: defaults("width"),
+            sidebarVisibilityDefaults: defaults("visibility"),
+            paneLayoutDefaults: defaults("paneLayout")
+        )
+    }
+}

--- a/ZenttyLogicTests/AgentIntegrationConsentTests.swift
+++ b/ZenttyLogicTests/AgentIntegrationConsentTests.swift
@@ -274,6 +274,22 @@ final class AgentIntegrationConsentTests: XCTestCase {
         XCTAssertEqual(registered, ["pane-xyz"], "an agent resume command must register the restore token")
     }
 
+    func test_makePane_registers_forEnvPrefixedHermesResumeCommand() {
+        var registered: [String] = []
+        _ = PaneRestorationBuilder.makePane(
+            makeRestoreInputs(command: #"env HERMES_HOME='/tmp/hermes profile' hermes --resume hermes-session-123"#),
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("wl"),
+            processEnvironment: ["HOME": "/tmp"]
+        ) { registered.append($0.rawValue) }
+
+        XCTAssertEqual(
+            registered,
+            ["pane-xyz"],
+            "an env-prefixed Hermes restore command must register the restore token"
+        )
+    }
+
     private func makeRestoreInputs(command: String?) -> PaneRestorationBuilder.PaneInputs {
         PaneRestorationBuilder.PaneInputs(
             id: PaneID("pane-xyz"),
@@ -301,5 +317,24 @@ final class AgentIntegrationConsentTests: XCTestCase {
         )
         XCTAssertNil(AgentBootstrapTool.wrappedAgent(forCommand: "vim"))
         XCTAssertNil(AgentBootstrapTool.wrappedAgent(forCommand: ""))
+    }
+
+    func test_wrappedAgent_matchesEnvPrefixedHermesCommand() {
+        XCTAssertEqual(
+            AgentBootstrapTool.wrappedAgent(
+                forCommand: #"env HERMES_HOME='/tmp/hermes profile' hermes --resume hermes-session-123"#
+            ),
+            .hermes
+        )
+        XCTAssertEqual(
+            AgentBootstrapTool.wrappedAgent(
+                forCommand: #"/usr/bin/env HERMES_HOME='/tmp/hermes profile' hermes --resume hermes-session-123"#
+            ),
+            .hermes
+        )
+        XCTAssertNil(
+            AgentBootstrapTool.wrappedAgent(forCommand: "env FOO=bar vim notes.txt"),
+            "env-prefixed non-agent commands must stay non-agents"
+        )
     }
 }

--- a/ZenttyLogicTests/AgentIntegrationConsentTests.swift
+++ b/ZenttyLogicTests/AgentIntegrationConsentTests.swift
@@ -1,0 +1,305 @@
+import XCTest
+@testable import Zentty
+
+final class AgentIntegrationConsentTests: XCTestCase {
+
+    // MARK: - Classification coverage
+
+    func test_persistent_and_ephemeral_lists_cover_every_tool() {
+        let grouped = Set(AgentIntegrationConsent.allTools)
+        XCTAssertEqual(
+            grouped,
+            Set(AgentBootstrapTool.allCases),
+            "allTools must cover every AgentBootstrapTool — add new agents to the persistent/ephemeral lists"
+        )
+        XCTAssertEqual(AgentIntegrationConsent.allTools.count, AgentBootstrapTool.allCases.count)
+        XCTAssertTrue(
+            Set(AgentIntegrationConsent.persistentTools)
+                .isDisjoint(with: AgentIntegrationConsent.ephemeralTools),
+            "a tool must not be in both groups"
+        )
+    }
+
+    func test_every_persistent_tool_has_hook_handlers_and_ephemeral_has_none() {
+        for tool in AgentIntegrationConsent.persistentTools {
+            XCTAssertNotNil(
+                AgentIntegrationHooks.handlers(for: tool),
+                "\(tool) is persistent but has no install/uninstall handlers — add it to AgentIntegrationHooks.handlers, "
+                    + "otherwise the grandfather migration and Settings toggle silently no-op on disk"
+            )
+        }
+        for tool in AgentIntegrationConsent.ephemeralTools {
+            XCTAssertNil(
+                AgentIntegrationHooks.handlers(for: tool),
+                "\(tool) is ephemeral and must not have install/uninstall handlers"
+            )
+        }
+    }
+
+    func test_integration_class_matches_group_membership() {
+        for tool in AgentIntegrationConsent.persistentTools {
+            XCTAssertEqual(tool.integrationClass, .persistent, "\(tool) should be persistent")
+        }
+        for tool in AgentIntegrationConsent.ephemeralTools {
+            XCTAssertEqual(tool.integrationClass, .ephemeral, "\(tool) should be ephemeral")
+        }
+    }
+
+    func test_default_states() {
+        XCTAssertEqual(AgentBootstrapTool.grok.defaultIntegrationState, .ask)
+        XCTAssertEqual(AgentBootstrapTool.agy.defaultIntegrationState, .ask)
+        XCTAssertEqual(AgentBootstrapTool.amp.defaultIntegrationState, .ask)
+        XCTAssertEqual(AgentBootstrapTool.claude.defaultIntegrationState, .on)
+        XCTAssertEqual(AgentBootstrapTool.kimi.defaultIntegrationState, .on)
+        XCTAssertEqual(AgentBootstrapTool.copilot.defaultIntegrationState, .on)
+    }
+
+    // MARK: - Effective state
+
+    func test_effective_state_falls_back_to_class_default() {
+        XCTAssertEqual(AgentIntegrationConsent.effectiveState(for: .grok, storedState: nil), .ask)
+        XCTAssertEqual(AgentIntegrationConsent.effectiveState(for: .grok, storedState: .on), .on)
+        XCTAssertEqual(AgentIntegrationConsent.effectiveState(for: .claude, storedState: nil), .on)
+        XCTAssertEqual(AgentIntegrationConsent.effectiveState(for: .claude, storedState: .off), .off)
+    }
+
+    // MARK: - Gate matrix
+
+    func test_gate_persistent_ask_interactive_needs_consent() {
+        XCTAssertEqual(
+            AgentIntegrationConsent.gate(for: .agy, storedState: nil, isRestore: false),
+            .needsConsent
+        )
+    }
+
+    func test_gate_persistent_ask_during_restore_is_suppressed() {
+        XCTAssertEqual(
+            AgentIntegrationConsent.gate(for: .agy, storedState: nil, isRestore: true),
+            .suppressedByRestore
+        )
+    }
+
+    func test_gate_on_proceeds_regardless_of_restore() {
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .agy, storedState: .on, isRestore: false), .proceed)
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .agy, storedState: .on, isRestore: true), .proceed)
+    }
+
+    func test_gate_off_is_off_regardless_of_restore() {
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .agy, storedState: .off, isRestore: false), .off)
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .grok, storedState: .off, isRestore: true), .off)
+    }
+
+    func test_gate_ephemeral_default_proceeds_never_needs_consent() {
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .claude, storedState: nil, isRestore: false), .proceed)
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .codex, storedState: nil, isRestore: true), .proceed)
+    }
+
+    func test_gate_ephemeral_off_is_off() {
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .claude, storedState: .off, isRestore: false), .off)
+    }
+
+    func test_gate_ephemeral_stray_ask_proceeds_defensively() {
+        // An ephemeral tool persisted as `.ask` is a data anomaly; it must not
+        // block on a consent panel that has nothing to install.
+        XCTAssertEqual(AgentIntegrationConsent.gate(for: .claude, storedState: .ask, isRestore: false), .proceed)
+    }
+
+    // MARK: - Decision mapping
+
+    func test_immediate_decision_mapping() {
+        XCTAssertEqual(AgentIntegrationGate.proceed.immediateDecision, .proceed)
+        XCTAssertEqual(AgentIntegrationGate.off.immediateDecision, .off)
+        XCTAssertEqual(AgentIntegrationGate.suppressedByRestore.immediateDecision, .suppressedByRestore)
+        XCTAssertNil(AgentIntegrationGate.needsConsent.immediateDecision)
+    }
+
+    func test_decision_for_consent_answer() {
+        XCTAssertEqual(AgentIntegrationConsent.decision(forConsentAnswer: .on), .proceed)
+        XCTAssertEqual(AgentIntegrationConsent.decision(forConsentAnswer: .off), .off)
+        // `.ask` is not a valid panel answer; treat as off (no install).
+        XCTAssertEqual(AgentIntegrationConsent.decision(forConsentAnswer: .ask), .off)
+    }
+
+    // MARK: - Display mapping
+
+    func test_agent_tool_display_names() {
+        XCTAssertEqual(AgentBootstrapTool.claude.integrationDisplayName, "Claude Code")
+        XCTAssertEqual(AgentBootstrapTool.agy.integrationDisplayName, "Antigravity")
+        XCTAssertEqual(AgentBootstrapTool.opencode.integrationDisplayName, "OpenCode")
+    }
+
+    // MARK: - integrationGate restore-pending consumption
+    //
+    // These assert the wiring introduced for the one-shot restore signal: the
+    // gate reads the pane id from the request env and consumes it via the
+    // injected closure. The gate's *output* (isRestore -> .suppressedByRestore)
+    // is covered by the pure `gate(...)` matrix above; `integrationGate` itself
+    // reads the real on-disk config via `loadAppConfig()`, so we assert only the
+    // consume wiring here, which is config-independent.
+
+    private func bootstrapRequest(tool: AgentBootstrapTool, paneID: String?) -> AgentIPCRequest {
+        var environment: [String: String] = [:]
+        if let paneID { environment["ZENTTY_PANE_ID"] = paneID }
+        return AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: [],
+            standardInput: nil,
+            environment: environment,
+            expectsResponse: true,
+            tool: tool
+        )
+    }
+
+    func test_integration_gate_consumes_pane_id_from_env() {
+        var consumed: [String] = []
+        let request = bootstrapRequest(tool: .agy, paneID: "pane-1")
+        _ = AgentLaunchBootstrap.integrationGate(for: request) { id in
+            consumed.append(id)
+            return true
+        }
+        XCTAssertEqual(consumed, ["pane-1"], "the gate must consume the pane id from the request env")
+    }
+
+    func test_integration_gate_without_pane_id_does_not_consume() {
+        var consumed: [String] = []
+        let request = bootstrapRequest(tool: .agy, paneID: nil)
+        _ = AgentLaunchBootstrap.integrationGate(for: request) { id in
+            consumed.append(id)
+            return true
+        }
+        XCTAssertTrue(consumed.isEmpty, "no pane id in the env means nothing to consume")
+    }
+
+    func test_integration_gate_returns_nil_without_tool_and_does_not_consume() {
+        var consumed: [String] = []
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: [],
+            standardInput: nil,
+            environment: ["ZENTTY_PANE_ID": "pane-1"],
+            expectsResponse: true,
+            tool: nil
+        )
+        let gate = AgentLaunchBootstrap.integrationGate(for: request) { id in
+            consumed.append(id)
+            return true
+        }
+        XCTAssertNil(gate, "a request with no tool has no gate")
+        XCTAssertTrue(consumed.isEmpty, "and must not consume a restore token")
+    }
+
+    // MARK: - AgentIPCServer restore-pending one-shot
+
+    func test_server_restore_pending_is_one_shot() {
+        let server = AgentIPCServer()
+        XCTAssertFalse(server.consumeRestorePendingPane("p1"), "an unregistered pane is not restore-pending")
+        server.registerRestorePendingPane("p1")
+        XCTAssertTrue(server.consumeRestorePendingPane("p1"), "a registered pane is restore-pending once")
+        XCTAssertFalse(server.consumeRestorePendingPane("p1"), "and only once — the next launch in that pane prompts")
+    }
+
+    func test_server_restore_pending_tracks_panes_independently() {
+        let server = AgentIPCServer()
+        server.registerRestorePendingPane("a")
+        server.registerRestorePendingPane("b")
+        XCTAssertTrue(server.consumeRestorePendingPane("a"))
+        XCTAssertFalse(server.consumeRestorePendingPane("a"))
+        XCTAssertTrue(server.consumeRestorePendingPane("b"), "consuming one pane must not affect another")
+    }
+
+    // MARK: - PaneRestorationBuilder registers (no leaky env var)
+
+    func test_makePane_registers_restore_pending_and_omits_legacy_env_var() {
+        var registered: [String] = []
+        let inputs = PaneRestorationBuilder.PaneInputs(
+            id: PaneID("pane-xyz"),
+            titleSeed: "shell",
+            lastActivityTitle: nil,
+            requestedWorkingDirectory: nil,
+            command: "grok",
+            prefillText: nil,
+            environmentOverrides: [:],
+            surfaceContext: .window,
+            columnWidth: 0.5,
+            statusTextWhenWorkingDirectoryMissing: nil
+        )
+
+        let result = PaneRestorationBuilder.makePane(
+            inputs,
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("wl"),
+            processEnvironment: ["HOME": "/tmp"]
+        ) { registered.append($0.rawValue) }
+
+        XCTAssertEqual(registered, ["pane-xyz"], "a restore pane must be registered exactly once")
+        XCTAssertNil(
+            result.pane.sessionRequest.environmentVariables["ZENTTY_RESTORE_LAUNCH"],
+            "the legacy persistent env var must no longer be set (it leaked into the pane's shell)"
+        )
+    }
+
+    func test_makePane_doesNotRegister_forShellPaneWithoutCommand() {
+        var registered: [String] = []
+        _ = PaneRestorationBuilder.makePane(
+            makeRestoreInputs(command: nil),
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("wl"),
+            processEnvironment: ["HOME": "/tmp"]
+        ) { registered.append($0.rawValue) }
+
+        XCTAssertEqual(registered, [], "a restored shell pane must not pre-consume the consent token")
+    }
+
+    func test_makePane_doesNotRegister_forNonAgentCommand() {
+        var registered: [String] = []
+        _ = PaneRestorationBuilder.makePane(
+            makeRestoreInputs(command: "vim notes.txt"),
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("wl"),
+            processEnvironment: ["HOME": "/tmp"]
+        ) { registered.append($0.rawValue) }
+
+        XCTAssertEqual(registered, [], "a non-agent command must not register a restore token")
+    }
+
+    func test_makePane_registers_forAgentResumeCommand() {
+        var registered: [String] = []
+        _ = PaneRestorationBuilder.makePane(
+            makeRestoreInputs(command: "claude --resume abc123"),
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("wl"),
+            processEnvironment: ["HOME": "/tmp"]
+        ) { registered.append($0.rawValue) }
+
+        XCTAssertEqual(registered, ["pane-xyz"], "an agent resume command must register the restore token")
+    }
+
+    private func makeRestoreInputs(command: String?) -> PaneRestorationBuilder.PaneInputs {
+        PaneRestorationBuilder.PaneInputs(
+            id: PaneID("pane-xyz"),
+            titleSeed: "shell",
+            lastActivityTitle: nil,
+            requestedWorkingDirectory: nil,
+            command: command,
+            prefillText: nil,
+            environmentOverrides: [:],
+            surfaceContext: .window,
+            columnWidth: 0.5,
+            statusTextWhenWorkingDirectoryMissing: nil
+        )
+    }
+
+    // MARK: - wrappedAgent(forCommand:)
+
+    func test_wrappedAgent_matchesKnownBinaries_andRejectsOthers() {
+        XCTAssertEqual(AgentBootstrapTool.wrappedAgent(forCommand: "grok"), .grok)
+        XCTAssertEqual(AgentBootstrapTool.wrappedAgent(forCommand: "claude --resume abc"), .claude)
+        XCTAssertEqual(AgentBootstrapTool.wrappedAgent(forCommand: "/usr/local/bin/agy"), .agy)
+        XCTAssertEqual(
+            AgentBootstrapTool.wrappedAgent(forCommand: "cursor-agent"), .cursor,
+            "cursor's real binary is cursor-agent"
+        )
+        XCTAssertNil(AgentBootstrapTool.wrappedAgent(forCommand: "vim"))
+        XCTAssertNil(AgentBootstrapTool.wrappedAgent(forCommand: ""))
+    }
+}

--- a/ZenttyLogicTests/AgentIntegrationGrandfatherTests.swift
+++ b/ZenttyLogicTests/AgentIntegrationGrandfatherTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import Zentty
+
+final class AgentIntegrationGrandfatherTests: XCTestCase {
+    private var tempDirs: [URL] = []
+    private var suiteNames: [String] = []
+
+    override func tearDownWithError() throws {
+        for dir in tempDirs {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        for name in suiteNames {
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+        tempDirs = []
+        suiteNames = []
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Migration behavior (injected detector)
+
+    func test_migration_marks_installed_persistent_agents_on_and_sets_flag() throws {
+        let store = try makeConfigStore()
+        XCTAssertFalse(store.current.agentIntegrations.grandfatheredV1)
+
+        AgentIntegrationGrandfather.migrateIfNeeded(configStore: store) { tool in
+            tool == .grok || tool == .agy
+        }
+
+        XCTAssertEqual(store.current.agentIntegrations.states["grok"], .on)
+        XCTAssertEqual(store.current.agentIntegrations.states["agy"], .on)
+        XCTAssertNil(store.current.agentIntegrations.states["cursor"], "uninstalled agents stay at their ask default")
+        XCTAssertTrue(store.current.agentIntegrations.grandfatheredV1)
+    }
+
+    func test_migration_runs_only_once() throws {
+        let store = try makeConfigStore()
+        AgentIntegrationGrandfather.migrateIfNeeded(configStore: store) { _ in true }
+        XCTAssertTrue(store.current.agentIntegrations.grandfatheredV1)
+
+        // User later turns grok off; a second migration must NOT re-add it.
+        try store.update { $0.agentIntegrations.states["grok"] = .off }
+        AgentIntegrationGrandfather.migrateIfNeeded(configStore: store) { _ in true }
+        XCTAssertEqual(store.current.agentIntegrations.states["grok"], .off)
+    }
+
+    func test_migration_does_not_clobber_explicit_state() throws {
+        let store = try makeConfigStore()
+        // User explicitly disabled grok before the migration runs.
+        try store.update { $0.agentIntegrations.states["grok"] = .off }
+
+        AgentIntegrationGrandfather.migrateIfNeeded(configStore: store) { _ in true }
+
+        XCTAssertEqual(store.current.agentIntegrations.states["grok"], .off, "explicit choice preserved")
+        XCTAssertEqual(store.current.agentIntegrations.states["agy"], .on, "others still grandfathered")
+    }
+
+    func test_migration_with_nothing_installed_only_sets_flag() throws {
+        let store = try makeConfigStore()
+        AgentIntegrationGrandfather.migrateIfNeeded(configStore: store) { _ in false }
+        XCTAssertTrue(store.current.agentIntegrations.grandfatheredV1)
+        XCTAssertTrue(store.current.agentIntegrations.states.isEmpty)
+    }
+
+    // MARK: - isInstalled round-trips (install → detected → uninstall → gone)
+
+    func test_cursor_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let url = CursorHooksInstaller.defaultUserHooksURL(home: home.path)
+        XCTAssertFalse(CursorHooksInstaller.isInstalled(at: url))
+        try CursorHooksInstaller.install(at: url, cliPath: "/bin/zentty")
+        XCTAssertTrue(CursorHooksInstaller.isInstalled(at: url))
+        try CursorHooksInstaller.uninstall(at: url)
+        XCTAssertFalse(CursorHooksInstaller.isInstalled(at: url))
+    }
+
+    func test_droid_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let url = DroidHooksInstaller.defaultUserSettingsURL(home: home.path)
+        XCTAssertFalse(DroidHooksInstaller.isInstalled(at: url))
+        try DroidHooksInstaller.install(at: url, cliPath: "/bin/zentty")
+        XCTAssertTrue(DroidHooksInstaller.isInstalled(at: url))
+        try DroidHooksInstaller.uninstall(at: url)
+        XCTAssertFalse(DroidHooksInstaller.isInstalled(at: url))
+    }
+
+    func test_grok_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let root = GrokHooksInstaller.defaultUserHooksURL(home: home.path)
+        XCTAssertFalse(GrokHooksInstaller.isInstalled(hooksRoot: root))
+        try GrokHooksInstaller.install(at: root, cliPath: "/bin/zentty")
+        XCTAssertTrue(GrokHooksInstaller.isInstalled(hooksRoot: root))
+        try GrokHooksInstaller.uninstall(at: root)
+        XCTAssertFalse(GrokHooksInstaller.isInstalled(hooksRoot: root))
+    }
+
+    func test_agy_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let url = AgyHooksInstaller.defaultUserHooksFileURL(home: home.path)
+        XCTAssertFalse(AgyHooksInstaller.isInstalled(hooksFileURL: url))
+        _ = try AgyHooksInstaller.install(hooksFileURL: url, cliPath: "/bin/zentty", home: home.path)
+        XCTAssertTrue(AgyHooksInstaller.isInstalled(hooksFileURL: url))
+        try AgyHooksInstaller.uninstall(hooksFileURL: url, home: home.path)
+        XCTAssertFalse(AgyHooksInstaller.isInstalled(hooksFileURL: url))
+    }
+
+    func test_hermes_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let configURL = home.appendingPathComponent("config.yaml")
+        let allowlistURL = home.appendingPathComponent("shell-hooks-allowlist.json")
+        XCTAssertFalse(HermesHooksInstaller.isInstalled(configURL: configURL))
+        _ = try HermesHooksInstaller.install(configURL: configURL, allowlistURL: allowlistURL, cliPath: "/bin/zentty")
+        XCTAssertTrue(HermesHooksInstaller.isInstalled(configURL: configURL))
+        try HermesHooksInstaller.uninstall(configURL: configURL, allowlistURL: allowlistURL)
+        XCTAssertFalse(HermesHooksInstaller.isInstalled(configURL: configURL))
+    }
+
+    func test_amp_isInstalled_round_trip() throws {
+        let home = try makeTempDir()
+        let source = home.appendingPathComponent("source.ts")
+        try "// \(AmpPluginInstaller.ownershipMarker)\nexport default {}".write(to: source, atomically: true, encoding: .utf8)
+        let destination = home
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false)
+
+        XCTAssertFalse(AmpPluginInstaller.isInstalled(destinationConfigHomeURL: home))
+        _ = try AmpPluginInstaller.install(sourceURL: source, destinationURL: destination)
+        XCTAssertTrue(AmpPluginInstaller.isInstalled(destinationConfigHomeURL: home))
+        try AmpPluginInstaller.uninstall(destinationURL: destination)
+        XCTAssertFalse(AmpPluginInstaller.isInstalled(destinationConfigHomeURL: home))
+    }
+
+    func test_amp_unmarked_plugin_is_not_detected() throws {
+        let home = try makeTempDir()
+        let destination = home
+            .appendingPathComponent("amp", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent(AmpPluginInstaller.pluginFileName, isDirectory: false)
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "export default {}".write(to: destination, atomically: true, encoding: .utf8)
+        XCTAssertFalse(
+            AmpPluginInstaller.isInstalled(destinationConfigHomeURL: home),
+            "a plugin file without our ownership marker must not count as installed"
+        )
+    }
+
+    // MARK: - Ownership-predicate divergence guards
+
+    func test_hermes_half_written_block_is_not_detected() throws {
+        let home = try makeTempDir()
+        let configURL = home.appendingPathComponent("config.yaml")
+        // Begin marker present but end marker missing (corrupted/hand-edited):
+        // uninstall would be a no-op, so isInstalled must NOT claim it.
+        try """
+        hooks:
+          # zentty hermes hooks begin
+          - event: foo
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        XCTAssertFalse(
+            HermesHooksInstaller.isInstalled(configURL: configURL),
+            "a begin marker without a matching end marker must not count as installed"
+        )
+    }
+
+    func test_agy_foreign_zentty_group_is_not_detected() throws {
+        let home = try makeTempDir()
+        let url = AgyHooksInstaller.defaultUserHooksFileURL(home: home.path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        // A top-level "zentty" group that is NOT one of ours (no agy marker in
+        // its commands): uninstall would refuse to touch it, so isInstalled
+        // must return false.
+        try #"{"zentty":{"SessionStart":[{"command":"echo hi"}]}}"#
+            .write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertFalse(
+            AgyHooksInstaller.isInstalled(hooksFileURL: url),
+            "a foreign top-level zentty group must not count as a Zentty install"
+        )
+    }
+
+    func test_cursor_foreign_entry_is_not_detected() throws {
+        let home = try makeTempDir()
+        let url = CursorHooksInstaller.defaultUserHooksURL(home: home.path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try #"{"version":1,"hooks":{"stop":[{"command":"/some/other/tool run"}]}}"#
+            .write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertFalse(
+            CursorHooksInstaller.isInstalled(at: url),
+            "an entry without our adapter marker must not count as a Zentty install"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentIntegrationGrandfatherTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        tempDirs.append(url)
+        return url
+    }
+
+    private func makeConfigStore() throws -> AppConfigStore {
+        let dir = try makeTempDir()
+        func defaults(_ suffix: String) -> UserDefaults {
+            let name = "ZenttyTests.Grandfather.\(suffix).\(UUID().uuidString)"
+            suiteNames.append(name)
+            return UserDefaults(suiteName: name) ?? .standard
+        }
+        return AppConfigStore(
+            fileURL: dir.appendingPathComponent("config.toml"),
+            sidebarWidthDefaults: defaults("width"),
+            sidebarVisibilityDefaults: defaults("visibility"),
+            paneLayoutDefaults: defaults("paneLayout")
+        )
+    }
+}

--- a/ZenttyLogicTests/AgentsSettingsSectionViewControllerTests.swift
+++ b/ZenttyLogicTests/AgentsSettingsSectionViewControllerTests.swift
@@ -105,6 +105,113 @@ final class AgentsSettingsSectionViewControllerTests: AppKitTestCase {
         XCTAssertEqual(store.current.agentIntegrations.state(for: .cursor), .off)
     }
 
+    func test_integration_status_indicator_reflects_state() throws {
+        let store = makeConfigStore()
+        let controller = AgentsSettingsSectionViewController(
+            configStore: store,
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) },
+            consentPresenter: { _, completion in completion(.on) },
+            performUninstall: { _ in }
+        )
+        controller.loadViewIfNeeded()
+
+        // Persistent agent defaults to `.ask`: visible amber label, no glyph and no
+        // hover tooltip.
+        let ask = try XCTUnwrap(controller.integrationStatusForTesting(.cursor))
+        XCTAssertTrue(ask.askVisible)
+        XCTAssertFalse(ask.glyphVisible)
+        XCTAssertNil(ask.tooltipText)
+
+        // Built-in agent defaults to `.on`: no trailing indicator at all.
+        let builtIn = try XCTUnwrap(controller.integrationStatusForTesting(.claude))
+        XCTAssertFalse(builtIn.askVisible)
+        XCTAssertFalse(builtIn.glyphVisible)
+        XCTAssertNil(builtIn.tooltipText)
+
+        // Enabling a persistent agent replaces the amber ask label with the status
+        // glyph and a hover tooltip. The tint/text vary with on-disk hook state
+        // (read from the real config), so we assert the glyph is now the visible
+        // treatment and that a non-empty tooltip is present — not which tint this
+        // machine yields.
+        controller.simulateIntegrationToggleForTesting(.cursor, on: true)
+        let enabled = try XCTUnwrap(controller.integrationStatusForTesting(.cursor))
+        XCTAssertTrue(enabled.glyphVisible)
+        XCTAssertFalse(enabled.askVisible)
+        let tooltip = try XCTUnwrap(enabled.tooltipText)
+        XCTAssertFalse(tooltip.isEmpty)
+    }
+
+    /// Presenting the section re-reads integration state from disk, so a glyph
+    /// recomputes (e.g. a launch that installed hooks, or — modelled here — a
+    /// state change made behind the panel's back) without needing a config push.
+    func test_prepareForPresentation_refreshes_integration_controls() throws {
+        let store = makeConfigStore()
+        let controller = AgentsSettingsSectionViewController(
+            configStore: store,
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) },
+            consentPresenter: { _, completion in completion(.on) },
+            performUninstall: { _ in }
+        )
+        controller.loadViewIfNeeded()
+
+        controller.simulateIntegrationToggleForTesting(.cursor, on: true)
+        XCTAssertEqual(controller.integrationStatusForTesting(.cursor)?.glyphVisible, true)
+
+        // Mutate state directly, bypassing the controller, so its row goes stale.
+        try store.update { $0.agentIntegrations.states["cursor"] = .ask }
+        XCTAssertEqual(controller.integrationStatusForTesting(.cursor)?.glyphVisible, true,
+                       "row is stale until the panel re-checks")
+
+        controller.prepareForPresentation()
+
+        let refreshed = try XCTUnwrap(controller.integrationStatusForTesting(.cursor))
+        XCTAssertTrue(refreshed.askVisible, "presenting the section re-reads state and shows the ask label")
+        XCTAssertFalse(refreshed.glyphVisible)
+    }
+
+    /// An `agentIntegrationHooksDidChange` post (fired after a launch may have
+    /// (re)installed hooks) refreshes the panel live while it is already open.
+    func test_hooksDidChange_notification_refreshes_integration_controls() throws {
+        let store = makeConfigStore()
+        let controller = AgentsSettingsSectionViewController(
+            configStore: store,
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) },
+            consentPresenter: { _, completion in completion(.on) },
+            performUninstall: { _ in }
+        )
+        controller.loadViewIfNeeded()
+
+        controller.simulateIntegrationToggleForTesting(.cursor, on: true)
+        XCTAssertEqual(controller.integrationStatusForTesting(.cursor)?.glyphVisible, true)
+
+        // Mutate state behind the panel's back, then signal a hook change. Posting
+        // on the main thread invokes the selector observer synchronously, so the
+        // refresh has already happened by the time `post` returns.
+        try store.update { $0.agentIntegrations.states["cursor"] = .ask }
+        NotificationCenter.default.post(name: .agentIntegrationHooksDidChange, object: nil)
+
+        let refreshed = try XCTUnwrap(controller.integrationStatusForTesting(.cursor))
+        XCTAssertTrue(refreshed.askVisible, "the hook-change signal re-reads state and shows the ask label")
+        XCTAssertFalse(refreshed.glyphVisible)
+    }
+
+    func test_integration_group_headers_are_vertically_centered() {
+        let controller = AgentsSettingsSectionViewController(
+            configStore: makeConfigStore(),
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) }
+        )
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 800)
+        controller.view.layoutSubtreeIfNeeded()
+
+        for title in ["MODIFIES YOUR CONFIG", "AUTOMATIC"] {
+            let offset = controller.groupHeaderCenterYOffsetForTesting(title: title)
+            XCTAssertNotNil(offset, "expected a group header titled \(title)")
+            XCTAssertEqual(offset ?? .greatestFiniteMagnitude, 0, accuracy: 1.0,
+                           "\(title) should be vertically centered in its band")
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeConfigStore() -> AppConfigStore {

--- a/ZenttyLogicTests/AgentsSettingsSectionViewControllerTests.swift
+++ b/ZenttyLogicTests/AgentsSettingsSectionViewControllerTests.swift
@@ -27,8 +27,9 @@ final class AgentsSettingsSectionViewControllerTests: AppKitTestCase {
     /// Regression: the Agents section once activated a separator's width
     /// constraint *before* the separator was added to its stack, throwing a
     /// "no common ancestor" exception that aborted `assembleContent` and left the
-    /// whole pane blank. Loading the view must assemble all three switch rows
-    /// (menu bar status, agent teams, prevent sleep) with a non-zero height.
+    /// whole pane blank. Loading the view must assemble the three global switch
+    /// rows (menu bar status, agent teams, prevent sleep) plus one switch per
+    /// agent in the integrations card, with a non-zero height.
     func test_agents_section_assembles_all_switch_rows() {
         let controller = AgentsSettingsSectionViewController(
             configStore: makeConfigStore(),
@@ -39,7 +40,8 @@ final class AgentsSettingsSectionViewControllerTests: AppKitTestCase {
         controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 600)
         controller.view.layoutSubtreeIfNeeded()
 
-        XCTAssertEqual(switches(in: controller.view).count, 3)
+        // 3 global toggles + one integration toggle per known agent.
+        XCTAssertEqual(switches(in: controller.view).count, 3 + AgentIntegrationConsent.allTools.count)
         XCTAssertGreaterThan(controller.measuredContentHeight(), 0)
     }
 
@@ -57,6 +59,50 @@ final class AgentsSettingsSectionViewControllerTests: AppKitTestCase {
 
         XCTAssertFalse(store.current.menuBar.showStatusItem)
         XCTAssertFalse(controller.isMenuBarStatusSwitchOn)
+    }
+
+    func test_integration_disable_uninstallFailure_keepsOff_andSurfacesFailure() {
+        struct UninstallError: Error {}
+        let store = makeConfigStore()
+        var failureTool: AgentBootstrapTool?
+        let controller = AgentsSettingsSectionViewController(
+            configStore: store,
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) },
+            consentPresenter: { _, completion in completion(.on) },
+            performUninstall: { _ in throw UninstallError() },
+            uninstallFailurePresenter: { _, tool, _ in failureTool = tool }
+        )
+        controller.loadViewIfNeeded()
+
+        controller.simulateIntegrationToggleForTesting(.cursor, on: true)
+        XCTAssertEqual(store.current.agentIntegrations.state(for: .cursor), .on)
+
+        controller.simulateIntegrationToggleForTesting(.cursor, on: false)
+
+        XCTAssertEqual(failureTool, .cursor, "an uninstall failure must be surfaced to the user")
+        XCTAssertEqual(
+            store.current.agentIntegrations.state(for: .cursor), .off,
+            "the user's off choice is recorded even when hook removal fails"
+        )
+    }
+
+    func test_integration_disable_uninstallSuccess_doesNotSurfaceFailure() {
+        let store = makeConfigStore()
+        var didPresentFailure = false
+        let controller = AgentsSettingsSectionViewController(
+            configStore: store,
+            agentTeamsEnableWarningPresenter: { _, completion in completion(.cancel) },
+            consentPresenter: { _, completion in completion(.on) },
+            performUninstall: { _ in },
+            uninstallFailurePresenter: { _, _, _ in didPresentFailure = true }
+        )
+        controller.loadViewIfNeeded()
+
+        controller.simulateIntegrationToggleForTesting(.cursor, on: true)
+        controller.simulateIntegrationToggleForTesting(.cursor, on: false)
+
+        XCTAssertFalse(didPresentFailure, "a successful uninstall must not surface a failure")
+        XCTAssertEqual(store.current.agentIntegrations.state(for: .cursor), .off)
     }
 
     // MARK: - Helpers

--- a/ZenttyLogicTests/AppConfigAgentIntegrationsTOMLTests.swift
+++ b/ZenttyLogicTests/AppConfigAgentIntegrationsTOMLTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Zentty
+
+final class AppConfigAgentIntegrationsTOMLTests: XCTestCase {
+
+    func test_round_trip_preserves_states_and_flag() {
+        var config = AppConfig.default
+        config.agentIntegrations.grandfatheredV1 = true
+        config.agentIntegrations.states = [
+            "agy": .on,
+            "grok": .off,
+            "claude": .off,
+        ]
+
+        let encoded = AppConfigTOML.encode(config)
+        let decoded = AppConfigTOML.decode(encoded)
+
+        XCTAssertEqual(decoded?.agentIntegrations.grandfatheredV1, true)
+        XCTAssertEqual(decoded?.agentIntegrations.states["agy"], .on)
+        XCTAssertEqual(decoded?.agentIntegrations.states["grok"], .off)
+        XCTAssertEqual(decoded?.agentIntegrations.states["claude"], .off)
+    }
+
+    func test_defaults_round_trip_to_empty_states() {
+        let config = AppConfig.default
+        let decoded = AppConfigTOML.decode(AppConfigTOML.encode(config))
+        XCTAssertEqual(decoded?.agentIntegrations.grandfatheredV1, false)
+        XCTAssertTrue(decoded?.agentIntegrations.states.isEmpty ?? false)
+    }
+
+    func test_full_default_config_round_trips_unchanged() {
+        let decoded = AppConfigTOML.decode(AppConfigTOML.encode(.default))
+        XCTAssertEqual(decoded, .default)
+    }
+
+    func test_encode_sorts_states_deterministically() {
+        var config = AppConfig.default
+        config.agentIntegrations.states = ["grok": .off, "agy": .on, "cursor": .on]
+        let encoded = AppConfigTOML.encode(config)
+
+        guard
+            let agy = encoded.range(of: "agy = "),
+            let cursor = encoded.range(of: "cursor = "),
+            let grok = encoded.range(of: "grok = ")
+        else {
+            return XCTFail("expected all three agent state lines in the encoded TOML")
+        }
+        XCTAssertTrue(agy.lowerBound < cursor.lowerBound)
+        XCTAssertTrue(cursor.lowerBound < grok.lowerBound)
+    }
+
+    func test_unknown_state_value_is_skipped_not_fatal() {
+        let source = """
+        [agent_integrations]
+        grandfathered_v1 = true
+
+        [agent_integrations.states]
+        agy = "on"
+        future = "paused"
+        """
+        let decoded = AppConfigTOML.decode(source)
+        XCTAssertNotNil(decoded, "an unknown state value must not discard the whole config")
+        XCTAssertEqual(decoded?.agentIntegrations.states["agy"], .on)
+        XCTAssertNil(decoded?.agentIntegrations.states["future"])
+        XCTAssertEqual(decoded?.agentIntegrations.grandfatheredV1, true)
+    }
+
+    func test_unknown_agent_key_with_valid_state_is_preserved() {
+        let source = """
+        [agent_integrations.states]
+        someNewAgent = "on"
+        """
+        let decoded = AppConfigTOML.decode(source)
+        XCTAssertEqual(decoded?.agentIntegrations.states["someNewAgent"], .on)
+    }
+}

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -174,6 +174,33 @@ final class AppConfigStoreTests: XCTestCase {
 
         XCTAssertEqual(store.current, AppConfig.default.normalized())
         XCTAssertEqual(try String(contentsOf: fileURL), invalidSource)
+        XCTAssertFalse(
+            store.didLoadFromValidFile,
+            "an unparseable config must report didLoadFromValidFile == false so startup migrations skip and don't overwrite it"
+        )
+    }
+
+    func test_store_reports_valid_load_for_parseable_and_missing_files() throws {
+        // Missing file: store writes a fresh default — counts as valid.
+        let missingURL = temporaryDirectoryURL.appendingPathComponent("missing.toml")
+        let missingStore = AppConfigStore(
+            fileURL: missingURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+        XCTAssertTrue(missingStore.didLoadFromValidFile)
+
+        // Parseable file: round-trips a valid default — counts as valid.
+        let validURL = temporaryDirectoryURL.appendingPathComponent("valid.toml")
+        try AppConfigTOML.encode(.default).write(to: validURL, atomically: true, encoding: .utf8)
+        let validStore = AppConfigStore(
+            fileURL: validURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+        XCTAssertTrue(validStore.didLoadFromValidFile)
     }
 
     func test_store_writes_updates_atomically_as_toml() throws {


### PR DESCRIPTION
## Why

Zentty installs hooks into some agents' own config files (Amp, Cursor, Droid, Grok, Antigravity, Hermes) to drive status, approvals, and restore. It did that silently, with no way to say no and no way to turn it back off afterward. There was also no signal when the hooks weren't actually there.

This adds a consent gate before any of those writes, plus per-agent on/off control in Settings.

## How it works

Each integration now has one of three states, stored per agent under `[agent_integrations]` in config:

- `ask`: never decided. The agent's first interactive launch shows a consent panel before Zentty touches its config. Default for config-modifying agents.
- `on`: enabled. Hooks are installed (config-modifying agents) or passed per launch (built-in agents). Default for built-in agents, which never touch your config.
- `off`: disabled. The agent launches with no Zentty hooks at all, and any previously installed hooks are removed from disk.

The IPC server blocks an agent's first launch until the panel resolves. Two of the same agent starting at once share one prompt instead of stacking two. Workspace restores don't prompt: they launch degraded (no hooks) and stay `ask`, so the next time you start that agent by hand you still get asked.

Upgrading users aren't re-prompted for agents they already had working. A one-time migration marks anything already installed on disk as `on`.

## Turning it off actually cleans up

Each installer gained `isInstalled()` / `uninstall()`. Flipping an integration off removes its hooks from the agent's config, matching what `zentty uninstall` does. If removal fails, you get a warning instead of a silent stale state.

## Settings reflects real disk state

The Agents settings pane reads the actual on-disk state for its status line. If an agent is marked on but its hooks were removed outside Zentty (a manual edit, another tool), the status now warns in orange ("Hooks missing — reinstalls on next launch") instead of looking like a fresh, never-installed integration. The toggle still reflects your intent; the status line reflects reality.

## Testing

- New logic tests for the consent coordinator (coalescing, persistence, degraded fallback), the tri-state config model and TOML round-trip, the grandfather migration, and the settings rows.
- `xcodebuild build -scheme Zentty` passes clean.

Worth a careful look on the IPC blocking path (`AgentConsentCoordinator.awaitDecisionBlocking`) and the restore-suppression branch — those are the trickiest parts.
