### PR TITLE
fix(tests): reuse the virtual test display instead of discarding it

### DIFF
--- a/scripts/test-on-virtual-display
+++ b/scripts/test-on-virtual-display
@@ -272,9 +272,18 @@ ensure_betterdisplay() {
 
 cleanup_betterdisplay() {
   resolve_betterdisplay_transport || return 0
-  betterdisplay_request discard -serial="$display_serial" >/dev/null 2>&1 || \
-    betterdisplay_request discard -name="$active_display_name" >/dev/null 2>&1 || \
-    betterdisplay_request discard -name="$display_name" >/dev/null 2>&1 || true
+  # Disconnect rather than discard. Discarding destroys the virtual screen, so
+  # macOS mints a fresh display UUID on the next create. Menu-bar managers like
+  # Thaw/Ice key per-display settings by UUID and never prune them, so a
+  # discard-per-run leaks a new ghost display into their config every run; it
+  # also lets concurrent agents stack duplicate "Name (1)" displays. Keeping the
+  # screen registered preserves its UUID, so the next run reconnects the same
+  # screen (by name, via connect_existing_betterdisplay) and Thaw keeps one entry.
+  # BetterDisplay assigns its own serial, so -name is the selector that matches;
+  # -serial is kept only as a harmless last-ditch fallback.
+  betterdisplay_request set -name="$active_display_name" -connected=off >/dev/null 2>&1 || \
+    betterdisplay_request set -name="$display_name" -connected=off >/dev/null 2>&1 || \
+    betterdisplay_request set -serial="$display_serial" -connected=off >/dev/null 2>&1 || true
 }
 
 ensure_simpledisplay() {

--- a/scripts/test_virtual_display_harness.sh
+++ b/scripts/test_virtual_display_harness.sh
@@ -150,9 +150,16 @@ if [[ "$create_count" != "1" ]]; then
   exit 1
 fi
 
+disconnect_count="$(grep -c -- '-connected=off' "$betterdisplay_log" 2>/dev/null || true)"
+if [[ "$disconnect_count" != "1" ]]; then
+  print -u2 "expected the last harness run to disconnect the shared virtual display once, got $disconnect_count disconnect calls"
+  cat "$betterdisplay_log" >&2
+  exit 1
+fi
+
 discard_count="$(grep -c '^discard ' "$betterdisplay_log" 2>/dev/null || true)"
-if [[ "$discard_count" != "1" ]]; then
-  print -u2 "expected the last harness run to discard the shared virtual display once, got $discard_count discard calls"
+if [[ "$discard_count" != "0" ]]; then
+  print -u2 "expected no discard calls (display is kept registered for reuse), got $discard_count discard calls"
   cat "$betterdisplay_log" >&2
   exit 1
 fi


### PR DESCRIPTION
## What

The virtual-display test harness now disconnects its shared BetterDisplay screen on cleanup instead of discarding it, so the screen keeps a stable display UUID across runs.

## Why

`cleanup_betterdisplay` discarded the virtual screen once the last test lease released. Discarding destroys the screen, and macOS hands out a fresh display UUID the next time it is created. Menu-bar managers like Thaw (and its upstream, Ice) store per-display settings keyed by UUID, and they never prune disconnected displays. So every test run left another ghost `ZenttyTests` entry behind — 213 had piled up in my local Thaw config. The same create/discard churn is also what let concurrent agents race into stacking duplicate `ZenttyTests (1)` displays.

## What changed

- `cleanup_betterdisplay` disconnects the screen (`set -connected=off`) and leaves it registered. The next run reconnects the same screen by name via `connect_existing_betterdisplay`, so the UUID stays put and Thaw records one entry. Concurrent agents share that one screen instead of stacking.
- BetterDisplay assigns its own serial and ignores the one we pass at create time, so disconnect has to match by `-name`. `-serial` stays as a harmless last-ditch fallback.
- The harness self-test now asserts one disconnect and zero discards.

## Verification

- `scripts/test_virtual_display_harness.sh` passes; `zsh -n` is clean.
- Checked a real disconnect/reconnect cycle against live BetterDisplay: the screen leaves `NSScreen.screens` on disconnect and comes back with the same CGDisplay UUID (`A9FD35D8…`), so it is reused, not recreated.

## Note

SimpleDisplay cannot persist a screen, so that provider still creates and removes per run. `auto` prefers BetterDisplay, so the common path is covered.