### PR TITLE
feat(terminal): let a user-set background-image override Zentty's forced transparency

### DIFF
--- a/Zentty/Terminal/LibghosttyRuntime.swift
+++ b/Zentty/Terminal/LibghosttyRuntime.swift
@@ -605,13 +605,32 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
         return latest
     }
 
+    private static func lastConfigValue(for key: String, in content: String?) -> String? {
+        guard let content else {
+            return nil
+        }
+
+        var latest: String?
+        for rawLine in content.split(whereSeparator: \.isNewline) {
+            guard let value = configValue(for: key, in: String(rawLine)) else {
+                continue
+            }
+
+            latest = value
+        }
+
+        return latest
+    }
+
     private static func configValue(for expectedKey: String, in rawLine: String) -> String? {
         let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !line.isEmpty, !line.hasPrefix("#"), !line.hasPrefix("//") else {
             return nil
         }
 
-        let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
+        let parts = line
+            .split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            .map(String.init)
         guard parts.count == 2 else {
             return nil
         }
@@ -743,11 +762,9 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
             return false
         }
 
-        // configValue returns nil for a missing or empty value (e.g. `background-image =`, which
-        // clears the image in Ghostty), so `?.isEmpty == false` treats those lines as no image.
-        return content.split(whereSeparator: \.isNewline).contains { line in
-            configValue(for: "background-image", in: String(line))?.isEmpty == false
-        }
+        // A final empty value (e.g. `background-image =`) clears the image in Ghostty, so only
+        // skip Zentty's transparency override when the effective value is non-empty.
+        return lastConfigValue(for: "background-image", in: content)?.isEmpty == false
     }
 
     static func makeRuntimeConfig(userdata: UnsafeMutableRawPointer?) -> ghostty_runtime_config_s {

--- a/Zentty/Terminal/LibghosttyRuntime.swift
+++ b/Zentty/Terminal/LibghosttyRuntime.swift
@@ -489,6 +489,13 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
     }
 
     static func transparentBackgroundOverrideContents(userConfigContents: String?) -> String? {
+        // A configured background-image only renders if background-opacity > 0 (the renderer
+        // multiplies the image by the background alpha). Skip forcing transparency so the user's
+        // own background-opacity, or libghostty's opaque default, applies and the image shows.
+        guard !userConfigContainsBackgroundImage(userConfigContents) else {
+            return nil
+        }
+
         var lines = "background-opacity = 0\n"
 
         guard !userConfigContainsBackgroundBlur(userConfigContents) else {
@@ -728,6 +735,18 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
             let parts = trimmed.split(separator: "=", maxSplits: 1)
             let key = parts.first?.trimmingCharacters(in: .whitespaces)
             return key == "background-blur" || key == "background-blur-radius"
+        }
+    }
+
+    private static func userConfigContainsBackgroundImage(_ content: String?) -> Bool {
+        guard let content else {
+            return false
+        }
+
+        // configValue returns nil for a missing or empty value (e.g. `background-image =`, which
+        // clears the image in Ghostty), so `?.isEmpty == false` treats those lines as no image.
+        return content.split(whereSeparator: \.isNewline).contains { line in
+            configValue(for: "background-image", in: String(line))?.isEmpty == false
         }
     }
 

--- a/ZenttyLogicTests/LibghosttyRuntimeTests.swift
+++ b/ZenttyLogicTests/LibghosttyRuntimeTests.swift
@@ -218,6 +218,49 @@ final class LibghosttyRuntimeTests: XCTestCase {
         XCTAssertEqual(contents, "background-opacity = 0\n")
     }
 
+    func testTransparentBackgroundOverrideContents_skipsTransparencyWhenBackgroundImageConfigured() {
+        let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
+            userConfigContents: """
+            background-opacity = 0.95
+            background-image = /Users/me/Pictures/wallpaper.png
+            background-image-fit = cover
+            """
+        )
+
+        XCTAssertNil(contents)
+    }
+
+    func testTransparentBackgroundOverrideContents_skipsTransparencyWhenBackgroundImageConfiguredWithBlur() {
+        let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
+            userConfigContents: """
+            background-image = /Users/me/Pictures/wallpaper.png
+            background-blur = 25
+            """
+        )
+
+        XCTAssertNil(contents)
+    }
+
+    func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageValueIsEmpty() {
+        let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
+            userConfigContents: """
+            background-image =
+            """
+        )
+
+        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+    }
+
+    func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageIsCommentedOut() {
+        let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
+            userConfigContents: """
+            # background-image = /Users/me/Pictures/wallpaper.png
+            """
+        )
+
+        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+    }
+
     func testPaddingPolicyOverrideContents_injectsDefaultsWhenKeysMissing() {
         let contents = LibghosttyRuntime.paddingPolicyOverrideContents(
             userConfigContents: """

--- a/ZenttyLogicTests/LibghosttyRuntimeTests.swift
+++ b/ZenttyLogicTests/LibghosttyRuntimeTests.swift
@@ -251,6 +251,17 @@ final class LibghosttyRuntimeTests: XCTestCase {
         XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
     }
 
+    func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageIsLaterCleared() {
+        let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
+            userConfigContents: """
+            background-image = /Users/me/Pictures/wallpaper.png
+            background-image =
+            """
+        )
+
+        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+    }
+
     func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageIsCommentedOut() {
         let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
             userConfigContents: """


### PR DESCRIPTION
## Summary

Lets a `background-image` set in the user's Ghostty config actually render in
Zentty. Today it never shows, because Zentty intentionally forces the terminal
background transparent, and that forced transparency is mutually exclusive with
a background image. This change makes a deliberate exception: when the user has
explicitly set `background-image`, Zentty stops forcing transparency so the
image can render. No new UI and no new config surface; it reads the existing
Ghostty config keys.

## Background: this is changing intentional behavior, not fixing a bug

Zentty deliberately forces `background-opacity = 0` (plus a default
`background-blur-radius = 20`) as the last layer of its config stack
(`transparentBackgroundOverrideContents` in `LibghosttyRuntime.swift`),
introduced in the theme-picker / background-opacity / window-blur feature. The
point is that Zentty draws its own window background (glass / canvas / sidebar)
and makes the libghostty surface transparent so that shows through; the
translucent terminal is the intended Zentty look.

libghostty already supports `background-image` and Zentty already loads the
user's config into it, so the image path reaches the engine. But the
background-image shader ends with `rgba *= bg_color.a`, where `bg_color.a` is
`background-opacity`. With Zentty's forced `0`, the image is multiplied to fully
transparent and never appears. So the two features genuinely conflict; this PR
resolves the conflict in favor of an explicitly-configured image.

## Change

In `transparentBackgroundOverrideContents`, skip emitting the
`background-opacity = 0` override when the user's config sets a
`background-image`. The user's own `background-opacity` (or libghostty's opaque
default) then applies, and the image renders. Detection reuses the existing
`configValue(for:in:)` parser.

- Image set, no explicit opacity -> libghostty's opaque default; image visible.
- Image set + explicit `background-opacity` -> the user's value is respected.
- No image -> unchanged: Zentty still forces transparency for its glass look.
- Empty (`background-image =`) or commented out -> treated as unset; the
  transparency override still applies.

## Compatibility (please weigh in)

Because Zentty reads the **shared** Ghostty config, this changes appearance for
existing users who never asked Zentty for anything: anyone with a
`background-image` line they set for real Ghostty will, after this lands, see
Zentty switch from its transparent/glass look to an opaque terminal showing that
image. Before, the line was silently ignored.

That is the right outcome for someone who wants the image in Zentty, but it is a
silent change-on-upgrade for everyone else. This is the main reason an opt-in
might be preferable to inferring intent from the shared config; see below.

## Open question for maintainers

Inferring intent from the presence of `background-image` is the lightest-touch
approach and matches "auto-read the user's Ghostty config". Given the
compatibility note above, alternatives if you'd prefer a different shape:

- a Zentty-specific opt-in (appearance setting) so existing shared-config users
  are unaffected unless they turn it on;
- compositing the image behind the glass rather than replacing the transparent
  look.

Happy to rework toward whichever you prefer.

## Tests

- `ZenttyLogicTests/LibghosttyRuntimeTests`: added 4 cases (image set -> no
  override; image + blur -> no override; empty `background-image =` -> still
  forces transparency; commented out -> still forces transparency). Green: 33
  tests, 0 failures.
- Full `ZenttyLogicTests` run surfaced only pre-existing failures unrelated to
  this change (a missing local `opencode` binary and home-directory-dependent
  path-truncation fixtures); none touch `LibghosttyRuntime`.
- Manual: built and launched with a real `background-image` in
  `~/.config/ghostty/config` and confirmed the image renders behind the
  terminal text.
- Run with signing disabled per CONTRIBUTING (`CODE_SIGNING_ALLOWED=NO ...`) via
  `scripts/test-on-virtual-display`.

## Known limitation

Detection is presence-based, not full last-wins: a config that sets then later
clears the image (`background-image = x` then `background-image =`) is still
treated as "image set", because a key-only line doesn't parse as a value
assignment. Edge case; can be a follow-up.

---

I have read CLA.md and agree to its terms.
