### PR TITLE
feat(worklanes): add new worklane placement preference

### DIFF
--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -286,7 +286,7 @@ extension WorklaneStore {
     ) {
         transferPaneToNewWorklane(
             paneID: paneID,
-            atIndex: worklanes.count,
+            atIndex: insertionIndexForNewWorklane(anchorWorklaneID: activeWorklaneID),
             singleColumnWidth: singleColumnWidth
         )
     }
@@ -678,7 +678,7 @@ extension WorklaneStore {
     ) {
         duplicatePaneToNewWorklane(
             paneID: paneID,
-            atIndex: worklanes.count,
+            atIndex: insertionIndexForNewWorklane(anchorWorklaneID: activeWorklaneID),
             singleColumnWidth: singleColumnWidth
         )
     }

--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -390,6 +390,7 @@ final class WorklaneStore {
     let currentDateProvider: @MainActor () -> Date
     private let scheduleReadyStatusTask: ReadyStatusScheduler
     let codexQuestionResolver: CodexQuestionResolver
+    private let newWorklanePlacementProvider: @MainActor () -> NewWorklanePlacement
     private let agentTeamsEnabledProvider: @MainActor () -> Bool
     private let serverDetectionProvider: @MainActor () -> AppConfig.ServerDetection
     /// In-memory mirror of `TmuxCompatStore.anchors` for this app session.
@@ -463,6 +464,7 @@ final class WorklaneStore {
         runtimeIdentity: WorklaneRuntimeIdentity = .live,
         serverRegistry: ServerRegistry = ServerRegistry(),
         terminalDiagnostics: TerminalDiagnostics = .shared,
+        newWorklanePlacementProvider: @escaping @MainActor () -> NewWorklanePlacement = { .afterCurrent },
         agentTeamsEnabledProvider: @escaping @MainActor () -> Bool = { false },
         serverDetectionProvider: @escaping @MainActor () -> AppConfig.ServerDetection = { .default }
     ) {
@@ -476,6 +478,7 @@ final class WorklaneStore {
         self.currentDateProvider = currentDateProvider
         self.scheduleReadyStatusTask = readyStatusScheduler
         self.codexQuestionResolver = codexQuestionResolver
+        self.newWorklanePlacementProvider = newWorklanePlacementProvider
         self.agentTeamsEnabledProvider = agentTeamsEnabledProvider
         self.serverDetectionProvider = serverDetectionProvider
         self.runtimeIdentity = runtimeIdentity
@@ -1763,6 +1766,20 @@ final class WorklaneStore {
         selectWorklane(id: worklanes[previousIndex].id)
     }
 
+    func insertionIndexForNewWorklane(anchorWorklaneID: WorklaneID? = nil) -> Int {
+        switch newWorklanePlacementProvider() {
+        case .top:
+            return 0
+        case .afterCurrent:
+            let resolvedAnchorID = anchorWorklaneID ?? activeWorklaneID
+            return worklanes
+                .firstIndex(where: { $0.id == resolvedAnchorID })
+                .map { worklanes.index(after: $0) } ?? worklanes.endIndex
+        case .end:
+            return worklanes.endIndex
+        }
+    }
+
     @discardableResult
     func createWorklane() -> WorklaneID {
         let previousPaneRef = currentPaneReference
@@ -1782,9 +1799,7 @@ final class WorklaneStore {
             runtimeIdentity: runtimeIdentity,
             agentTeamsEnabled: agentTeamsEnabledProvider()
         )
-        let insertionIndex = worklanes
-            .firstIndex(where: { $0.id == activeWorklaneID })
-            .map { worklanes.index(after: $0) } ?? worklanes.endIndex
+        let insertionIndex = insertionIndexForNewWorklane(anchorWorklaneID: activeWorklaneID)
         worklanes.insert(worklane, at: insertionIndex)
         activeWorklaneID = id
         recordFocusTransition(from: previousPaneRef)

--- a/Zentty/Config/AppConfig.swift
+++ b/Zentty/Config/AppConfig.swift
@@ -1,6 +1,34 @@
 import CoreGraphics
 import Foundation
 
+enum NewWorklanePlacement: String, CaseIterable, Equatable, Sendable {
+    case top
+    case afterCurrent = "after_current"
+    case end
+
+    var displayName: String {
+        switch self {
+        case .top:
+            "Top"
+        case .afterCurrent:
+            "After current"
+        case .end:
+            "End"
+        }
+    }
+
+    var settingsDescription: String {
+        switch self {
+        case .top:
+            "Add new worklanes to the top of the list."
+        case .afterCurrent:
+            "Add new worklanes after the current worklane."
+        case .end:
+            "Append new worklanes to the bottom of the list."
+        }
+    }
+}
+
 enum AppUpdateChannel: String, CaseIterable, Equatable, Sendable {
     case stable
     case beta
@@ -164,6 +192,12 @@ struct AppConfig: Equatable, Sendable {
         static let `default` = Clipboard(alwaysCleanCopies: false)
     }
 
+    struct Worklanes: Equatable, Sendable {
+        var newWorklanePlacement: NewWorklanePlacement
+
+        static let `default` = Worklanes(newWorklanePlacement: .afterCurrent)
+    }
+
     struct AgentTeams: Equatable, Sendable {
         var enabled: Bool
 
@@ -215,6 +249,7 @@ struct AppConfig: Equatable, Sendable {
     var notifications: Notifications
     var confirmations: Confirmations
     var clipboard: Clipboard
+    var worklanes: Worklanes
     var appearance: Appearance
     var restore: Restore
     var agentTeams: AgentTeams
@@ -237,6 +272,7 @@ struct AppConfig: Equatable, Sendable {
         notifications: .default,
         confirmations: .default,
         clipboard: .default,
+        worklanes: .default,
         appearance: .default,
         restore: .default,
         agentTeams: .default,
@@ -265,6 +301,7 @@ struct AppConfig: Equatable, Sendable {
             notifications: .default,
             confirmations: .default,
             clipboard: .default,
+            worklanes: .default,
             appearance: .default,
             restore: .default,
             agentTeams: .default,

--- a/Zentty/Config/AppConfigTOML.swift
+++ b/Zentty/Config/AppConfigTOML.swift
@@ -23,6 +23,7 @@ enum AppConfigTOML {
         case notifications
         case confirmations
         case clipboard
+        case worklanes
         case updates
         case restore
         case agentTeams
@@ -159,6 +160,10 @@ enum AppConfigTOML {
         lines.append("always_clean_copies = \(config.clipboard.alwaysCleanCopies)")
 
         lines.append("")
+        lines.append("[worklanes]")
+        lines.append("new_worklane_placement = \(encode(string: config.worklanes.newWorklanePlacement.rawValue))")
+
+        lines.append("")
         lines.append("[restore]")
         lines.append("restore_workspace_on_launch = \(config.restore.restoreWorkspaceOnLaunch)")
 
@@ -264,6 +269,10 @@ enum AppConfigTOML {
                 section = .clipboard
                 continue
             }
+            if line == "[worklanes]" {
+                section = .worklanes
+                continue
+            }
             if line == "[updates]" {
                 section = .updates
                 continue
@@ -358,6 +367,10 @@ enum AppConfigTOML {
                 }
             case .clipboard:
                 guard decodeClipboardAssignment(assignment, into: &config) else {
+                    return nil
+                }
+            case .worklanes:
+                guard decodeWorklanesAssignment(assignment, into: &config) else {
                     return nil
                 }
             case .updates:
@@ -788,6 +801,24 @@ enum AppConfigTOML {
         case "always_clean_copies":
             guard let value = decodeBool(assignment.value) else { return false }
             config.clipboard.alwaysCleanCopies = value
+        default:
+            return true
+        }
+
+        return true
+    }
+
+    private static func decodeWorklanesAssignment(
+        _ assignment: (key: String, value: String),
+        into config: inout AppConfig
+    ) -> Bool {
+        switch assignment.key {
+        case "new_worklane_placement":
+            guard let raw = decodeString(assignment.value),
+                  let placement = NewWorklanePlacement(rawValue: raw) else {
+                return false
+            }
+            config.worklanes.newWorklanePlacement = placement
         default:
             return true
         }

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -296,6 +296,9 @@ final class RootViewController: NSViewController {
             layoutContext: initialLayoutContext,
             activeWorklaneID: initialWorkspaceState?.activeWorklaneID,
             gitContextResolver: gitContextResolver,
+            newWorklanePlacementProvider: { [weak configStore] in
+                configStore?.current.worklanes.newWorklanePlacement ?? .afterCurrent
+            },
             agentTeamsEnabledProvider: { [weak configStore] in
                 configStore?.current.agentTeams.enabled ?? false
             },

--- a/Zentty/UI/Settings/SettingsSectionViewControllers.swift
+++ b/Zentty/UI/Settings/SettingsSectionViewControllers.swift
@@ -177,8 +177,11 @@ class SettingsScrollableSectionViewController: NSViewController, SettingsPaneMea
 @MainActor
 final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionViewController {
     private let configStore: AppConfigStore
+    private var worklanes: AppConfig.Worklanes
     private var panes: AppConfig.Panes
     private var paneLayout: PaneLayoutPreferences
+    private let newWorklanePlacementPopup = NSPopUpButton()
+    private let newWorklanePlacementSubtitleLabel = NSTextField(labelWithString: "")
     private let showLabelsSwitch = NSSwitch()
     private let showProjectIconsSwitch = NSSwitch()
     private let smoothScrollingSwitch = NSSwitch()
@@ -196,6 +199,7 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
 
     init(configStore: AppConfigStore) {
         self.configStore = configStore
+        self.worklanes = configStore.current.worklanes
         self.panes = configStore.current.panes
         self.paneLayout = configStore.current.paneLayout
         super.init(nibName: nil, bundle: nil)
@@ -222,6 +226,10 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         stackView.addArrangedSubview(subtitleLabel)
         subtitleLabel.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
 
+        let worklanesCard = makeWorklanesCard()
+        stackView.addArrangedSubview(worklanesCard)
+        worklanesCard.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
         let splitBehaviorCard = makeSplitBehaviorCard()
         stackView.addArrangedSubview(splitBehaviorCard)
         splitBehaviorCard.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
@@ -240,6 +248,7 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
         ])
 
+        apply(worklanes: worklanes)
         apply(panes: panes)
         apply(paneLayout: paneLayout)
     }
@@ -272,6 +281,25 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         paneLayout.visibleSplitWindowWidth
     }
 
+    var selectedNewWorklanePlacementForTesting: NewWorklanePlacement {
+        worklanes.newWorklanePlacement
+    }
+
+    var newWorklanePlacementSubtitleForTesting: String {
+        newWorklanePlacementSubtitleLabel.stringValue
+    }
+
+    var newWorklanePlacementPopupForTesting: NSPopUpButton {
+        newWorklanePlacementPopup
+    }
+
+    func apply(worklanes: AppConfig.Worklanes) {
+        self.worklanes = worklanes
+        guard isViewLoaded else { return }
+        newWorklanePlacementPopup.selectItem(withTitle: worklanes.newWorklanePlacement.displayName)
+        updateNewWorklanePlacementSubtitle(worklanes.newWorklanePlacement)
+    }
+
     func apply(panes: AppConfig.Panes) {
         self.panes = panes
         guard isViewLoaded else { return }
@@ -284,7 +312,8 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         isApplyingPanes = false
     }
 
-    func apply(panes: AppConfig.Panes, paneLayout: PaneLayoutPreferences) {
+    func apply(worklanes: AppConfig.Worklanes, panes: AppConfig.Panes, paneLayout: PaneLayoutPreferences) {
+        apply(worklanes: worklanes)
         apply(panes: panes)
         apply(paneLayout: paneLayout)
     }
@@ -303,6 +332,35 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         visibleSplitWindowWidthSlider.isEnabled = paneLayout.rightSplitBehaviorMode == .adaptive
         updateVisibleSplitWindowWidthLabelColors(isAdaptive: paneLayout.rightSplitBehaviorMode == .adaptive)
         isApplyingPaneLayout = false
+    }
+
+    private func makeWorklanesCard() -> NSView {
+        let card = SettingsCardView()
+        let contentStack = NSStackView()
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = 0
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(contentStack)
+
+        let row = makePopupRow(
+            title: "New worklane placement",
+            subtitleLabel: newWorklanePlacementSubtitleLabel,
+            popup: newWorklanePlacementPopup,
+            action: #selector(handleNewWorklanePlacementChanged(_:))
+        )
+        contentStack.addArrangedSubview(row)
+        row.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: card.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+        ])
+
+        configureNewWorklanePlacementPopup()
+        return card
     }
 
     private func makeSplitBehaviorCard() -> NSView {
@@ -500,6 +558,56 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         return container
     }
 
+    private func makePopupRow(
+        title: String,
+        subtitleLabel: NSTextField,
+        popup: NSPopUpButton,
+        action: Selector
+    ) -> NSView {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let leftStack = NSStackView()
+        leftStack.orientation = .vertical
+        leftStack.alignment = .leading
+        leftStack.spacing = 2
+        leftStack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(leftStack)
+
+        let titleLabel = makeLabel(
+            text: title,
+            font: .systemFont(ofSize: 13, weight: .semibold)
+        )
+        leftStack.addArrangedSubview(titleLabel)
+
+        subtitleLabel.font = .systemFont(ofSize: 12, weight: .regular)
+        subtitleLabel.textColor = .secondaryLabelColor
+        subtitleLabel.lineBreakMode = .byWordWrapping
+        subtitleLabel.maximumNumberOfLines = 0
+        leftStack.addArrangedSubview(subtitleLabel)
+        subtitleLabel.widthAnchor.constraint(equalTo: leftStack.widthAnchor).isActive = true
+
+        popup.target = self
+        popup.action = action
+        popup.controlSize = .regular
+        popup.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(popup)
+
+        NSLayoutConstraint.activate([
+            leftStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            leftStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            leftStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16),
+
+            popup.leadingAnchor.constraint(greaterThanOrEqualTo: leftStack.trailingAnchor, constant: 16),
+            popup.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            popup.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+
+            leftStack.trailingAnchor.constraint(lessThanOrEqualTo: popup.leadingAnchor, constant: -16),
+        ])
+
+        return container
+    }
+
     private func makeInactiveOpacityRow() -> NSView {
         let container = NSView()
         container.translatesAutoresizingMaskIntoConstraints = false
@@ -570,6 +678,17 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         visibleSplitWindowWidthSlider.action = #selector(handleVisibleSplitWindowWidthChanged(_:))
     }
 
+    private func configureNewWorklanePlacementPopup() {
+        newWorklanePlacementPopup.removeAllItems()
+        newWorklanePlacementPopup.addItems(withTitles: NewWorklanePlacement.allCases.map(\.displayName))
+        newWorklanePlacementPopup.selectItem(withTitle: worklanes.newWorklanePlacement.displayName)
+        updateNewWorklanePlacementSubtitle(worklanes.newWorklanePlacement)
+    }
+
+    private func updateNewWorklanePlacementSubtitle(_ placement: NewWorklanePlacement) {
+        newWorklanePlacementSubtitleLabel.stringValue = placement.settingsDescription
+    }
+
     private func updateInactiveOpacityLabel(_ opacity: CGFloat) {
         inactiveOpacityValueLabel.stringValue = "\(Int(round(opacity * 100)))%"
     }
@@ -612,6 +731,20 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         label.lineBreakMode = .byWordWrapping
         label.maximumNumberOfLines = 0
         return label
+    }
+
+    @objc
+    private func handleNewWorklanePlacementChanged(_ sender: NSPopUpButton) {
+        guard let placement = NewWorklanePlacement.allCases.first(where: {
+            $0.displayName == sender.titleOfSelectedItem
+        }) else {
+            return
+        }
+        worklanes.newWorklanePlacement = placement
+        updateNewWorklanePlacementSubtitle(placement)
+        try? configStore.update {
+            $0.worklanes.newWorklanePlacement = placement
+        }
     }
 
     @objc

--- a/Zentty/UI/Settings/SettingsWindowController.swift
+++ b/Zentty/UI/Settings/SettingsWindowController.swift
@@ -26,7 +26,7 @@ enum SettingsSection: String, CaseIterable, Hashable, Sendable {
         case .devServers:
             "Dev Servers"
         case .paneLayout:
-            "Panes"
+            "Worklanes & Panes"
         case .updatesPrivacy:
             "Updates & Privacy"
         case .agents:
@@ -72,7 +72,7 @@ enum SettingsSection: String, CaseIterable, Hashable, Sendable {
         case .devServers:
             "Dev server detection and browsers"
         case .paneLayout:
-            "Labels, icons, opacity, and split behavior"
+            "Worklane placement, labels, icons, opacity, and split behavior"
         case .updatesPrivacy:
             "Update channel and crash reporting"
         case .agents:
@@ -97,7 +97,7 @@ enum SettingsSection: String, CaseIterable, Hashable, Sendable {
         case .devServers:
             ["server", "localhost", "browser", "port", "detect", "ignored", "hidden"]
         case .paneLayout:
-            ["pane", "split", "layout", "opacity", "label", "icon", "scroll"]
+            ["worklane", "workspace", "pane", "split", "layout", "opacity", "label", "icon", "scroll"]
         case .updatesPrivacy:
             ["update", "channel", "beta", "stable", "crash", "error", "report", "privacy", "sentry"]
         case .agents:
@@ -738,7 +738,7 @@ final class SettingsViewController: NSSplitViewController, SettingsSidebarViewCo
             menuBar: config.menuBar
         )
         shortcutsViewController.apply(shortcuts: config.shortcuts)
-        paneLayoutViewController.apply(panes: config.panes, paneLayout: config.paneLayout)
+        paneLayoutViewController.apply(worklanes: config.worklanes, panes: config.panes, paneLayout: config.paneLayout)
         openWithViewController.apply(preferences: config.openWith)
         serverBrowserSettingsViewController.apply(serverDetection: config.serverDetection)
     }

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -107,6 +107,42 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertTrue(store.current.panes.smoothScrollingEnabled)
     }
 
+    func test_store_reads_worklane_placement_from_config_file() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        try """
+        [worklanes]
+        new_worklane_placement = "end"
+        """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(store.current.worklanes.newWorklanePlacement, .end)
+    }
+
+    func test_missing_worklanes_section_uses_after_current_without_rewriting_existing_file() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let source = """
+        [panes]
+        show_labels = false
+        """
+        try source.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(store.current.worklanes.newWorklanePlacement, .afterCurrent)
+        XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), source)
+    }
+
     func test_store_prefers_existing_config_file_over_user_defaults_migration() throws {
         let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
         try """
@@ -141,6 +177,24 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertEqual(store.current.paneLayout.ultrawidePreset, .compact)
         XCTAssertEqual(store.current.openWith.primaryTargetID, "cursor")
         XCTAssertEqual(store.current.openWith.enabledTargetIDs, ["cursor", "finder"])
+    }
+
+    func test_store_persists_worklane_placement_in_toml() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        try store.update { config in
+            config.worklanes.newWorklanePlacement = .top
+        }
+
+        let persisted = try String(contentsOf: fileURL, encoding: .utf8)
+        XCTAssertTrue(persisted.contains("[worklanes]"))
+        XCTAssertTrue(persisted.contains("new_worklane_placement = \"top\""))
     }
 
     func test_store_preserves_invalid_existing_config_file_without_overwriting_it() throws {

--- a/ZenttyLogicTests/PaneLayoutPreferencesTests.swift
+++ b/ZenttyLogicTests/PaneLayoutPreferencesTests.swift
@@ -370,6 +370,11 @@ final class PaneLayoutSettingsSectionViewControllerTests: AppKitTestCase {
         controller.loadViewIfNeeded()
 
         XCTAssertFalse(controller.smoothScrollingForTesting)
+        XCTAssertEqual(controller.selectedNewWorklanePlacementForTesting, .afterCurrent)
+        XCTAssertEqual(
+            controller.newWorklanePlacementSubtitleForTesting,
+            "Add new worklanes after the current worklane."
+        )
 
         controller.apply(panes: AppConfig.Panes(
             showLabels: true,
@@ -379,6 +384,36 @@ final class PaneLayoutSettingsSectionViewControllerTests: AppKitTestCase {
         ))
 
         XCTAssertTrue(controller.smoothScrollingForTesting)
+    }
+
+    func test_new_worklane_placement_popup_reflects_applied_preferences() throws {
+        let controller = PaneLayoutSettingsSectionViewController(configStore: makeConfigStore())
+        controller.loadViewIfNeeded()
+
+        controller.apply(worklanes: AppConfig.Worklanes(newWorklanePlacement: .end))
+
+        XCTAssertEqual(controller.selectedNewWorklanePlacementForTesting, .end)
+        XCTAssertEqual(
+            controller.newWorklanePlacementSubtitleForTesting,
+            "Append new worklanes to the bottom of the list."
+        )
+    }
+
+    func test_new_worklane_placement_popup_persists_config_change() throws {
+        let store = makeConfigStore()
+        let controller = PaneLayoutSettingsSectionViewController(configStore: store)
+        controller.loadViewIfNeeded()
+
+        let popup = controller.newWorklanePlacementPopupForTesting
+        popup.selectItem(withTitle: "Top")
+        _ = popup.target?.perform(popup.action, with: popup)
+
+        XCTAssertEqual(store.current.worklanes.newWorklanePlacement, .top)
+        XCTAssertEqual(controller.selectedNewWorklanePlacementForTesting, .top)
+        XCTAssertEqual(
+            controller.newWorklanePlacementSubtitleForTesting,
+            "Add new worklanes to the top of the list."
+        )
     }
 
     func test_smooth_scrolling_toggle_persists_config_change() throws {

--- a/ZenttyLogicTests/PaneStripStoreTests.swift
+++ b/ZenttyLogicTests/PaneStripStoreTests.swift
@@ -629,6 +629,54 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertEqual(store.activeWorklaneID, WorklaneID("wl_new"))
     }
 
+    func test_create_worklane_inserts_at_top_when_preference_is_top() {
+        let nextIDs = TestIDSequence(["new", "pane"])
+        let store = WorklaneStore(
+            worklanes: [
+                makeSinglePaneWorklane(id: "A"),
+                makeSinglePaneWorklane(id: "B"),
+                makeSinglePaneWorklane(id: "C"),
+            ],
+            activeWorklaneID: WorklaneID("B"),
+            runtimeIdentity: WorklaneRuntimeIdentity { nextIDs.next() },
+            newWorklanePlacementProvider: { .top }
+        )
+
+        _ = store.createWorklane()
+
+        XCTAssertEqual(store.worklanes.map(\.id), [
+            WorklaneID("wl_new"),
+            WorklaneID("A"),
+            WorklaneID("B"),
+            WorklaneID("C"),
+        ])
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("wl_new"))
+    }
+
+    func test_create_worklane_inserts_at_end_when_preference_is_end() {
+        let nextIDs = TestIDSequence(["new", "pane"])
+        let store = WorklaneStore(
+            worklanes: [
+                makeSinglePaneWorklane(id: "A"),
+                makeSinglePaneWorklane(id: "B"),
+                makeSinglePaneWorklane(id: "C"),
+            ],
+            activeWorklaneID: WorklaneID("B"),
+            runtimeIdentity: WorklaneRuntimeIdentity { nextIDs.next() },
+            newWorklanePlacementProvider: { .end }
+        )
+
+        _ = store.createWorklane()
+
+        XCTAssertEqual(store.worklanes.map(\.id), [
+            WorklaneID("A"),
+            WorklaneID("B"),
+            WorklaneID("C"),
+            WorklaneID("wl_new"),
+        ])
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("wl_new"))
+    }
+
     func test_split_out_pane_to_new_window_extracts_pane_state_without_closing_source_worklane() throws {
         let sourceWindowID = WindowID("wd_source")
         let destinationWindowID = WindowID("wd_destination")
@@ -3576,6 +3624,107 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertEqual(movedColumn.panes.map(\.id), [PaneID("left")])
         XCTAssertEqual(movedColumn.width, layoutContext.singlePaneWidth, accuracy: 0.001)
         XCTAssertNotEqual(movedColumn.width, halfWidth, accuracy: 0.001)
+    }
+
+    func test_transferPaneToNewWorklane_uses_preferred_placement_when_no_explicit_index() {
+        let nextIDs = TestIDSequence(["new"])
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: WorklaneID("A"),
+                    title: "A",
+                    paneStripState: PaneStripState(
+                        panes: [
+                            PaneState(id: PaneID("A1"), title: "A1"),
+                            PaneState(id: PaneID("A2"), title: "A2"),
+                        ],
+                        focusedPaneID: PaneID("A1")
+                    )
+                ),
+                makeSinglePaneWorklane(id: "B"),
+                makeSinglePaneWorklane(id: "C"),
+            ],
+            activeWorklaneID: WorklaneID("A"),
+            runtimeIdentity: WorklaneRuntimeIdentity { nextIDs.next() },
+            newWorklanePlacementProvider: { .end }
+        )
+
+        store.transferPaneToNewWorklane(
+            paneID: PaneID("A1"),
+            singleColumnWidth: store.layoutContext.singlePaneWidth
+        )
+
+        XCTAssertEqual(store.worklanes.map(\.id), [
+            WorklaneID("A"),
+            WorklaneID("B"),
+            WorklaneID("C"),
+            WorklaneID("wl_new"),
+        ])
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("wl_new"))
+    }
+
+    func test_transferPaneToNewWorklane_explicit_index_overrides_preferred_placement() {
+        let nextIDs = TestIDSequence(["new"])
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: WorklaneID("A"),
+                    title: "A",
+                    paneStripState: PaneStripState(
+                        panes: [
+                            PaneState(id: PaneID("A1"), title: "A1"),
+                            PaneState(id: PaneID("A2"), title: "A2"),
+                        ],
+                        focusedPaneID: PaneID("A1")
+                    )
+                ),
+                makeSinglePaneWorklane(id: "B"),
+                makeSinglePaneWorklane(id: "C"),
+            ],
+            activeWorklaneID: WorklaneID("A"),
+            runtimeIdentity: WorklaneRuntimeIdentity { nextIDs.next() },
+            newWorklanePlacementProvider: { .end }
+        )
+
+        store.transferPaneToNewWorklane(
+            paneID: PaneID("A1"),
+            atIndex: 1,
+            singleColumnWidth: store.layoutContext.singlePaneWidth
+        )
+
+        XCTAssertEqual(store.worklanes.map(\.id), [
+            WorklaneID("A"),
+            WorklaneID("wl_new"),
+            WorklaneID("B"),
+            WorklaneID("C"),
+        ])
+    }
+
+    func test_duplicatePaneToNewWorklane_uses_preferred_placement_when_no_explicit_index() {
+        let nextIDs = TestIDSequence(["new"])
+        let store = WorklaneStore(
+            worklanes: [
+                makeSinglePaneWorklane(id: "A"),
+                makeSinglePaneWorklane(id: "B"),
+                makeSinglePaneWorklane(id: "C"),
+            ],
+            activeWorklaneID: WorklaneID("B"),
+            runtimeIdentity: WorklaneRuntimeIdentity { nextIDs.next() },
+            newWorklanePlacementProvider: { .top }
+        )
+
+        store.duplicatePaneToNewWorklane(
+            paneID: PaneID("pane-B"),
+            singleColumnWidth: store.layoutContext.singlePaneWidth
+        )
+
+        XCTAssertEqual(store.worklanes.map(\.id), [
+            WorklaneID("wl_new"),
+            WorklaneID("A"),
+            WorklaneID("B"),
+            WorklaneID("C"),
+        ])
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("wl_new"))
     }
 
     func test_transfer_last_pane_to_worklane_with_identical_pane_keeps_both_panes() throws {

--- a/ZenttyLogicTests/SettingsSidebarTests.swift
+++ b/ZenttyLogicTests/SettingsSidebarTests.swift
@@ -98,6 +98,17 @@ final class SettingsSidebarSearchFilterTests: AppKitTestCase {
             groups: SettingsSidebarLayout.groups
         )
         XCTAssertEqual(sections(menuBarRows), [.agents])
+
+        let worklaneRows = SettingsSidebarViewController.filterRows(
+            query: "worklane",
+            groups: SettingsSidebarLayout.groups
+        )
+        XCTAssertEqual(sections(worklaneRows), [.paneLayout])
+    }
+
+    func test_pane_layout_section_is_labeled_worklanes_and_panes() {
+        XCTAssertEqual(SettingsSection.paneLayout.title, "Worklanes & Panes")
+        XCTAssertEqual(SettingsSection.paneLayout.subtitle, "Worklane placement, labels, icons, opacity, and split behavior")
     }
 
     func test_filter_drops_group_headers_with_no_matches() {


### PR DESCRIPTION
## Summary
- Adds a global new worklane placement preference with `Top`, `After current`, and `End`.
- Persists the setting in `[worklanes] new_worklane_placement`, defaulting existing configs to `after_current`.
- Wires implicit new-worklane creation through the preference while preserving explicit drag/drop insertion indexes.
- Adds the setting to Worklanes & Panes preferences with regression coverage for config, behavior, and UI.

## Test Plan
- `TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test -scheme Zentty -destination 'platform=macOS' -only-testing:ZenttyLogicTests/AppConfigStoreTests/test_store_reads_worklane_placement_from_config_file -only-testing:ZenttyLogicTests/PaneStripStoreTests/test_create_worklane_inserts_at_top_when_preference_is_top -only-testing:ZenttyLogicTests/PaneLayoutSettingsSectionViewControllerTests/test_new_worklane_placement_popup_persists_config_change`
- `TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test -scheme Zentty -destination 'platform=macOS' -only-testing:ZenttyLogicTests/AppConfigStoreTests -only-testing:ZenttyLogicTests/PaneStripStoreTests -only-testing:ZenttyLogicTests/PaneLayoutSettingsSectionViewControllerTests -only-testing:ZenttyLogicTests/SettingsSidebarLayoutTests -only-testing:ZenttyLogicTests/SettingsSidebarSearchFilterTests`
- `ZENTTY_TEST_DISPLAY_PROVIDER=betterdisplay scripts/test-on-virtual-display -only-testing:ZenttyLogicTests`
