### PR TITLE
fix(agent): support modern Kimi Code CLI config and run environment

### DIFF
--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -595,31 +595,41 @@ enum AgentLaunchBootstrap {
             )
         }
 
-        let isModern = checkIsModernKimiCode(executablePath)
-        let (forwardedArguments, configSource) = parseKimiConfig(executablePath: executablePath, arguments: arguments, environment: environment)
+        let isModern = checkIsModernKimiCode(executablePath, environment: environment)
+        let (forwardedArguments, configSource) = parseKimiConfig(
+            isModern: isModern,
+            arguments: arguments,
+            environment: environment
+        )
         let overlayDirectoryURL = try prepareToolDirectory(
             tool: .kimi,
             target: target,
             runtimeDirectoryURL: runtimeDirectoryURL,
             fileManager: fileManager
         )
-        let overlayConfigURL = overlayDirectoryURL.appendingPathComponent("config.toml", isDirectory: false)
         let existingConfig = try kimiConfigContents(from: configSource, fileManager: fileManager)
         let mergedConfig = try KimiHooksInstaller.mergedConfigText(existingConfig: existingConfig, cliPath: cliPath)
-        try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
 
         if isModern {
+            let overlayHomeURL = try prepareKimiCodeOverlay(
+                sourceHomeURL: kimiCodeHomeURL(environment: environment),
+                overlayDirectoryURL: overlayDirectoryURL,
+                mergedConfig: mergedConfig,
+                fileManager: fileManager
+            )
             return AgentLaunchPlan(
                 executablePath: executablePath,
                 arguments: forwardedArguments,
                 setEnvironment: [
                     "ZENTTY_AGENT_TOOL": "kimi",
-                    "KIMI_CODE_HOME": overlayDirectoryURL.path
+                    "KIMI_CODE_HOME": overlayHomeURL.path
                 ],
                 unsetEnvironment: [],
                 preLaunchActions: []
             )
         } else {
+            let overlayConfigURL = overlayDirectoryURL.appendingPathComponent("config.toml", isDirectory: false)
+            try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
             return AgentLaunchPlan(
                 executablePath: executablePath,
                 arguments: ["--config-file", overlayConfigURL.path] + forwardedArguments,
@@ -1022,6 +1032,50 @@ enum AgentLaunchBootstrap {
         }
 
         return overlayHomeURL.path
+    }
+
+    private static func prepareKimiCodeOverlay(
+        sourceHomeURL: URL,
+        overlayDirectoryURL: URL,
+        mergedConfig: String,
+        fileManager: FileManager
+    ) throws -> URL {
+        let overlayHomeURL = overlayDirectoryURL.appendingPathComponent("home", isDirectory: true)
+        try fileManager.createDirectory(at: overlayHomeURL, withIntermediateDirectories: true)
+        try symlinkDirectoryContentsSkipping(
+            from: sourceHomeURL,
+            to: overlayHomeURL,
+            skippingNames: ["config.toml"],
+            fileManager: fileManager
+        )
+
+        let overlayConfigURL = overlayHomeURL.appendingPathComponent("config.toml", isDirectory: false)
+        try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
+        let migrationSkipURL = overlayHomeURL.appendingPathComponent(".skip-migration-from-kimi-cli", isDirectory: false)
+        let migrationSkipPath = migrationSkipURL.path
+        let migrationSkipExists = fileManager.fileExists(atPath: migrationSkipPath)
+            || (try? fileManager.destinationOfSymbolicLink(atPath: migrationSkipPath)) != nil
+        if !migrationSkipExists {
+            try "".write(to: migrationSkipURL, atomically: true, encoding: .utf8)
+        }
+        return overlayHomeURL
+    }
+
+    private static func kimiCodeHomeURL(environment: [String: String]) -> URL {
+        if let kimiCodeHome = environment["KIMI_CODE_HOME"]?.nilIfBlank {
+            return URL(fileURLWithPath: kimiCodeHome, isDirectory: true)
+        }
+        let home = environment["HOME"]?.nilIfBlank ?? NSHomeDirectory()
+        return URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".kimi-code", isDirectory: true)
+    }
+
+    private static func legacyKimiConfigURL(environment: [String: String]) -> URL {
+        if let kimiShareDirectory = environment["KIMI_SHARE_DIR"]?.nilIfBlank {
+            return URL(fileURLWithPath: kimiShareDirectory, isDirectory: true)
+                .appendingPathComponent("config.toml", isDirectory: false)
+        }
+        return KimiHooksInstaller.defaultUserConfigURL(home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory())
     }
 
     private static func prepareGeminiOverlay(
@@ -1439,53 +1493,26 @@ enum AgentLaunchBootstrap {
         return false
     }
 
-    private static var isModernKimiCache = [String: Bool]()
-    private static let kimiLock = NSLock()
+    private static func checkIsModernKimiCode(_ executablePath: String, environment: [String: String]) -> Bool {
+        KimiVariantProbe.probeVariant(executablePath: executablePath, environment: environment) == .modern
+    }
 
-    private static func checkIsModernKimiCode(_ executablePath: String) -> Bool {
-        kimiLock.lock()
-        defer { kimiLock.unlock() }
-
-        if let cached = isModernKimiCache[executablePath] {
-            return cached
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = ["--help"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                let isModern = !output.contains("--config-file")
-                isModernKimiCache[executablePath] = isModern
-                return isModern
-            }
-        } catch {}
-
-        isModernKimiCache[executablePath] = false
-        return false
+    static func isModernKimiHelpOutput(_ helpText: String) -> Bool {
+        KimiVariantProbe.isModernHelpOutput(helpText)
     }
 
     private static func parseKimiConfig(
-        executablePath: String,
+        isModern: Bool,
         arguments: [String],
         environment: [String: String]
     ) -> (forwardedArguments: [String], source: KimiConfigSource) {
         var forwarded = [String]()
         var iterator = arguments.makeIterator()
         
-        let defaultConfigURL = checkIsModernKimiCode(executablePath)
-            ? KimiHooksInstaller.modernUserConfigURL(home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory())
-            : KimiHooksInstaller.defaultUserConfigURL(home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory())
-            
+        let defaultConfigURL = isModern
+            ? kimiCodeHomeURL(environment: environment).appendingPathComponent("config.toml", isDirectory: false)
+            : legacyKimiConfigURL(environment: environment)
+
         var source: KimiConfigSource = .defaultFile(defaultConfigURL)
 
         while let argument = iterator.next() {

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -595,7 +595,8 @@ enum AgentLaunchBootstrap {
             )
         }
 
-        let (forwardedArguments, configSource) = parseKimiConfig(arguments: arguments, environment: environment)
+        let isModern = checkIsModernKimiCode(executablePath)
+        let (forwardedArguments, configSource) = parseKimiConfig(executablePath: executablePath, arguments: arguments, environment: environment)
         let overlayDirectoryURL = try prepareToolDirectory(
             tool: .kimi,
             target: target,
@@ -607,15 +608,28 @@ enum AgentLaunchBootstrap {
         let mergedConfig = try KimiHooksInstaller.mergedConfigText(existingConfig: existingConfig, cliPath: cliPath)
         try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
 
-        return AgentLaunchPlan(
-            executablePath: executablePath,
-            arguments: ["--config-file", overlayConfigURL.path] + forwardedArguments,
-            setEnvironment: [
-                "ZENTTY_AGENT_TOOL": "kimi",
-            ],
-            unsetEnvironment: [],
-            preLaunchActions: []
-        )
+        if isModern {
+            return AgentLaunchPlan(
+                executablePath: executablePath,
+                arguments: forwardedArguments,
+                setEnvironment: [
+                    "ZENTTY_AGENT_TOOL": "kimi",
+                    "KIMI_CODE_HOME": overlayDirectoryURL.path
+                ],
+                unsetEnvironment: [],
+                preLaunchActions: []
+            )
+        } else {
+            return AgentLaunchPlan(
+                executablePath: executablePath,
+                arguments: ["--config-file", overlayConfigURL.path] + forwardedArguments,
+                setEnvironment: [
+                    "ZENTTY_AGENT_TOOL": "kimi",
+                ],
+                unsetEnvironment: [],
+                preLaunchActions: []
+            )
+        }
     }
 
     private static func claudePlan(
@@ -1425,15 +1439,54 @@ enum AgentLaunchBootstrap {
         return false
     }
 
+    private static var isModernKimiCache = [String: Bool]()
+    private static let kimiLock = NSLock()
+
+    private static func checkIsModernKimiCode(_ executablePath: String) -> Bool {
+        kimiLock.lock()
+        defer { kimiLock.unlock() }
+
+        if let cached = isModernKimiCache[executablePath] {
+            return cached
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = ["--help"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                let isModern = !output.contains("--config-file")
+                isModernKimiCache[executablePath] = isModern
+                return isModern
+            }
+        } catch {}
+
+        isModernKimiCache[executablePath] = false
+        return false
+    }
+
     private static func parseKimiConfig(
+        executablePath: String,
         arguments: [String],
         environment: [String: String]
     ) -> (forwardedArguments: [String], source: KimiConfigSource) {
         var forwarded = [String]()
         var iterator = arguments.makeIterator()
-        var source: KimiConfigSource = .defaultFile(KimiHooksInstaller.defaultUserConfigURL(
-            home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory()
-        ))
+        
+        let defaultConfigURL = checkIsModernKimiCode(executablePath)
+            ? KimiHooksInstaller.modernUserConfigURL(home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory())
+            : KimiHooksInstaller.defaultUserConfigURL(home: environment["HOME"]?.nilIfBlank ?? NSHomeDirectory())
+            
+        var source: KimiConfigSource = .defaultFile(defaultConfigURL)
 
         while let argument = iterator.next() {
             switch argument {

--- a/Zentty/AppState/Agent/KimiHooksInstaller.swift
+++ b/Zentty/AppState/Agent/KimiHooksInstaller.swift
@@ -17,6 +17,14 @@ enum KimiHooksInstaller {
             .appendingPathComponent("config.toml", isDirectory: false)
     }
 
+    static func modernUserConfigURL(
+        home: String = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+    ) -> URL {
+        URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".kimi-code", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+    }
+
     static func install(
         at configURL: URL,
         cliPath: String,
@@ -76,14 +84,20 @@ enum KimiHooksInstaller {
             return
         }
 
-        let configURL = defaultUserConfigURL(home: home)
-        do {
-            try install(at: configURL, cliPath: cliPath, fileManager: fileManager)
-            kimiInstallerLogger.info("Installed Zentty Kimi hooks in \(configURL.path, privacy: .public)")
-        } catch {
-            kimiInstallerLogger.error(
-                "Failed to install Kimi hooks at \(configURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
-            )
+        let configURLs = [
+            defaultUserConfigURL(home: home),
+            modernUserConfigURL(home: home)
+        ]
+
+        for configURL in configURLs {
+            do {
+                try install(at: configURL, cliPath: cliPath, fileManager: fileManager)
+                kimiInstallerLogger.info("Installed Zentty Kimi hooks in \(configURL.path, privacy: .public)")
+            } catch {
+                kimiInstallerLogger.error(
+                    "Failed to install Kimi hooks at \(configURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 

--- a/Zentty/AppState/Agent/KimiHooksInstaller.swift
+++ b/Zentty/AppState/Agent/KimiHooksInstaller.swift
@@ -3,6 +3,193 @@ import os
 
 private let kimiInstallerLogger = Logger(subsystem: "be.zenjoy.zentty", category: "KimiHookInstall")
 
+enum KimiVariant: String {
+    case modern
+    case legacy
+
+    init?(rawPin: String?) {
+        guard let rawPin else {
+            return nil
+        }
+        self.init(rawValue: rawPin)
+    }
+}
+
+enum KimiVariantProbe {
+    private static let cache = KimiVariantProbeCache()
+
+    static func strippingANSISequences(from text: String) -> String {
+        var output = String()
+        var index = text.startIndex
+
+        while index < text.endIndex {
+            let scalar = text[index].unicodeScalars.first
+            guard scalar?.value == 0x1B else {
+                output.append(text[index])
+                index = text.index(after: index)
+                continue
+            }
+
+            index = text.index(after: index)
+            guard index < text.endIndex else {
+                break
+            }
+
+            if text[index] == "[" {
+                index = text.index(after: index)
+                while index < text.endIndex {
+                    let value = text[index].unicodeScalars.first?.value ?? 0
+                    index = text.index(after: index)
+                    if value >= 0x40 && value <= 0x7E {
+                        break
+                    }
+                }
+            } else {
+                let value = text[index].unicodeScalars.first?.value ?? 0
+                if value >= 0x20 && value <= 0x2F {
+                    index = text.index(after: index)
+                    if index < text.endIndex {
+                        index = text.index(after: index)
+                    }
+                } else {
+                    index = text.index(after: index)
+                }
+            }
+        }
+
+        return output
+    }
+
+    static func isModernHelpOutput(_ helpText: String) -> Bool {
+        !strippingANSISequences(from: helpText).contains("--config-file")
+    }
+
+    static func probeVariant(executablePath: String, environment: [String: String]) -> KimiVariant? {
+        if let cached = cache.value(for: executablePath) {
+            return cached
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = ["--help"]
+        var probeEnvironment = environment
+        probeEnvironment["NO_COLOR"] = "1"
+        probeEnvironment["TERM"] = "dumb"
+        process.environment = probeEnvironment
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        let outputBuffer = KimiProbeOutputBuffer()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            outputBuffer.append(handle.availableData)
+        }
+        defer {
+            pipe.fileHandleForReading.readabilityHandler = nil
+        }
+
+        do {
+            let semaphore = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in
+                semaphore.signal()
+            }
+            try process.run()
+            let timedOut = semaphore.wait(timeout: .now() + .seconds(10)) == .timedOut
+            if timedOut {
+                process.terminate()
+                process.waitUntilExit()
+                kimiInstallerLogger.warning("Kimi variant probe timed out for \(executablePath, privacy: .public)")
+                return nil
+            }
+
+            guard process.terminationStatus == 0 else {
+                kimiInstallerLogger.warning(
+                    "Kimi variant probe exited with status \(process.terminationStatus, privacy: .public) for \(executablePath, privacy: .public)"
+                )
+                return nil
+            }
+
+            pipe.fileHandleForReading.readabilityHandler = nil
+            outputBuffer.append(pipe.fileHandleForReading.readDataToEndOfFile())
+            let data = outputBuffer.contents()
+
+            guard let output = String(data: data, encoding: .utf8) else {
+                kimiInstallerLogger.warning("Kimi variant probe returned undecodable output for \(executablePath, privacy: .public)")
+                return nil
+            }
+
+            let variant: KimiVariant = isModernHelpOutput(output) ? .modern : .legacy
+            cache.store(variant, for: executablePath)
+            return variant
+        } catch {
+            kimiInstallerLogger.warning(
+                "Kimi variant probe failed for \(executablePath, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+
+    static func selectBinary(
+        pinned: KimiVariant,
+        candidates: [String],
+        probe: (String) -> KimiVariant?
+    ) -> String? {
+        candidates.first { probe($0) == pinned }
+    }
+
+    static func resolvePreferred(
+        pin: KimiVariant?,
+        candidates: [String],
+        probe: (String) -> KimiVariant?
+    ) -> String? {
+        guard !candidates.isEmpty else {
+            return nil
+        }
+        if let pin {
+            return selectBinary(pinned: pin, candidates: candidates, probe: probe)
+        }
+        guard candidates.count >= 2 else {
+            return nil
+        }
+        return selectBinary(pinned: .modern, candidates: candidates, probe: probe)
+    }
+
+    private final class KimiVariantProbeCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values = [String: KimiVariant]()
+
+        func value(for key: String) -> KimiVariant? {
+            lock.lock()
+            defer { lock.unlock() }
+            return values[key]
+        }
+
+        func store(_ value: KimiVariant, for key: String) {
+            lock.lock()
+            values[key] = value
+            lock.unlock()
+        }
+    }
+
+    private final class KimiProbeOutputBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func append(_ chunk: Data) {
+            guard !chunk.isEmpty else { return }
+            lock.lock()
+            data.append(chunk)
+            lock.unlock()
+        }
+
+        func contents() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return data
+        }
+    }
+}
+
 enum KimiHooksInstaller {
     static let beginMarker = "### BEGIN ZENTTY KIMI HOOKS"
     static let endMarker = "### END ZENTTY KIMI HOOKS"

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -311,6 +311,16 @@ struct AgentToolLauncher {
 
     private func findRealBinary() throws -> String {
         let wrappedToolNames = tool.realBinaryNames
+        if let realBinaryPath = environment["ZENTTY_REAL_BINARY"]?.nonEmpty {
+            let realBinaryName = URL(fileURLWithPath: realBinaryPath).lastPathComponent
+            var isDirectory: ObjCBool = false
+            if wrappedToolNames.contains(realBinaryName),
+               FileManager.default.fileExists(atPath: realBinaryPath, isDirectory: &isDirectory),
+               !isDirectory.boolValue,
+               FileManager.default.isExecutableFile(atPath: realBinaryPath) {
+                return realBinaryPath
+            }
+        }
         let wrapperDirectories = environmentPathEntries(forKeys: [
             "ZENTTY_ALL_WRAPPER_BIN_DIRS",
             "ZENTTY_WRAPPER_BIN_DIRS",
@@ -321,6 +331,54 @@ struct AgentToolLauncher {
             .map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
         let excludedDirectories = Set(wrapperDirectories + [cliDirectory].compactMap { $0 })
 
+        if tool == .kimi {
+            let pin = KimiVariant(rawPin: environment["ZENTTY_KIMI_VARIANT"])
+            var candidates = [String]()
+            visitRealBinaryCandidates(
+                wrappedToolNames: wrappedToolNames,
+                excludedDirectories: excludedDirectories,
+                deduplicate: true
+            ) { candidate in
+                candidates.append(candidate)
+                return true
+            }
+
+            if let selected = KimiVariantProbe.resolvePreferred(
+                pin: pin,
+                candidates: candidates,
+                probe: { candidate in
+                    KimiVariantProbe.probeVariant(executablePath: candidate, environment: environment)
+                }
+            ) {
+                trace("findRealBinary kimi-resolved (pin=\(pin?.rawValue ?? "none")) -> \(selected)")
+                return selected
+            }
+        }
+
+        var firstCandidate: String?
+        visitRealBinaryCandidates(
+            wrappedToolNames: wrappedToolNames,
+            excludedDirectories: excludedDirectories,
+            deduplicate: false
+        ) { candidate in
+            firstCandidate = candidate
+            return false
+        }
+        if let firstCandidate {
+            return firstCandidate
+        }
+
+        throw POSIXError(.ENOENT)
+    }
+
+    private func visitRealBinaryCandidates(
+        wrappedToolNames: [String],
+        excludedDirectories: Set<String>,
+        deduplicate: Bool,
+        _ visit: (String) -> Bool
+    ) {
+        var seen = Set<String>()
+
         for entry in environmentPathEntries(forKeys: ["PATH"]) {
             guard !excludedDirectories.contains(entry) else {
                 continue
@@ -329,13 +387,17 @@ struct AgentToolLauncher {
                 let candidate = URL(fileURLWithPath: entry, isDirectory: true)
                     .appendingPathComponent(wrappedToolName, isDirectory: false)
                     .path
-                if FileManager.default.isExecutableFile(atPath: candidate) {
-                    return candidate
+                guard FileManager.default.isExecutableFile(atPath: candidate) else {
+                    continue
+                }
+                if deduplicate, !seen.insert(candidate).inserted {
+                    continue
+                }
+                guard visit(candidate) else {
+                    return
                 }
             }
         }
-
-        throw POSIXError(.ENOENT)
     }
 
     private func resolveMiseShimIfNeeded(_ executablePath: String) -> Result<String, LaunchFailureDiagnostic>? {
@@ -488,6 +550,7 @@ struct AgentToolLauncher {
             "ZENTTY_CURSOR_VERBOSE_HOOKS",
             "ZENTTY_DROID_HOOKS_DISABLED",
             "ZENTTY_KIMI_HOOKS_DISABLED",
+            "ZENTTY_KIMI_VARIANT",
             "ZENTTY_GROK_HOOKS_DISABLED",
             "ZENTTY_AGY_HOOKS_DISABLED",
             "ZENTTY_HERMES_HOOKS_DISABLED",
@@ -498,6 +561,8 @@ struct AgentToolLauncher {
             "CODEX_HOME",
             "COPILOT_HOME",
             "HERMES_HOME",
+            "KIMI_CODE_HOME",
+            "KIMI_SHARE_DIR",
             "XDG_CONFIG_HOME",
             "XDG_STATE_HOME",
             "OPENCODE_CONFIG",

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -120,12 +120,12 @@ struct InstallCommand: ParsableCommand {
             try DroidHooksInstaller.suppressHookOutput(at: hooksConfigURL)
             print("Installed Zentty Droid hooks at \(settingsURL.path).")
         case .kimiHooks:
-            let configURL = KimiHooksInstaller.defaultUserConfigURL()
-            try KimiHooksInstaller.install(
-                at: configURL,
-                cliPath: resolveInvokingCLIPath()
-            )
-            print("Installed Zentty Kimi hooks at \(configURL.path).")
+            let cliPath = resolveInvokingCLIPath()
+            let legacyURL = KimiHooksInstaller.defaultUserConfigURL()
+            let modernURL = KimiHooksInstaller.modernUserConfigURL()
+            try KimiHooksInstaller.install(at: legacyURL, cliPath: cliPath)
+            try KimiHooksInstaller.install(at: modernURL, cliPath: cliPath)
+            print("Installed Zentty Kimi hooks at \(legacyURL.path) and \(modernURL.path).")
         case .grokHooks:
             try GrokHooksInstaller.install(cliPath: resolveInvokingCLIPath())
             print("Installed Zentty Grok hooks (JSON + ~/.grok/hooks/) under \(GrokHooksInstaller.defaultUserHooksURL().path).")
@@ -178,9 +178,11 @@ struct UninstallCommand: ParsableCommand {
             try DroidHooksInstaller.uninstall(at: settingsURL)
             print("Removed Zentty Droid hook entries from \(settingsURL.path).")
         case .kimiHooks:
-            let configURL = KimiHooksInstaller.defaultUserConfigURL()
-            try KimiHooksInstaller.uninstall(at: configURL)
-            print("Removed Zentty Kimi hook entries from \(configURL.path).")
+            let legacyURL = KimiHooksInstaller.defaultUserConfigURL()
+            let modernURL = KimiHooksInstaller.modernUserConfigURL()
+            try KimiHooksInstaller.uninstall(at: legacyURL)
+            try KimiHooksInstaller.uninstall(at: modernURL)
+            print("Removed Zentty Kimi hook entries from \(legacyURL.path) and \(modernURL.path).")
         case .grokHooks:
             try GrokHooksInstaller.uninstall()
             print("Removed Zentty Grok hook entries (JSON + directory) from \(GrokHooksInstaller.defaultUserHooksURL().path).")

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -123,9 +123,20 @@ struct InstallCommand: ParsableCommand {
             let cliPath = resolveInvokingCLIPath()
             let legacyURL = KimiHooksInstaller.defaultUserConfigURL()
             let modernURL = KimiHooksInstaller.modernUserConfigURL()
-            try KimiHooksInstaller.install(at: legacyURL, cliPath: cliPath)
-            try KimiHooksInstaller.install(at: modernURL, cliPath: cliPath)
-            print("Installed Zentty Kimi hooks at \(legacyURL.path) and \(modernURL.path).")
+            var firstError: Error?
+            for configURL in [legacyURL, modernURL] {
+                do {
+                    try KimiHooksInstaller.install(at: configURL, cliPath: cliPath)
+                    print("Installed Zentty Kimi hooks at \(configURL.path).")
+                } catch {
+                    if firstError == nil {
+                        firstError = error
+                    }
+                }
+            }
+            if let firstError {
+                throw firstError
+            }
         case .grokHooks:
             try GrokHooksInstaller.install(cliPath: resolveInvokingCLIPath())
             print("Installed Zentty Grok hooks (JSON + ~/.grok/hooks/) under \(GrokHooksInstaller.defaultUserHooksURL().path).")
@@ -180,9 +191,20 @@ struct UninstallCommand: ParsableCommand {
         case .kimiHooks:
             let legacyURL = KimiHooksInstaller.defaultUserConfigURL()
             let modernURL = KimiHooksInstaller.modernUserConfigURL()
-            try KimiHooksInstaller.uninstall(at: legacyURL)
-            try KimiHooksInstaller.uninstall(at: modernURL)
-            print("Removed Zentty Kimi hook entries from \(legacyURL.path) and \(modernURL.path).")
+            var firstError: Error?
+            for configURL in [legacyURL, modernURL] {
+                do {
+                    try KimiHooksInstaller.uninstall(at: configURL)
+                    print("Removed Zentty Kimi hook entries from \(configURL.path).")
+                } catch {
+                    if firstError == nil {
+                        firstError = error
+                    }
+                }
+            }
+            if let firstError {
+                throw firstError
+            }
         case .grokHooks:
             try GrokHooksInstaller.uninstall()
             print("Removed Zentty Grok hook entries (JSON + directory) from \(GrokHooksInstaller.defaultUserHooksURL().path).")

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -3268,6 +3268,12 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: configURL.path))
     }
 
+    func test_kimi_hooks_installer_modern_user_config_url() throws {
+        let home = "/Users/test"
+        let url = KimiHooksInstaller.modernUserConfigURL(home: home)
+        XCTAssertEqual(url.path, "/Users/test/.kimi-code/config.toml")
+    }
+
     func test_kimi_hooks_installer_install_if_possible_treats_whitespace_env_as_blank() throws {
         let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-blank-env")
         let configURL = directory

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -337,6 +337,37 @@ final class AgentStatusSupportTests: XCTestCase {
         }
     }
 
+    func test_agent_tool_launcher_forwards_kimi_home_and_variant_environment() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let launcherPath = repoRoot
+            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
+            .path
+        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
+
+        for key in ["KIMI_CODE_HOME", "KIMI_SHARE_DIR", "ZENTTY_KIMI_VARIANT"] {
+            XCTAssertTrue(
+                source.contains("\"\(key)\""),
+                "AgentToolLauncher should forward \(key) for Kimi bootstrap requests"
+            )
+        }
+    }
+
+    func test_agent_tool_launcher_uses_guarded_real_binary_override() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let launcherPath = repoRoot
+            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
+            .path
+        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("let realBinaryPath = environment[\"ZENTTY_REAL_BINARY\"]"))
+        XCTAssertTrue(source.contains("wrappedToolNames.contains(realBinaryName)"))
+        XCTAssertTrue(source.contains("FileManager.default.isExecutableFile(atPath: realBinaryPath)"))
+    }
+
     func test_agent_status_helper_returns_nil_when_resource_directories_are_missing() throws {
         let bundle = try makeTemporaryBundle(named: "MissingResources")
 
@@ -3274,6 +3305,158 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(url.path, "/Users/test/.kimi-code/config.toml")
     }
 
+    func test_agent_launch_bootstrap_detects_legacy_kimi_help_output_with_plain_config_file_flag() {
+        let help = "Usage: kimi [OPTIONS]\n  --config-file PATH"
+
+        XCTAssertFalse(AgentLaunchBootstrap.isModernKimiHelpOutput(help))
+    }
+
+    func test_agent_launch_bootstrap_detects_legacy_kimi_help_output_with_ansi_split_config_file_flag() {
+        let help = "\u{1B}[1;36m-\u{1B}[0m\u{1B}[1;36m-config\u{1B}[0m\u{1B}[1;36m-file\u{1B}[0m"
+
+        XCTAssertFalse(AgentLaunchBootstrap.isModernKimiHelpOutput(help))
+    }
+
+    func test_agent_launch_bootstrap_detects_modern_kimi_help_output_without_config_file_flag() {
+        let help = "Usage: kimi-code [OPTIONS]\n  --model TEXT"
+
+        XCTAssertTrue(AgentLaunchBootstrap.isModernKimiHelpOutput(help))
+    }
+
+    func test_kimi_variant_probe_detects_legacy_help_output_with_plain_config_file_flag() {
+        let help = "Usage: kimi [OPTIONS]\n  --config-file PATH"
+
+        XCTAssertFalse(KimiVariantProbe.isModernHelpOutput(help))
+    }
+
+    func test_kimi_variant_probe_detects_legacy_help_output_with_ansi_split_config_file_flag() {
+        let help = "\u{1B}[1;36m-\u{1B}[0m\u{1B}[1;36m-config\u{1B}[0m\u{1B}[1;36m-file\u{1B}[0m"
+
+        XCTAssertFalse(KimiVariantProbe.isModernHelpOutput(help))
+    }
+
+    func test_kimi_variant_probe_detects_modern_help_output_without_config_file_flag() {
+        let help = "Usage: kimi-code [OPTIONS]\n  --model TEXT"
+
+        XCTAssertTrue(KimiVariantProbe.isModernHelpOutput(help))
+    }
+
+    func test_kimi_variant_probe_selects_first_candidate_matching_pinned_variant() {
+        let candidates = ["/legacy/kimi", "/modern/kimi"]
+        let probe: (String) -> KimiVariant? = { path in
+            switch path {
+            case "/legacy/kimi":
+                return .legacy
+            case "/modern/kimi":
+                return .modern
+            default:
+                return nil
+            }
+        }
+
+        XCTAssertEqual(
+            KimiVariantProbe.selectBinary(pinned: .modern, candidates: candidates, probe: probe),
+            "/modern/kimi"
+        )
+        XCTAssertEqual(
+            KimiVariantProbe.selectBinary(pinned: .legacy, candidates: candidates, probe: probe),
+            "/legacy/kimi"
+        )
+        XCTAssertNil(
+            KimiVariantProbe.selectBinary(pinned: .modern, candidates: ["/legacy/kimi"], probe: probe)
+        )
+    }
+
+    func test_kimi_variant_probe_resolve_preferred_defaults_to_modern_when_unpinned_with_multiple_candidates() {
+        let probe: (String) -> KimiVariant? = { path in
+            path.contains("modern") ? .modern : .legacy
+        }
+
+        XCTAssertEqual(
+            KimiVariantProbe.resolvePreferred(
+                pin: nil,
+                candidates: ["/legacy/kimi", "/modern/kimi"],
+                probe: probe
+            ),
+            "/modern/kimi"
+        )
+        XCTAssertEqual(
+            KimiVariantProbe.resolvePreferred(
+                pin: nil,
+                candidates: ["/modern/kimi", "/legacy/kimi"],
+                probe: probe
+            ),
+            "/modern/kimi"
+        )
+    }
+
+    func test_kimi_variant_probe_resolve_preferred_returns_nil_when_unpinned_with_no_modern_candidate() {
+        let probe: (String) -> KimiVariant? = { _ in .legacy }
+
+        XCTAssertNil(
+            KimiVariantProbe.resolvePreferred(
+                pin: nil,
+                candidates: ["/first/kimi", "/second/kimi"],
+                probe: probe
+            )
+        )
+    }
+
+    func test_kimi_variant_probe_resolve_preferred_skips_probe_for_unpinned_single_candidate() {
+        var probeCallCount = 0
+        let probe: (String) -> KimiVariant? = { _ in
+            probeCallCount += 1
+            return .modern
+        }
+
+        XCTAssertNil(
+            KimiVariantProbe.resolvePreferred(
+                pin: nil,
+                candidates: ["/only/kimi"],
+                probe: probe
+            )
+        )
+        XCTAssertEqual(probeCallCount, 0)
+    }
+
+    func test_kimi_variant_probe_resolve_preferred_honors_pinned_variant() {
+        let candidates = ["/legacy/kimi", "/modern/kimi"]
+        let probe: (String) -> KimiVariant? = { path in
+            path.contains("modern") ? .modern : .legacy
+        }
+
+        XCTAssertEqual(
+            KimiVariantProbe.resolvePreferred(pin: .modern, candidates: candidates, probe: probe),
+            "/modern/kimi"
+        )
+        XCTAssertEqual(
+            KimiVariantProbe.resolvePreferred(pin: .legacy, candidates: candidates, probe: probe),
+            "/legacy/kimi"
+        )
+        XCTAssertNil(
+            KimiVariantProbe.resolvePreferred(pin: .modern, candidates: ["/legacy/kimi"], probe: probe)
+        )
+    }
+
+    func test_kimi_variant_probe_resolve_preferred_returns_nil_for_empty_candidates() {
+        var probeCallCount = 0
+        let probe: (String) -> KimiVariant? = { _ in
+            probeCallCount += 1
+            return .modern
+        }
+
+        XCTAssertNil(KimiVariantProbe.resolvePreferred(pin: nil, candidates: [], probe: probe))
+        XCTAssertEqual(probeCallCount, 0)
+    }
+
+    func test_kimi_variant_raw_pin_mapping() {
+        XCTAssertEqual(KimiVariant(rawPin: "modern"), .modern)
+        XCTAssertEqual(KimiVariant(rawPin: "legacy"), .legacy)
+        XCTAssertNil(KimiVariant(rawPin: nil))
+        XCTAssertNil(KimiVariant(rawPin: ""))
+        XCTAssertNil(KimiVariant(rawPin: "garbage"))
+    }
+
     func test_kimi_hooks_installer_install_if_possible_treats_whitespace_env_as_blank() throws {
         let directory = try makeTemporaryDirectory(named: "kimi-hooks-installer-blank-env")
         let configURL = directory
@@ -4212,6 +4395,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 "HOME": homeDirectory.path,
                 "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
                 "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
             ],
             expectsResponse: true,
             tool: .kimi
@@ -4270,6 +4454,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 "HOME": NSHomeDirectory(),
                 "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
                 "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
             ],
             expectsResponse: true,
             tool: .kimi
@@ -4316,6 +4501,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 "HOME": NSHomeDirectory(),
                 "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
                 "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
             ],
             expectsResponse: true,
             tool: .kimi
@@ -4359,6 +4545,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 "HOME": NSHomeDirectory(),
                 "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
                 "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
             ],
             expectsResponse: true,
             tool: .kimi
@@ -4395,6 +4582,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 "HOME": NSHomeDirectory(),
                 "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
                 "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
             ],
             expectsResponse: true,
             tool: .kimi
@@ -4415,6 +4603,188 @@ final class AgentStatusSupportTests: XCTestCase {
             XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
             XCTAssertEqual(nsError.code, CocoaError.fileNoSuchFile.rawValue)
         }
+    }
+
+    func test_agent_launch_bootstrap_builds_modern_kimi_overlay_preserving_source_home_state() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-runtime")
+        let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-home")
+        let kimiCodeHome = homeDirectory.appendingPathComponent(".kimi-code", isDirectory: true)
+        let userConfigURL = kimiCodeHome.appendingPathComponent("config.toml", isDirectory: false)
+        let credentialsURL = kimiCodeHome.appendingPathComponent("credentials", isDirectory: true)
+        let sessionsURL = kimiCodeHome.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: credentialsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sessionsURL, withIntermediateDirectories: true)
+        try "token".write(
+            to: credentialsURL.appendingPathComponent("auth.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "session".write(
+            to: sessionsURL.appendingPathComponent("latest.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        let original = """
+        default_model = "kimi-code/kimi-for-coding"
+        hooks = []
+        """
+        try original.write(to: userConfigURL, atomically: true, encoding: .utf8)
+        let fakeKimiURL = try makeFakeKimiBinary(modern: true)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["chat", "hello"],
+            standardInput: nil,
+            environment: [
+                "HOME": homeDirectory.path,
+                "KIMI_CODE_HOME": kimiCodeHome.path,
+                "ZENTTY_REAL_BINARY": fakeKimiURL.path,
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "modern",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.arguments, ["chat", "hello"])
+        XCTAssertFalse(plan.arguments.contains("--config-file"))
+        let overlayHomePath = try XCTUnwrap(plan.setEnvironment["KIMI_CODE_HOME"])
+        XCTAssertTrue(overlayHomePath.hasPrefix(runtimeDirectory.path))
+
+        let overlayHomeURL = URL(fileURLWithPath: overlayHomePath, isDirectory: true)
+        let overlayConfig = try String(
+            contentsOf: overlayHomeURL.appendingPathComponent("config.toml", isDirectory: false),
+            encoding: .utf8
+        )
+        XCTAssertTrue(overlayConfig.contains(#"default_model = "kimi-code/kimi-for-coding""#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: overlayHomeURL
+                    .appendingPathComponent(".skip-migration-from-kimi-cli", isDirectory: false)
+                    .path
+            )
+        )
+
+        let overlayCredentialsURL = overlayHomeURL.appendingPathComponent("credentials", isDirectory: true)
+        let overlaySessionsURL = overlayHomeURL.appendingPathComponent("sessions", isDirectory: true)
+        XCTAssertEqual(
+            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: overlayCredentialsURL.path))
+                .resolvingSymlinksInPath()
+                .path,
+            credentialsURL.resolvingSymlinksInPath().path
+        )
+        XCTAssertEqual(
+            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: overlaySessionsURL.path))
+                .resolvingSymlinksInPath()
+                .path,
+            sessionsURL.resolvingSymlinksInPath().path
+        )
+
+        let sourceConfig = try String(contentsOf: userConfigURL, encoding: .utf8)
+        XCTAssertEqual(sourceConfig, original)
+    }
+
+    func test_agent_launch_bootstrap_builds_modern_kimi_overlay_from_default_home_config() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-default-runtime")
+        let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-default-home")
+        let userConfigURL = homeDirectory
+            .appendingPathComponent(".kimi-code", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: userConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"default_model = "kimi-code/kimi-for-coding""#.write(
+            to: userConfigURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let fakeKimiURL = try makeFakeKimiBinary(modern: true)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["chat"],
+            standardInput: nil,
+            environment: [
+                "HOME": homeDirectory.path,
+                "ZENTTY_REAL_BINARY": fakeKimiURL.path,
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "modern",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        let overlayHomePath = try XCTUnwrap(plan.setEnvironment["KIMI_CODE_HOME"])
+        let overlayConfigURL = URL(fileURLWithPath: overlayHomePath, isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        let overlayConfig = try String(contentsOf: overlayConfigURL, encoding: .utf8)
+        XCTAssertTrue(overlayConfig.contains(#"default_model = "kimi-code/kimi-for-coding""#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
+    }
+
+    func test_agent_launch_bootstrap_builds_legacy_kimi_overlay_from_kimi_share_dir() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-share-runtime")
+        let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-share-home")
+        let shareDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-share-source")
+        let userConfigURL = shareDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let original = """
+        default_model = "kimi-share-dir-model"
+        hooks = []
+        """
+        try original.write(to: userConfigURL, atomically: true, encoding: .utf8)
+
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["chat"],
+            standardInput: nil,
+            environment: [
+                "HOME": homeDirectory.path,
+                "KIMI_SHARE_DIR": shareDirectory.path,
+                "ZENTTY_REAL_BINARY": "/usr/local/bin/kimi",
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "legacy",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        let plan = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        XCTAssertEqual(plan.arguments.first, "--config-file")
+        let overlayConfigURL = URL(fileURLWithPath: try XCTUnwrap(plan.arguments.dropFirst().first), isDirectory: false)
+        let overlayConfig = try String(contentsOf: overlayConfigURL, encoding: .utf8)
+        XCTAssertTrue(overlayConfig.contains(#"default_model = "kimi-share-dir-model""#))
+        XCTAssertTrue(overlayConfig.contains(#"command = "\"/tmp/zentty\" ipc agent-event --adapter=kimi""#))
     }
 
     func test_agent_launch_bootstrap_builds_gemini_system_settings_overlay_and_forces_notifications() throws {
@@ -9942,6 +10312,26 @@ final class AgentStatusSupportTests: XCTestCase {
         addTeardownBlock {
             try? FileManager.default.removeItem(at: url)
         }
+        return url
+    }
+
+    private func makeFakeKimiBinary(modern: Bool) throws -> URL {
+        let directory = try makeTemporaryDirectory(named: modern ? "fake-modern-kimi" : "fake-legacy-kimi")
+        let url = directory.appendingPathComponent("kimi", isDirectory: false)
+        let helpLines = modern
+            ? ["Usage: kimi-code [OPTIONS]", "  --model TEXT"]
+            : ["Usage: kimi [OPTIONS]", "  --config-file PATH"]
+        let quotedHelpLines = helpLines.map { "'\($0)'" }.joined(separator: " ")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--help" ]; then
+          printf '%s\\n' \(quotedHelpLines)
+          exit 0
+        fi
+        exit 0
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url
     }
 

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -27,7 +27,7 @@ from collections import Counter
 from typing import Any
 
 
-SUPPORTED_AGENTS = ("agy", "amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "hermes", "kimi", "opencode", "pi", "small-harness", "vibe")
+SUPPORTED_AGENTS = ("agy", "amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "hermes", "kimi", "kimi-code", "opencode", "pi", "small-harness", "vibe")
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BENCH_ROOT = pathlib.Path(__file__).resolve().parent
 DEFAULT_RUNS_DIR = REPO_ROOT / ".agent-bench-runs"
@@ -56,6 +56,8 @@ ROUTING_ENV_KEYS = {
     "ZENTTY_SMALL_HARNESS_PID",
     "CODEX_HOME",
     "COPILOT_HOME",
+    "KIMI_CODE_HOME",
+    "KIMI_SHARE_DIR",
     "KIMI_HOME",
     "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
     "SMALL_HARNESS_MANAGED_HOOKS_FILE",
@@ -89,6 +91,8 @@ REFUSAL_PATTERNS = [
     r"\bcan you (?:confirm|clarify|tell me)\b",
 ]
 OSC_TERMINAL_PATTERN = re.compile(r"\x1b\](?P<code>0|2|9);(?P<text>[^\x07\x1b]*)(?:\x07|\x1b\\)")
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+KIMI_VARIANT_PROBE_CACHE: dict[str, str] = {}
 
 
 @dataclasses.dataclass
@@ -123,6 +127,12 @@ class AgentProfile:
     input_by_scenario: dict[str, list[dict[str, Any]]] = dataclasses.field(default_factory=dict)
     repeat_by_scenario: dict[str, int] = dataclasses.field(default_factory=dict)
     skip_patterns: list[str] = dataclasses.field(default_factory=list)
+    tool: str = ""
+    kimi_variant: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tool:
+            self.tool = self.name
 
 
 @dataclasses.dataclass
@@ -273,7 +283,12 @@ def _trace_contains_post_stop_notification(records: list[TraceRecord]) -> bool:
     return False
 
 
-def validate_scenario(agent: str, expectation: ScenarioExpectation, records: list[TraceRecord]) -> ScenarioResult:
+def validate_scenario(
+    agent: str,
+    expectation: ScenarioExpectation,
+    records: list[TraceRecord],
+    agent_tool: str | None = None,
+) -> ScenarioResult:
     observed = [record.event_name for record in records if record.agent == agent and record.scenario == expectation.name]
     observed_values = [event for event in observed if event]
     observed_counts = Counter(observed_values)
@@ -304,7 +319,7 @@ def validate_scenario(agent: str, expectation: ScenarioExpectation, records: lis
         if required_arguments in observed_bootstrap_arguments:
             continue
         missing.append("bootstrap:" + " ".join(required_arguments))
-    session_missing, session_observations = validate_session_identity(agent, expectation, records)
+    session_missing, session_observations = validate_session_identity(agent, expectation, records, agent_tool=agent_tool)
     missing.extend(session_missing)
     if missing:
         result_kind = "missing-bootstrap" if any(item.startswith("bootstrap:") for item in missing) else "missing-hook"
@@ -340,6 +355,7 @@ def validate_session_identity(
     agent: str,
     expectation: ScenarioExpectation,
     records: list[TraceRecord],
+    agent_tool: str | None = None,
 ) -> tuple[list[str], list[dict[str, Any]]]:
     if expectation.session_identity is None:
         return ([], [])
@@ -349,6 +365,7 @@ def validate_session_identity(
         expectation.name,
         records,
         expectation.session_identity.session_id_pattern,
+        agent_tool=agent_tool,
     )
     missing: list[str] = []
     if not any(observation.get("session_id_valid") is True for observation in observations):
@@ -363,6 +380,7 @@ def session_identity_observations_for_records(
     scenario: str,
     records: list[TraceRecord],
     session_id_pattern: str,
+    agent_tool: str | None = None,
 ) -> list[dict[str, Any]]:
     observations: list[dict[str, Any]] = []
     for record in records:
@@ -371,7 +389,7 @@ def session_identity_observations_for_records(
 
         payload = parse_json_object(record.standard_input)
         session_id, session_source = extract_session_id(agent, payload)
-        tracked_pid, pid_source = extract_tracked_pid(agent, payload, record.environment or {})
+        tracked_pid, pid_source = extract_tracked_pid(agent, payload, record.environment or {}, agent_tool=agent_tool)
         if session_id is None and tracked_pid is None:
             continue
 
@@ -406,8 +424,13 @@ def extract_session_id(agent: str, payload: dict[str, Any]) -> tuple[str | None,
     return (None, None)
 
 
-def extract_tracked_pid(agent: str, payload: dict[str, Any], environment: dict[str, str]) -> tuple[int | None, str | None]:
-    expected_key = agent_pid_env_key(agent)
+def extract_tracked_pid(
+    agent: str,
+    payload: dict[str, Any],
+    environment: dict[str, str],
+    agent_tool: str | None = None,
+) -> tuple[int | None, str | None]:
+    expected_key = agent_pid_env_key(agent, agent_tool=agent_tool)
     pid = parse_positive_int(environment.get(expected_key))
     if pid is not None:
         return (pid, expected_key)
@@ -419,8 +442,9 @@ def extract_tracked_pid(agent: str, payload: dict[str, Any], environment: dict[s
     return (None, None)
 
 
-def agent_pid_env_key(agent: str) -> str:
-    return f"ZENTTY_{agent.upper().replace('-', '_')}_PID"
+def agent_pid_env_key(agent: str, agent_tool: str | None = None) -> str:
+    pid_agent = agent_tool or agent
+    return f"ZENTTY_{pid_agent.upper().replace('-', '_')}_PID"
 
 
 def parse_positive_int(value: Any) -> int | None:
@@ -440,6 +464,11 @@ def session_id_matches_pattern(session_id: str, pattern: str) -> bool:
     if pattern == "uuid":
         return re.fullmatch(
             r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+            session_id,
+        ) is not None
+    if pattern == "kimi-code":
+        return re.fullmatch(
+            r"(?:session_)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
             session_id,
         ) is not None
     if pattern == "codex":
@@ -493,8 +522,9 @@ def classify_completed_result(
     exit_code: int,
     completed_by_predicate: bool,
     strict: bool,
+    agent_tool: str | None = None,
 ) -> ScenarioResult:
-    result = validate_scenario(agent, expectation, records)
+    result = validate_scenario(agent, expectation, records, agent_tool=agent_tool)
     if not result.passed:
         if result.result_kind == "forbidden-hook":
             result.status = "fail"
@@ -604,8 +634,9 @@ def classify_timeout_result(
     skip_patterns: list[str],
     timeout: int,
     strict: bool,
+    agent_tool: str | None = None,
 ) -> ScenarioResult:
-    partial = validate_scenario(agent, expectation, records)
+    partial = validate_scenario(agent, expectation, records, agent_tool=agent_tool)
     if not partial.missing_events:
         forbidden_phases = forbidden_terminal_phases(expectation, terminal_observations)
         if forbidden_phases:
@@ -1193,6 +1224,7 @@ class CaptureServer:
         self._thread: threading.Thread | None = None
         self._active = 0
         self._active_lock = threading.Lock()
+        self.current_agent: str | None = None
 
     def start(self) -> None:
         self.socket_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1293,10 +1325,11 @@ class CaptureServer:
 
     def _bootstrap_response(self, request: dict[str, Any]) -> dict[str, Any]:
         tool = request.get("tool")
-        if not isinstance(tool, str) or tool not in self.profiles:
+        profile = self._profile_for_bootstrap_tool(tool)
+        if profile is None:
             return self._error_response(request, f"Unsupported bootstrap tool: {tool}")
         plan = LaunchPlanner(
-            profile=self.profiles[tool],
+            profile=profile,
             scenario=self.scenario,
             run_dir=self.run_dir,
             resources_dir=self.resources_dir,
@@ -1305,7 +1338,7 @@ class CaptureServer:
         self.recorder.append(
             TraceRecord(
                 kind="bootstrap",
-                agent=tool,
+                agent=self._agent_name_for_profile(profile),
                 scenario=self.scenario,
                 extra={
                     "arguments": [str(argument) for argument in arguments],
@@ -1320,6 +1353,30 @@ class CaptureServer:
             "result": {"launchPlan": plan},
             "error": None,
         }
+
+    def _profile_for_bootstrap_tool(self, tool: Any) -> AgentProfile | None:
+        if not isinstance(tool, str):
+            return None
+        if current_profile := self._current_profile_for_tool(tool):
+            return current_profile
+        profile = self.profiles.get(tool)
+        if profile and profile.tool == tool:
+            return profile
+        matches = [profile for profile in self.profiles.values() if profile.tool == tool]
+        return matches[0] if len(matches) == 1 else None
+
+    def _current_profile_for_tool(self, tool: str | None) -> AgentProfile | None:
+        if not tool or not self.current_agent:
+            return None
+        profile = self.profiles.get(self.current_agent)
+        if profile and profile.tool == tool:
+            return profile
+        return None
+
+    def _agent_name_for_profile(self, profile: AgentProfile) -> str:
+        if self.current_agent and self.profiles.get(self.current_agent) is profile:
+            return self.current_agent
+        return profile.name
 
     def _error_response(self, request: dict[str, Any], message: str) -> dict[str, Any]:
         return {
@@ -1337,6 +1394,8 @@ class CaptureServer:
         environment = request.get("environment") if isinstance(request.get("environment"), dict) else {}
         hook = infer_hook_event(subcommand, [str(arg) for arg in args], stdin_payload if isinstance(stdin_payload, str) else None)
         agent = agent_from_adapter(hook.adapter, environment, stdin_payload if isinstance(stdin_payload, str) else None)
+        if current_profile := self._current_profile_for_tool(agent):
+            agent = current_profile.name
         extra = cursor_trace_extra(agent, stdin_payload if isinstance(stdin_payload, str) else None)
         self.recorder.append(
             TraceRecord(
@@ -1377,13 +1436,16 @@ class LaunchPlanner:
         # process (which can fail synchronously on bogus session ids and race
         # the completion predicate).
         if self.scenario.startswith("restore_launch"):
-            return self._launch_plan("/usr/bin/true", [], {"ZENTTY_AGENT_TOOL": self.profile.name})
-        method_name = f"_plan_{self.profile.name.replace('-', '_')}"
+            env = {"ZENTTY_AGENT_TOOL": self.profile.tool}
+            if self.profile.tool == "kimi" and self.profile.kimi_variant:
+                env["ZENTTY_KIMI_VARIANT"] = self.profile.kimi_variant
+            return self._launch_plan("/usr/bin/true", [], env)
+        method_name = f"_plan_{self.profile.tool.replace('-', '_')}"
         method = getattr(self, method_name, self._direct_plan)
         return method(executable, arguments, environment, cli_path)
 
     def _direct_plan(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
-        return self._launch_plan(executable, arguments, {"ZENTTY_AGENT_TOOL": self.profile.name})
+        return self._launch_plan(executable, arguments, {"ZENTTY_AGENT_TOOL": self.profile.tool})
 
     def _plan_vibe(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
         # Mirror AgentLaunchBootstrap.vibePlan: tag the tool and pre-send a
@@ -1625,15 +1687,35 @@ class LaunchPlanner:
         return self._launch_plan(executable, arguments, {"ZENTTY_AGENT_TOOL": "gemini", "GEMINI_CLI_SYSTEM_SETTINGS_PATH": str(overlay)})
 
     def _plan_kimi(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
-        overlay = self._overlay_dir("kimi") / "config.toml"
+        variant = self._kimi_variant(executable, environment)
         command = toml_basic_string(f'"{shell_escape_double_quoted(cli_path)}" ipc agent-event --adapter=kimi')
         entries = "\n".join(f'[[hooks]]\nevent = "{event}"\ncommand = "{command}"\n' for event in ("SessionStart", "SessionEnd", "UserPromptSubmit", "Stop", "Notification", "PreToolUse", "PostToolUse"))
-        source = config_source_dir(environment, "KIMI_HOME", ".kimi") / "config.toml"
+        overlay_dir = self._overlay_dir("kimi")
+        source_dir = kimi_config_source_dir(environment, variant)
+        source = source_dir / "config.toml"
         existing = remove_top_level_toml_key(source.read_text(encoding="utf-8"), "hooks") if source.exists() else ""
-        overlay.parent.mkdir(parents=True, exist_ok=True)
         separator = "\n\n" if existing.strip() else ""
-        overlay.write_text(existing.rstrip() + separator + entries, encoding="utf-8")
-        return self._launch_plan(executable, ["--config-file", str(overlay)] + arguments, {"ZENTTY_AGENT_TOOL": "kimi"})
+        merged = existing.rstrip() + separator + entries
+        env = {"ZENTTY_AGENT_TOOL": "kimi", "ZENTTY_KIMI_VARIANT": variant}
+        if variant == "modern":
+            overlay_home = overlay_dir / "home"
+            symlink_directory_contents_skipping(source_dir, overlay_home, {"config.toml"})
+            (overlay_home / "config.toml").write_text(merged, encoding="utf-8")
+            migration_skip = overlay_home / ".skip-migration-from-kimi-cli"
+            if not os.path.lexists(migration_skip):
+                migration_skip.touch()
+            env["KIMI_CODE_HOME"] = str(overlay_home)
+            return self._launch_plan(executable, arguments, env)
+        overlay = overlay_dir / "config.toml"
+        overlay.write_text(merged, encoding="utf-8")
+        return self._launch_plan(executable, ["--config-file", str(overlay)] + arguments, env)
+
+    def _kimi_variant(self, executable: str, environment: dict[str, Any]) -> str:
+        if self.profile.kimi_variant in ("legacy", "modern"):
+            return self.profile.kimi_variant
+        if environment.get("ZENTTY_KIMI_VARIANT") in ("legacy", "modern"):
+            return str(environment["ZENTTY_KIMI_VARIANT"])
+        return probe_kimi_variant(executable) or "legacy"
 
     def _plan_opencode(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
         overlay = self._overlay_dir("opencode") / "config"
@@ -2056,6 +2138,8 @@ def load_profiles(path: pathlib.Path) -> dict[str, AgentProfile]:
             input_by_scenario={name: list(values) for name, values in raw.get("input_by_scenario", {}).items()},
             repeat_by_scenario={name: int(count) for name, count in raw.get("repeat_by_scenario", {}).items()},
             skip_patterns=list(raw.get("skip_patterns", [])),
+            tool=str(raw.get("tool") or raw["name"]),
+            kimi_variant=raw.get("kimi_variant") if raw.get("kimi_variant") in ("legacy", "modern") else None,
         )
         profiles[profile.name] = profile
     return profiles
@@ -2104,7 +2188,11 @@ class BenchRunner:
                     scenario_env["ZENTTY_WORKLANE_ID"] = "agent-bench-worklane"
                     scenario_env["ZENTTY_PANE_ID"] = "agent-bench-pane"
                     for agent in agents:
-                        results.append(self._run_agent_scenario(agent, scenario, scenario_env))
+                        server.current_agent = agent
+                        try:
+                            results.append(self._run_agent_scenario(agent, scenario, scenario_env))
+                        finally:
+                            server.current_agent = None
                 finally:
                     server.stop()
             self._write_report(results)
@@ -2183,6 +2271,7 @@ class BenchRunner:
             pass
 
     def _run_agent_scenario(self, agent: str, scenario: str, env: dict[str, str]) -> ScenarioResult:
+        env = dict(env)
         profile = self.profiles[agent]
         if scenario not in profile.expectations:
             return self._finalize_result(
@@ -2198,14 +2287,22 @@ class BenchRunner:
                 [],
                 [],
             )
-        command = None
-        for candidate in [profile.command] + profile.real_binary_names:
-            command = shutil.which(candidate, path=env["PATH"])
-            if command:
-                break
-        if not command:
-            names = ", ".join([profile.command] + profile.real_binary_names)
-            return self._finalize_result(self._skip_or_fail(agent, scenario, f"none of {names} found", "binary-skip"), [], [])
+        if profile.tool == "kimi" and profile.kimi_variant in ("legacy", "modern"):
+            names = list(dict.fromkeys([profile.command] + profile.real_binary_names))
+            wrapper_candidates = all_which_candidates(names, env["PATH"])
+            command = wrapper_candidates[0] if wrapper_candidates else None
+            if not command:
+                return self._finalize_result(self._skip_or_fail(agent, scenario, f"none of {', '.join(names)} found", "binary-skip"), [], [])
+            real_command, real_skip_message = resolve_agent_binary(profile, filtered_inherited_path(env["PATH"]))
+            if not real_command:
+                return self._finalize_result(self._skip_or_fail(agent, scenario, real_skip_message or "kimi binary not found", "binary-skip"), [], [])
+            env["PATH"] = prioritize_path_entry_after_zentty_resources(env["PATH"], str(pathlib.Path(real_command).parent))
+            env["ZENTTY_KIMI_VARIANT"] = profile.kimi_variant
+            env["ZENTTY_REAL_BINARY"] = real_command
+        else:
+            command, skip_message = resolve_agent_binary(profile, env["PATH"])
+            if not command:
+                return self._finalize_result(self._skip_or_fail(agent, scenario, skip_message or "binary not found", "binary-skip"), [], [])
         version = run_version(command, profile.version_args, env)
         self.recorder.append(TraceRecord(kind="version", agent=agent, scenario=scenario, extra={"version": version}))
         argv = [command] + profile.launch_args_by_scenario.get(scenario, [])
@@ -2225,7 +2322,7 @@ class BenchRunner:
                 timeout=self.args.timeout,
                 transcript_path=iteration_transcript_path,
                 completion_predicate=lambda _output, current_observations: (
-                    not validate_scenario(agent, expectation, self.recorder.records()).missing_events
+                    not validate_scenario(agent, expectation, self.recorder.records(), agent_tool=profile.tool).missing_events
                     and not missing_required_terminal_phases(expectation, observations + current_observations)
                     and (
                         not scenario_requires_terminal_needs_input(scenario)
@@ -2256,6 +2353,7 @@ class BenchRunner:
                 skip_patterns=profile.skip_patterns,
                 timeout=self.args.timeout,
                 strict=self.args.strict,
+                agent_tool=profile.tool,
             )
             return self._finalize_result(result, self.recorder.records(), observations)
         result = classify_completed_result(
@@ -2269,6 +2367,7 @@ class BenchRunner:
             exit_code=completed.exit_code,
             completed_by_predicate=completed.completed_by_predicate,
             strict=self.args.strict,
+            agent_tool=profile.tool,
         )
         return self._finalize_result(result, self.recorder.records(), observations)
 
@@ -2336,7 +2435,7 @@ class BenchRunner:
         scenario_records = [
             record for record in records if record.agent == agent and record.scenario == scenario
         ]
-        result = validate_scenario(agent, expectation, scenario_records)
+        result = validate_scenario(agent, expectation, scenario_records, agent_tool=profile.tool)
         if (
             result.passed
             and expectation.post_stop_notification_required
@@ -2703,6 +2802,78 @@ def run_version(command: str, args: list[str], env: dict[str, str]) -> str:
         return f"unavailable: {error}"
 
 
+def resolve_agent_binary(
+    profile: AgentProfile,
+    path_value: str,
+    variant_probe: Any = None,
+) -> tuple[str | None, str | None]:
+    names = list(dict.fromkeys([profile.command] + profile.real_binary_names))
+    candidates = all_which_candidates(names, path_value)
+    if profile.tool == "kimi" and profile.kimi_variant in ("legacy", "modern"):
+        probe = variant_probe or probe_kimi_variant
+        for candidate in candidates:
+            if probe(candidate) == profile.kimi_variant:
+                return candidate, None
+        return None, f"no {profile.kimi_variant} kimi binary found"
+    if candidates:
+        return candidates[0], None
+    return None, f"none of {', '.join(names)} found"
+
+
+def all_which_candidates(names: list[str], path_value: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        first = shutil.which(name, path=path_value)
+        if first and first not in seen:
+            seen.add(first)
+            candidates.append(first)
+        for entry in path_value.split(os.pathsep):
+            if not entry:
+                continue
+            candidate = str(pathlib.Path(entry) / name)
+            if candidate in seen:
+                continue
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                seen.add(candidate)
+                candidates.append(candidate)
+    return candidates
+
+
+def probe_kimi_variant(executable: str) -> str | None:
+    cached = KIMI_VARIANT_PROBE_CACHE.get(executable)
+    if cached:
+        return cached
+    env = os.environ.copy()
+    env["NO_COLOR"] = "1"
+    env["TERM"] = "dumb"
+    try:
+        result = subprocess.run(
+            [executable, "--help"],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            variant = "legacy"
+        else:
+            variant = "modern" if is_modern_kimi_help_output(result.stdout) else "legacy"
+    except Exception:
+        variant = "legacy"
+    KIMI_VARIANT_PROBE_CACHE[executable] = variant
+    return variant
+
+
+def is_modern_kimi_help_output(help_text: str) -> bool:
+    return "--config-file" not in strip_ansi_sequences(help_text)
+
+
+def strip_ansi_sequences(text: str) -> str:
+    return ANSI_ESCAPE_PATTERN.sub("", text)
+
+
 def parse_build_settings(output: str) -> dict[str, str]:
     values: dict[str, str] = {}
     for line in output.splitlines():
@@ -2726,18 +2897,18 @@ def missing_agent_wrapper_resource(app_path: pathlib.Path, profile: AgentProfile
     if not shared_launcher.exists():
         return f"app is missing shared Zentty launcher: {shared_launcher}"
 
-    wrapper_dir = resources_dir / "bin" / profile.name
+    wrapper_dir = resources_dir / "bin" / profile.tool
     if not wrapper_dir.exists():
-        return f"app is missing {profile.name} wrapper directory: {wrapper_dir}"
+        return f"app is missing {profile.tool} wrapper directory: {wrapper_dir}"
 
     candidate_names = list(dict.fromkeys([profile.command] + profile.real_binary_names))
     candidates = [wrapper_dir / name for name in candidate_names]
     if not any(path.exists() for path in candidates):
         names = ", ".join(path.name for path in candidates)
-        return f"app is missing {profile.name} wrapper executable in {wrapper_dir}: expected one of {names}"
+        return f"app is missing {profile.tool} wrapper executable in {wrapper_dir}: expected one of {names}"
     if not any(os.access(path, os.X_OK) for path in candidates):
         names = ", ".join(path.name for path in candidates)
-        return f"app has non-executable {profile.name} wrapper in {wrapper_dir}: expected one of {names}"
+        return f"app has non-executable {profile.tool} wrapper in {wrapper_dir}: expected one of {names}"
 
     return None
 
@@ -2788,12 +2959,31 @@ def is_zentty_resource_bin_path(entry: str) -> bool:
     return False
 
 
+def prioritize_path_entry_after_zentty_resources(path_value: str, preferred_entry: str) -> str:
+    if not preferred_entry:
+        return path_value
+    entries = [entry for entry in path_value.split(os.pathsep) if entry and entry != preferred_entry]
+    insert_at = 0
+    while insert_at < len(entries) and is_zentty_resource_bin_path(entries[insert_at]):
+        insert_at += 1
+    entries.insert(insert_at, preferred_entry)
+    return os.pathsep.join(entries)
+
+
 def config_source_dir(environment: dict[str, Any], env_key: str, default_name: str) -> pathlib.Path:
     home = pathlib.Path(str(environment.get("HOME") or pathlib.Path.home())).expanduser()
     configured = str(environment.get(env_key) or "").strip()
     if configured and not is_zentty_launch_cache_path(configured):
         return pathlib.Path(configured).expanduser()
     return home / default_name
+
+
+def kimi_config_source_dir(environment: dict[str, Any], variant: str) -> pathlib.Path:
+    if variant == "modern":
+        return config_source_dir(environment, "KIMI_CODE_HOME", ".kimi-code")
+    if str(environment.get("KIMI_SHARE_DIR") or "").strip():
+        return config_source_dir(environment, "KIMI_SHARE_DIR", ".kimi")
+    return config_source_dir(environment, "KIMI_HOME", ".kimi")
 
 
 def is_zentty_launch_cache_path(entry: str) -> bool:

--- a/scripts/agent-bench/profiles/kimi-code.json
+++ b/scripts/agent-bench/profiles/kimi-code.json
@@ -1,26 +1,22 @@
 {
-  "name": "kimi",
+  "name": "kimi-code",
+  "tool": "kimi",
   "command": "kimi",
-  "real_binary_names": ["kimi", "kimi-cli"],
-  "kimi_variant": "legacy",
+  "real_binary_names": ["kimi"],
+  "kimi_variant": "modern",
   "version_args": ["--version"],
   "launch_args_by_scenario": {
     "smoke": [
-      "--print",
-      "--prompt",
+      "-p",
       "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
     ],
     "session_capture": [
-      "--print",
-      "--prompt",
+      "-p",
       "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
     ],
-    "approval": [
-      "--prompt",
-      "Run this exact shell command: printf ZENTTY_AGENT_BENCH_APPROVAL_OK"
-    ],
+    "approval": [],
     "restore_launch": [
-      "-r",
+      "-S",
       "237d8c32-2a27-4850-8da8-3a110f13682c"
     ]
   },
@@ -31,7 +27,7 @@
     "session_capture": {
       "required_events": ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SessionEnd"],
       "session_identity": {
-        "session_id_pattern": "uuid",
+        "session_id_pattern": "kimi-code",
         "tracked_pid": true
       }
     },
@@ -40,17 +36,21 @@
     },
     "restore_launch": {
       "required_events": [],
-      "required_bootstrap_arguments": [["-r", "237d8c32-2a27-4850-8da8-3a110f13682c"]]
+      "required_bootstrap_arguments": [["-S", "237d8c32-2a27-4850-8da8-3a110f13682c"]]
     }
   },
   "input_by_scenario": {
     "approval": [
       {
-        "after": 10,
-        "text": "y\n"
+        "after": 8,
+        "text": "Run this exact shell command: printf ZENTTY_AGENT_BENCH_APPROVAL_OK\r"
       },
       {
-        "after": 45,
+        "after": 30,
+        "text": "y\r"
+      },
+      {
+        "after": 60,
         "text": "\u0003"
       }
     ]

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -6,6 +6,7 @@ import socket
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -97,8 +98,27 @@ class EventInferenceTests(unittest.TestCase):
 
         self.assertEqual(agent, "opencode")
 
+    def test_agent_inference_ignores_removed_bench_scoping_env(self):
+        agent = agent_bench.agent_from_adapter(
+            adapter="kimi",
+            environment={"ZENTTY_AGENT_BENCH_AGENT": "kimi-code"},
+            standard_input=None,
+        )
+
+        self.assertEqual(agent, "kimi")
+
 
 class SyntheticScenarioTests(unittest.TestCase):
+    def test_load_profiles_parses_tool_and_kimi_variant_fields(self):
+        profiles = agent_bench.load_profiles(ROOT / "profiles")
+
+        self.assertEqual(profiles["codex"].tool, "codex")
+        self.assertIsNone(profiles["codex"].kimi_variant)
+        self.assertEqual(profiles["kimi"].tool, "kimi")
+        self.assertEqual(profiles["kimi"].kimi_variant, "legacy")
+        self.assertEqual(profiles["kimi-code"].tool, "kimi")
+        self.assertEqual(profiles["kimi-code"].kimi_variant, "modern")
+
     def test_post_stop_notification_detector_flags_late_notification(self):
         records = [
             agent_bench.TraceRecord(kind="hook", agent="claude", scenario="stop_race", event_name="SessionStart"),
@@ -186,6 +206,172 @@ class SyntheticScenarioTests(unittest.TestCase):
 
 
 class ExpectationTests(unittest.TestCase):
+    def test_kimi_help_output_with_plain_config_file_flag_is_legacy(self):
+        self.assertFalse(agent_bench.is_modern_kimi_help_output("Usage: kimi --config-file config.toml"))
+
+    def test_kimi_help_output_with_ansi_split_config_file_flag_is_legacy(self):
+        help_text = "Usage: kimi \x1b[1;36m-\x1b[0m\x1b[1;36m-config\x1b[0m\x1b[1;36m-file\x1b[0m config.toml"
+
+        self.assertFalse(agent_bench.is_modern_kimi_help_output(help_text))
+
+    def test_kimi_help_output_without_config_file_flag_is_modern(self):
+        self.assertTrue(agent_bench.is_modern_kimi_help_output("Usage: kimi-code -p, --prompt <prompt>"))
+
+    def test_kimi_code_session_id_pattern_accepts_optional_session_prefix(self):
+        session_id = "0abf9419-c274-464b-aa3e-7946c2153829"
+
+        self.assertTrue(agent_bench.session_id_matches_pattern(session_id, "kimi-code"))
+        self.assertTrue(agent_bench.session_id_matches_pattern(f"session_{session_id}", "kimi-code"))
+        self.assertFalse(agent_bench.session_id_matches_pattern("session_not-a-uuid", "kimi-code"))
+        self.assertFalse(agent_bench.session_id_matches_pattern("not-a-uuid", "kimi-code"))
+        self.assertFalse(agent_bench.session_id_matches_pattern(f"prefix_{session_id}", "kimi-code"))
+
+    def test_kimi_legacy_plan_uses_config_file_and_kimi_share_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            share = root / "share"
+            share.mkdir()
+            (share / "config.toml").write_text('model = "moonshot"\n', encoding="utf-8")
+            planner = agent_bench.LaunchPlanner(
+                profile=agent_bench.AgentProfile(
+                    name="kimi",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi-cli"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={},
+                    expectations={},
+                    kimi_variant="legacy",
+                ),
+                scenario="smoke",
+                run_dir=root,
+                resources_dir=None,
+            )
+
+            plan = planner._plan_kimi(
+                "/usr/bin/kimi",
+                ["--prompt", "hello"],
+                {"HOME": str(root / "home"), "KIMI_SHARE_DIR": str(share)},
+                "/usr/bin/zentty",
+            )
+
+            self.assertEqual(plan["arguments"][:2], ["--config-file", plan["arguments"][1]])
+            overlay = pathlib.Path(plan["arguments"][1])
+            self.assertEqual(plan["arguments"][2:], ["--prompt", "hello"])
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_AGENT_TOOL"], "kimi")
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_KIMI_VARIANT"], "legacy")
+            self.assertIn('model = "moonshot"', overlay.read_text(encoding="utf-8"))
+
+    def test_kimi_modern_plan_uses_overlay_home_and_symlinks_source_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            source_home = root / "source-home"
+            source_home.mkdir()
+            (source_home / "credentials").mkdir()
+            (source_home / "credentials" / "token.json").write_text("{}", encoding="utf-8")
+            (source_home / "sessions").mkdir()
+            (source_home / "tui.toml").write_text("theme = 'dark'\n", encoding="utf-8")
+            (source_home / "config.toml").write_text('model = "kimi"\n', encoding="utf-8")
+            planner = agent_bench.LaunchPlanner(
+                profile=agent_bench.AgentProfile(
+                    name="kimi-code",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={},
+                    expectations={},
+                    kimi_variant="modern",
+                ),
+                scenario="smoke",
+                run_dir=root,
+                resources_dir=None,
+            )
+
+            plan = planner._plan_kimi(
+                "/usr/bin/kimi",
+                ["-p", "hello"],
+                {"HOME": str(root / "home"), "KIMI_CODE_HOME": str(source_home)},
+                "/usr/bin/zentty",
+            )
+
+            overlay_home = pathlib.Path(plan["setEnvironment"]["KIMI_CODE_HOME"])
+
+            self.assertEqual(plan["arguments"], ["-p", "hello"])
+            self.assertNotIn("--config-file", plan["arguments"])
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_AGENT_TOOL"], "kimi")
+            self.assertEqual(plan["setEnvironment"]["ZENTTY_KIMI_VARIANT"], "modern")
+            self.assertTrue(str(overlay_home).startswith(str(root / "overlays")))
+            self.assertTrue((overlay_home / "credentials").is_symlink())
+            self.assertTrue((overlay_home / "sessions").is_symlink())
+            self.assertTrue((overlay_home / "tui.toml").is_symlink())
+            self.assertFalse((overlay_home / "config.toml").is_symlink())
+            merged = (overlay_home / "config.toml").read_text(encoding="utf-8")
+            self.assertIn('model = "kimi"', merged)
+            self.assertIn("[[hooks]]", merged)
+            self.assertTrue((overlay_home / ".skip-migration-from-kimi-cli").is_file())
+
+    def test_resolve_agent_binary_picks_matching_kimi_variant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            first = root / "first"
+            second = root / "second"
+            first.mkdir()
+            second.mkdir()
+            legacy = first / "kimi"
+            modern = second / "kimi"
+            legacy.write_text("#!/bin/sh\n", encoding="utf-8")
+            modern.write_text("#!/bin/sh\n", encoding="utf-8")
+            legacy.chmod(0o755)
+            modern.chmod(0o755)
+            profile = agent_bench.AgentProfile(
+                name="kimi-code",
+                tool="kimi",
+                command="kimi",
+                real_binary_names=["kimi"],
+                version_args=["--version"],
+                launch_args_by_scenario={},
+                expectations={},
+                kimi_variant="modern",
+            )
+
+            resolved, skip = agent_bench.resolve_agent_binary(
+                profile,
+                os.pathsep.join([str(first), str(second)]),
+                variant_probe=lambda path: "modern" if pathlib.Path(path) == modern else "legacy",
+            )
+
+        self.assertEqual(resolved, str(modern))
+        self.assertIsNone(skip)
+
+    def test_resolve_agent_binary_reports_skip_when_pinned_kimi_variant_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            legacy = bin_dir / "kimi"
+            legacy.write_text("#!/bin/sh\n", encoding="utf-8")
+            legacy.chmod(0o755)
+            profile = agent_bench.AgentProfile(
+                name="kimi-code",
+                tool="kimi",
+                command="kimi",
+                real_binary_names=["kimi"],
+                version_args=["--version"],
+                launch_args_by_scenario={},
+                expectations={},
+                kimi_variant="modern",
+            )
+
+            resolved, skip = agent_bench.resolve_agent_binary(
+                profile,
+                str(bin_dir),
+                variant_probe=lambda _path: "legacy",
+            )
+
+        self.assertIsNone(resolved)
+        self.assertEqual(skip, "no modern kimi binary found")
+
     def test_load_profiles_parses_session_identity_requirements(self):
         profile_dir = ROOT / "profiles"
         profiles = agent_bench.load_profiles(profile_dir)
@@ -324,6 +510,33 @@ class ExpectationTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_validation_uses_profile_tool_for_tool_aliased_pid_environment(self):
+        session_id = "session_0abf9419-c274-464b-aa3e-7946c2153829"
+        scenario = agent_bench.ScenarioExpectation(
+            name="session_capture",
+            required_events=["SessionStart"],
+            session_identity=agent_bench.SessionIdentityExpectation(
+                session_id_pattern="kimi-code",
+                tracked_pid=True,
+            ),
+        )
+        observed = [
+            agent_bench.TraceRecord(
+                kind="hook",
+                agent="kimi-code",
+                scenario="session_capture",
+                event_name="SessionStart",
+                standard_input=f'{{"hook_event_name":"SessionStart","session_id":"{session_id}"}}',
+                environment={"ZENTTY_KIMI_PID": "5925"},
+            )
+        ]
+
+        result = agent_bench.validate_scenario("kimi-code", scenario, observed, agent_tool="kimi")
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.session_identity_observations[0]["tracked_pid"], 5925)
+        self.assertEqual(result.session_identity_observations[0]["tracked_pid_source"], "ZENTTY_KIMI_PID")
 
     def test_validation_accepts_small_harness_pid_from_underscore_environment_key(self):
         scenario = agent_bench.ScenarioExpectation(
@@ -1480,6 +1693,110 @@ class IPCServerTests(unittest.TestCase):
         self.assertEqual(records[0].environment["OPENAI_API_KEY"], "<redacted>")
         self.assertEqual(records[0].standard_input, '{"event":"x"}')
 
+    def test_capture_server_current_agent_selects_tool_alias_profile_for_bootstrap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            profiles = {
+                "kimi": agent_bench.AgentProfile(
+                    name="kimi",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={"smoke": []},
+                    expectations={"smoke": agent_bench.ScenarioExpectation("smoke", [])},
+                    kimi_variant="legacy",
+                ),
+                "kimi-code": agent_bench.AgentProfile(
+                    name="kimi-code",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={"smoke": []},
+                    expectations={"smoke": agent_bench.ScenarioExpectation("smoke", [])},
+                    kimi_variant="modern",
+                ),
+            }
+            recorder = agent_bench.TraceRecorder(pathlib.Path(tmp))
+            server = agent_bench.CaptureServer(
+                pathlib.Path(tmp) / "bench.sock",
+                recorder=recorder,
+                profiles=profiles,
+                scenario="smoke",
+                run_dir=pathlib.Path(tmp),
+            )
+            server.current_agent = "kimi-code"
+
+            response = server._bootstrap_response(
+                {
+                    "id": "bootstrap",
+                    "kind": "bootstrap",
+                    "arguments": ["-p", "hello"],
+                    "environment": {
+                        "HOME": str(pathlib.Path(tmp) / "home"),
+                        "ZENTTY_CLI_BIN": "/usr/bin/zentty",
+                        "ZENTTY_REAL_BINARY": "/usr/bin/kimi",
+                    },
+                    "expectsResponse": True,
+                    "tool": "kimi",
+                }
+            )
+
+        plan = response["result"]["launchPlan"]
+        records = recorder.records()
+        self.assertTrue(response["ok"])
+        self.assertEqual(plan["arguments"], ["-p", "hello"])
+        self.assertNotIn("--config-file", plan["arguments"])
+        self.assertEqual(plan["setEnvironment"]["ZENTTY_KIMI_VARIANT"], "modern")
+        self.assertEqual(records[0].agent, "kimi-code")
+
+    def test_capture_server_current_agent_reattributes_tool_level_hooks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            profiles = {
+                "kimi": agent_bench.AgentProfile(
+                    name="kimi",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={"smoke": []},
+                    expectations={"smoke": agent_bench.ScenarioExpectation("smoke", [])},
+                    kimi_variant="legacy",
+                ),
+                "kimi-code": agent_bench.AgentProfile(
+                    name="kimi-code",
+                    tool="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={"smoke": []},
+                    expectations={"smoke": agent_bench.ScenarioExpectation("smoke", [])},
+                    kimi_variant="modern",
+                ),
+            }
+            recorder = agent_bench.TraceRecorder(pathlib.Path(tmp))
+            server = agent_bench.CaptureServer(
+                pathlib.Path(tmp) / "bench.sock",
+                recorder=recorder,
+                profiles=profiles,
+                scenario="smoke",
+            )
+            server.current_agent = "kimi-code"
+
+            server._record_ipc(
+                {
+                    "kind": "ipc",
+                    "arguments": ["--adapter=kimi"],
+                    "standardInput": '{"hook_event_name":"SessionStart"}',
+                    "environment": {},
+                    "subcommand": "agent-event",
+                }
+            )
+
+        records = recorder.records()
+        self.assertEqual(records[0].agent, "kimi-code")
+        self.assertEqual(records[0].event_name, "SessionStart")
+
 
 class ProfileTests(unittest.TestCase):
     def test_loads_profiles_for_all_zentty_supported_agents(self):
@@ -1499,6 +1816,7 @@ class ProfileTests(unittest.TestCase):
                 "grok",
                 "hermes",
                 "kimi",
+                "kimi-code",
                 "opencode",
                 "pi",
                 "small-harness",
@@ -1555,6 +1873,24 @@ class ProfileTests(unittest.TestCase):
         self.assertEqual(profile.launch_args_by_scenario["approval"][:2], ["--prompt", "Run this exact shell command: printf ZENTTY_AGENT_BENCH_APPROVAL_OK"])
         self.assertIn("--allow-all-paths", profile.launch_args_by_scenario["approval"])
         self.assertNotIn("--allow-all-tools", profile.launch_args_by_scenario["approval"])
+
+    def test_kimi_code_profile_uses_prompt_mode_and_interactive_approval(self):
+        profile = agent_bench.load_profiles(ROOT / "profiles")["kimi-code"]
+        smoke_prompt = "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
+        approval_prompt = "Run this exact shell command: printf ZENTTY_AGENT_BENCH_APPROVAL_OK"
+
+        self.assertEqual(profile.launch_args_by_scenario["smoke"], ["-p", smoke_prompt])
+        self.assertEqual(profile.launch_args_by_scenario["session_capture"], ["-p", smoke_prompt])
+        self.assertEqual(profile.launch_args_by_scenario["approval"], [])
+        self.assertEqual(profile.expectations["session_capture"].session_identity.session_id_pattern, "kimi-code")
+        self.assertEqual(
+            profile.input_by_scenario["approval"],
+            [
+                {"after": 8, "text": approval_prompt + "\r"},
+                {"after": 30, "text": "y\r"},
+                {"after": 60, "text": "\u0003"},
+            ],
+        )
 
     def test_claude_approval_profile_drives_permission_tool_hook(self):
         profile = agent_bench.load_profiles(ROOT / "profiles")["claude"]
@@ -2021,6 +2357,76 @@ class AppPathResolutionTests(unittest.TestCase):
                 runner._cleanup_socket_dir()
                 agent_bench.REPO_ROOT = old_repo_root
                 agent_bench.latest_derived_data_zentty_app = old_latest
+
+
+class BenchRunnerExecutionTests(unittest.TestCase):
+    def test_variant_pinned_kimi_profile_sets_explicit_real_binary_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            app_path = root / "Zentty.app"
+            resources = app_path / "Contents" / "Resources"
+            zentty = resources / "bin" / "shared" / "zentty"
+            zentty.parent.mkdir(parents=True)
+            zentty.write_text("#!/bin/sh\n", encoding="utf-8")
+            zentty.chmod(0o755)
+            wrapper_dir = resources / "bin" / "kimi"
+            wrapper_dir.mkdir(parents=True)
+            wrapper = wrapper_dir / "kimi"
+            wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
+            wrapper.chmod(0o755)
+            real_command = root / "real" / "kimi-cli"
+            real_command.parent.mkdir()
+            real_command.write_text("#!/bin/sh\n", encoding="utf-8")
+            real_command.chmod(0o755)
+
+            args = type(
+                "Args",
+                (),
+                {
+                    "run_dir": str(root / "run"),
+                    "app_path": str(app_path),
+                    "no_build": True,
+                    "timeout": 30,
+                    "strict": False,
+                    "agents": "kimi",
+                    "scenarios": "smoke",
+                },
+            )()
+            runner = agent_bench.BenchRunner(args)
+            runner._resolved_app_path = app_path
+            runner.profiles = {
+                "kimi": agent_bench.AgentProfile(
+                    name="kimi",
+                    command="kimi",
+                    real_binary_names=["kimi", "kimi-cli"],
+                    version_args=["--version"],
+                    launch_args_by_scenario={"smoke": []},
+                    expectations={"smoke": agent_bench.ScenarioExpectation("smoke", [])},
+                    tool="kimi",
+                    kimi_variant="legacy",
+                )
+            }
+            captured_env = {}
+
+            def fake_run_pty(argv, env, cwd, inputs, timeout, transcript_path, completion_predicate):
+                captured_env.update(env)
+                return agent_bench.PtyResult(0, False, "", completed_by_predicate=True)
+
+            try:
+                with mock.patch.object(agent_bench, "resolve_agent_binary", return_value=(str(real_command), None)), \
+                     mock.patch.object(agent_bench, "run_version", return_value="kimi 0.0"), \
+                     mock.patch.object(agent_bench, "run_pty", side_effect=fake_run_pty):
+                    result = runner._run_agent_scenario(
+                        "kimi",
+                        "smoke",
+                        {"PATH": str(wrapper_dir), "HOME": str(root / "home")},
+                    )
+            finally:
+                runner._cleanup_socket_dir()
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(captured_env.get("ZENTTY_KIMI_VARIANT"), "legacy")
+        self.assertEqual(captured_env.get("ZENTTY_REAL_BINARY"), str(real_command))
 
 
 class EnvironmentTests(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for the modern Kimi Code CLI while keeping backward compatibility with the legacy version. In the modern version, the configuration file is moved from ~/.kimi/config.toml to ~/.kimi-code/config.toml, and the --config-file argument is no longer supported. This is addressed by relocating the config home via KIMI_CODE_HOME environment variable.