### PR TITLE
feat(ui): add smooth vertical push transition animation on worklane change

### DIFF
--- a/Zentty/Motion/PaneStripMotionController.swift
+++ b/Zentty/Motion/PaneStripMotionController.swift
@@ -50,8 +50,11 @@ final class PaneStripMotionController {
         static let fallbackSpacing: CGFloat = 16
     }
 
-    static let defaultAnimationDuration: TimeInterval = 0.22
-    static let defaultAnimationTimingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+    static let defaultAnimationDuration: TimeInterval = 0.30
+    static let defaultAnimationTimingFunction = CAMediaTimingFunction(controlPoints: 0.16, 1.0, 0.3, 1.0)
+    static let worklaneTransitionDuration: TimeInterval = 0.32
+    // Fast start, gentle settle, no overshoot.
+    static let worklaneTransitionTimingFunction = CAMediaTimingFunction(controlPoints: 0.16, 1.0, 0.3, 1.0)
 
     func presentation(
         for state: PaneStripState,

--- a/Zentty/UI/Canvas/AppCanvasView.swift
+++ b/Zentty/UI/Canvas/AppCanvasView.swift
@@ -392,6 +392,7 @@ final class AppCanvasView: NSView {
                 worklaneColor: worklaneColor,
                 leadingVisibleInset: leadingVisibleInset,
                 animated: animated,
+                transitionDirection: transitionDirection,
                 duration: duration,
                 timingFunction: timingFunction
             )

--- a/Zentty/UI/Canvas/AppCanvasView.swift
+++ b/Zentty/UI/Canvas/AppCanvasView.swift
@@ -374,6 +374,7 @@ final class AppCanvasView: NSView {
         theme: ZenttyTheme,
         leadingVisibleInset: CGFloat? = nil,
         animated: Bool = true,
+        transitionDirection: WorklaneTransitionDirection? = nil,
         duration: TimeInterval = PaneStripMotionController.defaultAnimationDuration,
         timingFunction: CAMediaTimingFunction = PaneStripMotionController.defaultAnimationTimingFunction
     ) {
@@ -406,6 +407,7 @@ final class AppCanvasView: NSView {
                 worklaneColor: worklaneColor,
                 leadingVisibleInset: leadingVisibleInset,
                 animated: animated,
+                transitionDirection: transitionDirection,
                 duration: duration,
                 timingFunction: timingFunction
             )

--- a/Zentty/UI/PaneStrip/PaneStripView.swift
+++ b/Zentty/UI/PaneStrip/PaneStripView.swift
@@ -161,6 +161,7 @@ final class PaneStripView: NSView {
         private var hoverFocusWindowIsKeyOverrideForTesting: Bool?
         private var hoverFocusPressedMouseButtonsOverrideForTesting: Int?
         private var hoverFocusMouseLocationOverrideForTesting: NSPoint?
+        private var accessibilityReduceMotionOverrideForTesting: Bool?
     #endif
     private var currentWorklaneColor: WorklaneColor?
     private var currentPresentation: StripPresentation?
@@ -227,6 +228,15 @@ final class PaneStripView: NSView {
     var leadingVisibleInset: CGFloat {
         get { resolvedLeadingVisibleInset }
         set { setLeadingVisibleInset(newValue, animated: false) }
+    }
+
+    private var accessibilityDisplayShouldReduceMotion: Bool {
+        #if DEBUG
+            if let accessibilityReduceMotionOverrideForTesting {
+                return accessibilityReduceMotionOverrideForTesting
+            }
+        #endif
+        return NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     }
 
     override var fittingSize: NSSize {
@@ -484,6 +494,7 @@ final class PaneStripView: NSView {
         worklaneColor: WorklaneColor? = nil,
         leadingVisibleInset: CGFloat,
         animated: Bool,
+        transitionDirection: WorklaneTransitionDirection? = nil,
         duration: TimeInterval = PaneStripMotionController.defaultAnimationDuration,
         timingFunction: CAMediaTimingFunction = PaneStripMotionController.defaultAnimationTimingFunction
     ) {
@@ -520,6 +531,7 @@ final class PaneStripView: NSView {
         renderCurrentState(
             state,
             animated: animated,
+            transitionDirection: transitionDirection,
             animationDuration: duration,
             animationTimingFunction: timingFunction
         )
@@ -837,6 +849,11 @@ final class PaneStripView: NSView {
             set { hoverFocusMouseLocationOverrideForTesting = newValue }
         }
 
+        var accessibilityReduceMotionForTesting: Bool? {
+            get { accessibilityReduceMotionOverrideForTesting }
+            set { accessibilityReduceMotionOverrideForTesting = newValue }
+        }
+
         var pendingHoverFocusPaneIDForTesting: PaneID? {
             pendingHoverFocusPaneID
         }
@@ -944,14 +961,25 @@ final class PaneStripView: NSView {
             && needsTerminalRedrawAfterRender
             && insertionTransition == nil
             && removalTransition == nil
-        
-        if let transitionDirection {
+
+        let shouldAnimateWorklaneTransition = animated
+            && transitionDirection != nil
+            && window?.isVisible == true
+            && window?.inLiveResize != true
+            && !inLiveResize
+            && !isResizeSuppressedRender
+            && !isZoomedOut
+            && !accessibilityDisplayShouldReduceMotion
+
+        if shouldAnimateWorklaneTransition, let transitionDirection {
             let transition = CATransition()
             transition.type = .push
             transition.subtype = transitionDirection == .down ? .fromBottom : .fromTop
-            transition.duration = animationDuration
-            transition.timingFunction = animationTimingFunction
+            transition.duration = PaneStripMotionController.worklaneTransitionDuration
+            transition.timingFunction = PaneStripMotionController.worklaneTransitionTimingFunction
             viewportView.layer?.add(transition, forKey: kCATransition)
+        } else if transitionDirection != nil {
+            viewportView.layer?.removeAnimation(forKey: kCATransition)
         }
 
         reconcilePaneViews(

--- a/Zentty/UI/PaneStrip/PaneStripView.swift
+++ b/Zentty/UI/PaneStrip/PaneStripView.swift
@@ -423,6 +423,7 @@ final class PaneStripView: NSView {
         worklaneColor: WorklaneColor? = nil,
         leadingVisibleInset: CGFloat? = nil,
         animated: Bool = true,
+        transitionDirection: WorklaneTransitionDirection? = nil,
         duration: TimeInterval = PaneStripMotionController.defaultAnimationDuration,
         timingFunction: CAMediaTimingFunction = PaneStripMotionController.defaultAnimationTimingFunction
     ) {
@@ -461,6 +462,7 @@ final class PaneStripView: NSView {
         renderCurrentState(
             state,
             animated: animated && !paneViews.isEmpty,
+            transitionDirection: transitionDirection,
             animationDuration: duration,
             animationTimingFunction: timingFunction
         )
@@ -868,6 +870,7 @@ final class PaneStripView: NSView {
     private func renderCurrentState(
         _ state: PaneStripState,
         animated: Bool,
+        transitionDirection: WorklaneTransitionDirection? = nil,
         forceViewportLayoutBeforeViewportSync: Bool = false,
         animationDuration: TimeInterval = PaneStripMotionController.defaultAnimationDuration,
         animationTimingFunction: CAMediaTimingFunction = PaneStripMotionController.defaultAnimationTimingFunction
@@ -941,6 +944,16 @@ final class PaneStripView: NSView {
             && needsTerminalRedrawAfterRender
             && insertionTransition == nil
             && removalTransition == nil
+        
+        if let transitionDirection {
+            let transition = CATransition()
+            transition.type = .push
+            transition.subtype = transitionDirection == .down ? .fromBottom : .fromTop
+            transition.duration = animationDuration
+            transition.timingFunction = animationTimingFunction
+            viewportView.layer?.add(transition, forKey: kCATransition)
+        }
+
         reconcilePaneViews(
             with: state,
             presentation: presentation,

--- a/Zentty/UI/WorklaneRenderCoordinator.swift
+++ b/Zentty/UI/WorklaneRenderCoordinator.swift
@@ -1,7 +1,7 @@
 import AppKit
 import QuartzCore
 
-enum WorklaneTransitionDirection {
+enum WorklaneTransitionDirection: Equatable, Sendable {
     case up
     case down
 }
@@ -263,7 +263,7 @@ final class WorklaneRenderCoordinator {
             previousActiveWorklaneID = currentID
 
             var transitionDirection: WorklaneTransitionDirection? = nil
-            if animated, let previousID, let currentID, previousID != currentID {
+            if animated, let previousID, previousID != currentID {
                 let worklanes = worklaneStore.worklanes
                 if let prevIndex = worklanes.firstIndex(where: { $0.id == previousID }),
                    let currIndex = worklanes.firstIndex(where: { $0.id == currentID }) {

--- a/Zentty/UI/WorklaneRenderCoordinator.swift
+++ b/Zentty/UI/WorklaneRenderCoordinator.swift
@@ -1,6 +1,11 @@
 import AppKit
 import QuartzCore
 
+enum WorklaneTransitionDirection {
+    case up
+    case down
+}
+
 @MainActor
 protocol RenderEnvironmentProviding: AnyObject {
     var renderTheme: ZenttyTheme { get }
@@ -62,6 +67,7 @@ final class WorklaneRenderCoordinator {
     private var needsRuntimeSynchronization = true
     private var worklaneStoreSubscription: WorklaneChangeSubscription?
     private let reviewPollingScheduler: ReviewPollingScheduler
+    private var previousActiveWorklaneID: WorklaneID?
 
     weak var environment: RenderEnvironmentProviding?
 
@@ -206,7 +212,7 @@ final class WorklaneRenderCoordinator {
             updateRuntimeSurfaceActivities()
             bootstrapReviewRefresh(force: true)
         case .activeWorklaneChanged:
-            renderCurrentWorklane(animated: false)
+            renderCurrentWorklane(animated: true)
             updateRuntimeSurfaceActivities()
             bootstrapReviewRefresh(force: true)
         case .auxiliaryStateUpdated(let worklaneID, let paneID, let impacts):
@@ -252,6 +258,19 @@ final class WorklaneRenderCoordinator {
                 return
             }
 
+            let previousID = previousActiveWorklaneID
+            let currentID = worklaneStore.activeWorklaneID
+            previousActiveWorklaneID = currentID
+
+            var transitionDirection: WorklaneTransitionDirection? = nil
+            if animated, let previousID, let currentID, previousID != currentID {
+                let worklanes = worklaneStore.worklanes
+                if let prevIndex = worklanes.firstIndex(where: { $0.id == previousID }),
+                   let currIndex = worklanes.firstIndex(where: { $0.id == currentID }) {
+                    transitionDirection = currIndex > prevIndex ? .down : .up
+                }
+            }
+
             terminalDiagnostics.recordRender(.full, activePaneID: activePaneID)
             worklaneStore.batchUpdate { [self] in
                 if needsRuntimeSynchronization {
@@ -278,7 +297,7 @@ final class WorklaneRenderCoordinator {
                 let headerSummary = WorklaneHeaderSummaryBuilder.summary(for: worklane)
                 terminalDiagnostics.recordRender(.header, activePaneID: activePaneID)
                 renderWindowChrome(headerSummary, in: views)
-                renderCanvasForCurrentWorklane(animated: animated)
+                renderCanvasForCurrentWorklane(animated: animated, transitionDirection: transitionDirection)
                 let windowState = environment?.renderWindowState ?? (isVisible: false, isKeyWindow: false)
                 attentionNotificationCoordinator.update(
                     windowID: windowID,
@@ -295,6 +314,7 @@ final class WorklaneRenderCoordinator {
     private func renderCanvasForCurrentWorklane(
         leadingVisibleInsetOverride: CGFloat? = nil,
         animated: Bool = false,
+        transitionDirection: WorklaneTransitionDirection? = nil,
         duration: TimeInterval = PaneStripMotionController.defaultAnimationDuration,
         timingFunction: CAMediaTimingFunction = PaneStripMotionController.defaultAnimationTimingFunction
     ) {
@@ -340,6 +360,7 @@ final class WorklaneRenderCoordinator {
                 theme: currentTheme,
                 leadingVisibleInset: effectiveInset,
                 animated: animated,
+                transitionDirection: transitionDirection,
                 duration: duration,
                 timingFunction: timingFunction
             )

--- a/ZenttyLogicTests/PaneStripViewTests.swift
+++ b/ZenttyLogicTests/PaneStripViewTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 import XCTest
 @testable import Zentty
 
@@ -1775,6 +1776,179 @@ final class PaneStripViewTests: AppKitTestCase {
         paneStripView.render(worklane2State)
         paneStripView.layoutSubtreeIfNeeded()
 
+        XCTAssertFalse(paneStripView.lastRenderWasAnimated)
+    }
+
+    @MainActor
+    func test_render_coordinator_applies_vertical_push_direction_on_active_worklane_change() throws {
+        let worklane1 = WorklaneState(
+            id: WorklaneID("worklane-1"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: PaneID("main-shell"), title: "shell")],
+                focusedPaneID: PaneID("main-shell")
+            )
+        )
+        let worklane2 = WorklaneState(
+            id: WorklaneID("worklane-2"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: PaneID("worklane-2-shell"), title: "shell")],
+                focusedPaneID: PaneID("worklane-2-shell")
+            )
+        )
+        let store = WorklaneStore()
+        store.replaceWorklanes([worklane1, worklane2], activeWorklaneID: worklane1.id)
+        let runtimeRegistry = stubRegistry()
+        let appCanvasView = AppCanvasView(runtimeRegistry: runtimeRegistry)
+        appCanvasView.frame = NSRect(x: 0, y: 0, width: 980, height: 680)
+        appCanvasView.paneStripView.accessibilityReduceMotionForTesting = false
+        addTeardownBlock {
+            MainActor.assumeIsolated {
+                appCanvasView.prepareForTestingTearDown()
+            }
+        }
+
+        let window = NSWindow(
+            contentRect: appCanvasView.frame,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        addTeardownBlock {
+            window.orderOut(nil)
+            window.close()
+        }
+        window.contentView = appCanvasView
+        window.makeKeyAndOrderFrontForAppKitTesting(nil)
+
+        let coordinator = WorklaneRenderCoordinator(
+            worklaneStore: store,
+            runtimeRegistry: runtimeRegistry,
+            notificationStore: NotificationStore()
+        )
+        coordinator.bind(to: WorklaneRenderCoordinator.ViewBindings(
+            sidebarView: SidebarView(),
+            windowChromeView: WindowChromeView(),
+            appCanvasView: appCanvasView
+        ))
+        coordinator.startObserving()
+        coordinator.render()
+        appCanvasView.layoutSubtreeIfNeeded()
+        appCanvasView.paneStripView.viewportLayerForTesting?.removeAnimation(forKey: kCATransition)
+
+        store.selectWorklane(id: worklane2.id)
+
+        let downwardTransition = try XCTUnwrap(
+            appCanvasView.paneStripView.viewportLayerForTesting?.animation(forKey: kCATransition) as? CATransition
+        )
+        XCTAssertEqual(downwardTransition.type, .push)
+        XCTAssertEqual(downwardTransition.subtype, .fromBottom)
+
+        appCanvasView.paneStripView.viewportLayerForTesting?.removeAnimation(forKey: kCATransition)
+        store.selectWorklane(id: worklane1.id)
+
+        let upwardTransition = try XCTUnwrap(
+            appCanvasView.paneStripView.viewportLayerForTesting?.animation(forKey: kCATransition) as? CATransition
+        )
+        XCTAssertEqual(upwardTransition.type, .push)
+        XCTAssertEqual(upwardTransition.subtype, .fromTop)
+    }
+
+    @MainActor
+    func test_worklane_transition_adds_vertical_push_when_visible() throws {
+        let paneStripView = makePaneStripView(width: 980)
+        paneStripView.accessibilityReduceMotionForTesting = false
+        hostInVisibleWindow(paneStripView)
+        let mainState = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("main-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("main-shell")
+        )
+        let worklane2State = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("worklane-2-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("worklane-2-shell")
+        )
+
+        paneStripView.render(mainState, animated: false)
+        paneStripView.layoutSubtreeIfNeeded()
+        paneStripView.viewportLayerForTesting?.removeAnimation(forKey: kCATransition)
+
+        paneStripView.render(
+            worklane2State,
+            animated: true,
+            transitionDirection: .down
+        )
+
+        let transition = try XCTUnwrap(
+            paneStripView.viewportLayerForTesting?.animation(forKey: kCATransition) as? CATransition
+        )
+        XCTAssertEqual(transition.type, .push)
+        XCTAssertEqual(transition.subtype, .fromBottom)
+        XCTAssertEqual(
+            transition.duration,
+            PaneStripMotionController.worklaneTransitionDuration,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(transition.timingFunction, PaneStripMotionController.worklaneTransitionTimingFunction)
+        XCTAssertFalse(paneStripView.lastRenderWasAnimated)
+    }
+
+    @MainActor
+    func test_worklane_transition_skips_when_window_is_not_visible() {
+        let paneStripView = makePaneStripView(width: 980)
+        paneStripView.accessibilityReduceMotionForTesting = false
+        let mainState = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("main-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("main-shell")
+        )
+        let worklane2State = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("worklane-2-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("worklane-2-shell")
+        )
+
+        paneStripView.render(mainState, animated: false)
+        paneStripView.layoutSubtreeIfNeeded()
+        paneStripView.viewportLayerForTesting?.removeAnimation(forKey: kCATransition)
+
+        paneStripView.render(worklane2State, animated: true, transitionDirection: .down)
+
+        XCTAssertNil(paneStripView.viewportLayerForTesting?.animation(forKey: kCATransition))
+        XCTAssertFalse(paneStripView.lastRenderWasAnimated)
+    }
+
+    @MainActor
+    func test_worklane_transition_skips_when_reduce_motion_is_enabled() {
+        let paneStripView = makePaneStripView(width: 980)
+        paneStripView.accessibilityReduceMotionForTesting = true
+        hostInVisibleWindow(paneStripView)
+        let mainState = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("main-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("main-shell")
+        )
+        let worklane2State = PaneStripState(
+            panes: [
+                PaneState(id: PaneID("worklane-2-shell"), title: "shell"),
+            ],
+            focusedPaneID: PaneID("worklane-2-shell")
+        )
+
+        paneStripView.render(mainState, animated: false)
+        paneStripView.layoutSubtreeIfNeeded()
+        paneStripView.viewportLayerForTesting?.removeAnimation(forKey: kCATransition)
+
+        paneStripView.render(worklane2State, animated: true, transitionDirection: .down)
+
+        XCTAssertNil(paneStripView.viewportLayerForTesting?.animation(forKey: kCATransition))
         XCTAssertFalse(paneStripView.lastRenderWasAnimated)
     }
 
@@ -4432,6 +4606,10 @@ private extension NSView {
 
         walk(self)
         return paneViews
+    }
+
+    var viewportLayerForTesting: CALayer? {
+        subviews.first?.layer
     }
 }
 


### PR DESCRIPTION
This PR
  introduces a smooth vertical slide transition when switching between different worklanes. When the active worklane changes,
  it calculates the relative transition direction (up/down) and applies a hardware-accelerated CATransition push animation to
  the viewport layer.