### PR TITLE
fix(bookmarks): normalize column widths to current layout on apply

### DIFF
--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -2895,14 +2895,8 @@ final class WorklaneStore {
         from previousLayoutContext: PaneLayoutContext,
         to nextLayoutContext: PaneLayoutContext
     ) -> CGFloat? {
-        let previousReadableWidth = previousLayoutContext.sizing.readableWidth(
-            for: previousLayoutContext.viewportWidth,
-            leadingVisibleInset: previousLayoutContext.leadingVisibleInset
-        )
-        let nextReadableWidth = nextLayoutContext.sizing.readableWidth(
-            for: nextLayoutContext.viewportWidth,
-            leadingVisibleInset: nextLayoutContext.leadingVisibleInset
-        )
+        let previousReadableWidth = previousLayoutContext.readableWidth
+        let nextReadableWidth = nextLayoutContext.readableWidth
         guard previousReadableWidth > 0, nextReadableWidth > 0 else {
             return nil
         }

--- a/Zentty/Bookmarks/WorkspaceTemplate.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplate.swift
@@ -15,6 +15,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
     var title: String?
     var color: String?
     var projectRoot: String?
+    var capturedReadableWidth: Double?
     var nextPaneNumber: Int
     var focusedColumnID: String?
     var columns: [Column]
@@ -31,6 +32,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
         title: String? = nil,
         color: String? = nil,
         projectRoot: String? = nil,
+        capturedReadableWidth: Double? = nil,
         nextPaneNumber: Int = 1,
         focusedColumnID: String? = nil,
         columns: [Column] = [],
@@ -46,6 +48,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
         self.title = title
         self.color = color
         self.projectRoot = projectRoot
+        self.capturedReadableWidth = capturedReadableWidth
         self.nextPaneNumber = nextPaneNumber
         self.focusedColumnID = focusedColumnID
         self.columns = columns

--- a/Zentty/Bookmarks/WorkspaceTemplateCapture.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplateCapture.swift
@@ -13,6 +13,7 @@ enum WorkspaceTemplateCapture {
         worklane: WorklaneState,
         kind: WorkspaceTemplate.Kind,
         name: String,
+        capturedReadableWidth: Double? = nil,
         processTreeProvider: ProcessTreeProvider? = nil
     ) -> WorkspaceTemplate {
         let columns = worklane.paneStripState.columns.map { column -> WorkspaceTemplate.Column in
@@ -45,6 +46,7 @@ enum WorkspaceTemplateCapture {
             title: WorklaneContextFormatter.trimmed(worklane.title),
             color: worklane.color?.rawValue,
             projectRoot: projectRoot,
+            capturedReadableWidth: capturedReadableWidth,
             nextPaneNumber: worklane.nextPaneNumber,
             focusedColumnID: worklane.paneStripState.focusedColumnID?.rawValue,
             columns: columns

--- a/Zentty/Bookmarks/WorkspaceTemplateImporter.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplateImporter.swift
@@ -42,6 +42,10 @@ enum WorkspaceTemplateImporter {
         let paneIDsByColumn = template.columns.map { column -> [PaneID] in
             column.panes.map { _ in runtimeIdentity.makePaneID() }
         }
+        let columnWidths = normalizedColumnWidths(
+            for: template,
+            layoutContext: layoutContext
+        )
         let resolveCommand: (String) -> Bool = commandResolver ?? {
             isCommandOnPath($0, processEnvironment: processEnvironment)
         }
@@ -61,7 +65,7 @@ enum WorkspaceTemplateImporter {
                     paneCountInColumn: paneCount,
                     totalColumns: totalColumns,
                     totalWorklanes: totalWorklanes,
-                    columnWidth: CGFloat(templateColumn.width),
+                    columnWidth: columnWidths[columnIndex],
                     fallbackWorkingDirectory: fallbackWorkingDirectory,
                     windowID: windowID,
                     worklaneID: worklaneID,
@@ -75,7 +79,7 @@ enum WorkspaceTemplateImporter {
             return PaneColumnState(
                 id: columnIDs[columnIndex],
                 panes: panes,
-                width: CGFloat(templateColumn.width),
+                width: columnWidths[columnIndex],
                 paneHeights: templateColumn.paneHeights.map { CGFloat($0) },
                 focusedPaneID: templateColumn.focusedPaneID.flatMap { paneIDByTemplateID[$0] },
                 lastFocusedPaneID: templateColumn.lastFocusedPaneID.flatMap { paneIDByTemplateID[$0] }
@@ -100,6 +104,28 @@ enum WorkspaceTemplateImporter {
         )
 
         return Result(worklane: worklane, fallbacks: fallbacks)
+    }
+
+    static func normalizedColumnWidths(
+        for template: WorkspaceTemplate,
+        layoutContext: PaneLayoutContext
+    ) -> [CGFloat] {
+        guard template.columns.count != 1 else {
+            return [layoutContext.singlePaneWidth]
+        }
+        guard template.columns.count > 1,
+              let capturedReadableWidth = template.capturedReadableWidth,
+              capturedReadableWidth > 0
+        else {
+            return template.columns.map { CGFloat($0.width) }
+        }
+
+        let scaleFactor = layoutContext.readableWidth / CGFloat(capturedReadableWidth)
+        guard abs(scaleFactor - 1) >= 0.001 else {
+            return template.columns.map { CGFloat($0.width) }
+        }
+
+        return template.columns.map { max(1, CGFloat($0.width) * scaleFactor) }
     }
 
     private static func makePane(

--- a/Zentty/Layout/PaneLayoutPreferences.swift
+++ b/Zentty/Layout/PaneLayoutPreferences.swift
@@ -299,6 +299,13 @@ struct PaneLayoutContext: Equatable, Sendable {
         max(0, viewportWidth - leadingVisibleInset)
     }
 
+    var readableWidth: CGFloat {
+        sizing.readableWidth(
+            for: viewportWidth,
+            leadingVisibleInset: leadingVisibleInset
+        )
+    }
+
     var newPaneWidth: CGFloat {
         preset.defaultPaneWidth(
             for: displayClass,

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -4138,6 +4138,7 @@ private extension RootViewController {
             worklane: worklane,
             kind: kind,
             name: name,
+            capturedReadableWidth: Double(currentPaneLayoutContext.readableWidth),
             processTreeProvider: { rootPID in
                 sampler.sample(rootPID: rootPID)
             }

--- a/ZenttyLogicTests/WorkspaceTemplateCaptureTests.swift
+++ b/ZenttyLogicTests/WorkspaceTemplateCaptureTests.swift
@@ -316,6 +316,24 @@ final class WorkspaceTemplateCaptureTests: XCTestCase {
         ])
     }
 
+    func test_capture_stamps_captured_readable_width() {
+        let worklane = makeWorklane(
+            panes: [
+                paneFixture(id: "p1", cwd: "/Users/peter", processName: nil),
+            ],
+            color: nil
+        )
+
+        let template = WorkspaceTemplateCapture.capture(
+            worklane: worklane,
+            kind: .bookmark,
+            name: "Test",
+            capturedReadableWidth: 1234
+        )
+
+        XCTAssertEqual(template.capturedReadableWidth, 1234)
+    }
+
     private struct PaneFixture {
         let pane: PaneState
         let auxiliary: PaneAuxiliaryState

--- a/ZenttyLogicTests/WorkspaceTemplateImporterTests.swift
+++ b/ZenttyLogicTests/WorkspaceTemplateImporterTests.swift
@@ -145,6 +145,164 @@ final class WorkspaceTemplateImporterTests: XCTestCase {
         XCTAssertEqual(result.worklane.bookmarkOriginID, template.id)
     }
 
+    func test_import_normalizes_single_column_width_to_current_single_pane_width() {
+        let context = PaneLayoutContext(
+            displayClass: .largeDisplay,
+            preset: .balanced,
+            viewportWidth: 1800,
+            leadingVisibleInset: 0,
+            sizing: .balanced
+        )
+        let template = makeTemplate(
+            kind: .bookmark,
+            panes: [makePane(id: "p1", workingDirectory: temporaryDirectoryURL.path, command: nil)]
+        )
+
+        let result = WorkspaceTemplateImporter.makeWorklane(
+            from: template,
+            worklaneID: WorklaneID("w1"),
+            fallbackWorkingDirectory: nil,
+            windowID: WindowID("win1"),
+            layoutContext: context,
+            processEnvironment: ["HOME": NSHomeDirectory()],
+            commandResolver: { _ in true }
+        )
+
+        XCTAssertEqual(result.worklane.paneStripState.columns.first?.width, context.singlePaneWidth)
+    }
+
+    func test_import_scales_multi_column_widths_from_captured_readable_width() {
+        var template = WorkspaceTemplate(
+            name: "Scaled",
+            kind: .bookmark,
+            capturedReadableWidth: 600,
+            focusedColumnID: "left",
+            columns: [
+                WorkspaceTemplate.Column(
+                    id: "left",
+                    width: 200,
+                    focusedPaneID: "p1",
+                    lastFocusedPaneID: "p1",
+                    paneHeights: [1],
+                    panes: [makePane(id: "p1", workingDirectory: temporaryDirectoryURL.path, command: nil)]
+                ),
+                WorkspaceTemplate.Column(
+                    id: "right",
+                    width: 400,
+                    focusedPaneID: "p2",
+                    lastFocusedPaneID: "p2",
+                    paneHeights: [1],
+                    panes: [makePane(id: "p2", workingDirectory: temporaryDirectoryURL.path, command: nil)]
+                ),
+            ]
+        )
+        let context = PaneLayoutContext(
+            displayClass: .largeDisplay,
+            preset: .balanced,
+            viewportWidth: 1200,
+            leadingVisibleInset: 100,
+            sizing: .balanced
+        )
+        template.capturedReadableWidth = Double(context.readableWidth / 2)
+
+        let result = WorkspaceTemplateImporter.makeWorklane(
+            from: template,
+            worklaneID: WorklaneID("w1"),
+            fallbackWorkingDirectory: nil,
+            windowID: WindowID("win1"),
+            layoutContext: context,
+            processEnvironment: ["HOME": NSHomeDirectory()],
+            commandResolver: { _ in true }
+        )
+
+        let widths = result.worklane.paneStripState.columns.map(\.width)
+        XCTAssertEqual(widths[0], 400, accuracy: 0.001)
+        XCTAssertEqual(widths[1], 800, accuracy: 0.001)
+    }
+
+    func test_import_keeps_legacy_multi_column_widths_without_captured_readable_width() {
+        let template = WorkspaceTemplate(
+            name: "Legacy",
+            kind: .bookmark,
+            focusedColumnID: "left",
+            columns: [
+                WorkspaceTemplate.Column(
+                    id: "left",
+                    width: 250,
+                    focusedPaneID: "p1",
+                    lastFocusedPaneID: "p1",
+                    paneHeights: [1],
+                    panes: [makePane(id: "p1", workingDirectory: temporaryDirectoryURL.path, command: nil)]
+                ),
+                WorkspaceTemplate.Column(
+                    id: "right",
+                    width: 350,
+                    focusedPaneID: "p2",
+                    lastFocusedPaneID: "p2",
+                    paneHeights: [1],
+                    panes: [makePane(id: "p2", workingDirectory: temporaryDirectoryURL.path, command: nil)]
+                ),
+            ]
+        )
+
+        let result = WorkspaceTemplateImporter.makeWorklane(
+            from: template,
+            worklaneID: WorklaneID("w1"),
+            fallbackWorkingDirectory: nil,
+            windowID: WindowID("win1"),
+            layoutContext: layoutContext(),
+            processEnvironment: ["HOME": NSHomeDirectory()],
+            commandResolver: { _ in true }
+        )
+
+        XCTAssertEqual(result.worklane.paneStripState.columns.map(\.width), [250, 350])
+    }
+
+    func test_decodes_template_payload_without_captured_readable_width() throws {
+        let payload = """
+        {
+          "schemaVersion": 1,
+          "id": "B99AAE70-EF4D-4739-AFB0-7C6FB5857001",
+          "name": "Legacy",
+          "kind": "bookmark",
+          "title": null,
+          "color": null,
+          "projectRoot": null,
+          "nextPaneNumber": 1,
+          "focusedColumnID": "c0",
+          "columns": [
+            {
+              "id": "c0",
+              "width": 600,
+              "focusedPaneID": "p1",
+              "lastFocusedPaneID": "p1",
+              "paneHeights": [1],
+              "panes": [
+                {
+                  "id": "p1",
+                  "titleSeed": null,
+                  "workingDirectory": null,
+                  "command": null,
+                  "environment": {},
+                  "wasUserEdited": false
+                }
+              ]
+            }
+          ],
+          "pinned": false,
+          "createdAt": "2026-01-01T00:00:00Z",
+          "updatedAt": "2026-01-01T00:00:00Z",
+          "lastUsedAt": null
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let template = try decoder.decode(WorkspaceTemplate.self, from: Data(payload.utf8))
+
+        XCTAssertNil(template.capturedReadableWidth)
+    }
+
     func test_import_allocates_fresh_ids_and_remaps_focus_references() {
         let template = WorkspaceTemplate(
             name: "Focused",


### PR DESCRIPTION
## What

Applying a bookmark saved on a smaller screen left the pane(s) at their old width — a single-pane bookmark filled only the left half of the window until you resized it.

Bookmarks store column widths in absolute points, and `applyTemplate` copied them verbatim. The only place widths get normalized is `updateLayoutContext`, which fires on window resize — hence "resize fixes it".

## How

- Applying a template now snaps a single column to the current `singlePaneWidth`, the same thing a resize would do.
- Multi-column bookmarks record the readable width at capture time (new optional `capturedReadableWidth` field) and scale proportionally on apply, mirroring the resize-time `scalePaneWidths` semantics.
- Old bookmark files without the field still decode; multi-column legacy bookmarks keep today's behavior. No schema bump needed.

The reverse direction (bookmark saved on a big screen, applied on the laptop) is fixed by the same change.

## Testing

Five new tests in `ZenttyLogicTests`: single-column snap, proportional multi-column scaling, legacy multi-column passthrough, decoding a payload without the new field, and capture stamping. Full `ZenttyLogicTests` suite: 3333 tests, 0 failures.