### PR TITLE
fix(restore): emit variant-correct Kimi resume command

### DIFF
--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -730,11 +730,16 @@ enum AgentResumeCommandBuilder {
             }
             return "gemini --resume"
         case .kimi:
-            guard let sessionID = validatedKimiSessionID(from: draft.sessionID) else {
+            guard let invocation = kimiResumeInvocation(from: draft.sessionID) else {
                 logRejectedSessionID(for: draft)
                 return nil
             }
-            return "kimi -r \(sessionID)"
+            switch invocation {
+            case .legacy(let sessionID):
+                return "kimi -r \(sessionID)"
+            case .modern(let sessionID):
+                return "kimi -S \(sessionID)"
+            }
         case .droid:
             guard let sessionID = validatedDroidSessionID(from: draft.sessionID) else {
                 logRejectedSessionID(for: draft)
@@ -879,11 +884,27 @@ enum AgentResumeCommandBuilder {
         return sessionID
     }
 
-    private static func validatedKimiSessionID(from sessionID: String) -> String? {
-        guard let uuid = UUID(uuidString: sessionID) else {
+    private enum KimiResumeInvocation {
+        case legacy(sessionID: String)
+        case modern(sessionID: String)
+    }
+
+    /// Legacy Kimi uses bare UUIDs; modern kimi-code uses `session_<uuid>`.
+    private static func kimiResumeInvocation(from sessionID: String) -> KimiResumeInvocation? {
+        let trimmedSessionID = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedSessionID.hasPrefix("session_") {
+            let uuidPart = String(trimmedSessionID.dropFirst("session_".count))
+            guard UUID(uuidString: uuidPart) != nil else {
+                return nil
+            }
+            return .modern(sessionID: "session_" + uuidPart.lowercased())
+        }
+
+        guard let uuid = UUID(uuidString: trimmedSessionID) else {
             return nil
         }
-        return uuid.uuidString.lowercased()
+        return .legacy(sessionID: uuid.uuidString.lowercased())
     }
 
     private static func validatedDroidSessionID(from sessionID: String) -> String? {

--- a/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
+++ b/ZenttyLogicTests/AgentResumeCommandBuilderTests.swift
@@ -243,6 +243,80 @@ final class AgentResumeCommandBuilderTests: XCTestCase {
         )
     }
 
+    func test_builder_returns_kimi_resume_command_for_uppercase_uuid_session_id() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "0CB916DB-26AA-40F2-86B5-1BA81B225FD2",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            "kimi -r 0cb916db-26aa-40f2-86b5-1ba81b225fd2"
+        )
+    }
+
+    func test_builder_returns_kimi_modern_resume_command_for_session_prefixed_uuid() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "session_0cb916db-26aa-40f2-86b5-1ba81b225fd2",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            "kimi -S session_0cb916db-26aa-40f2-86b5-1ba81b225fd2"
+        )
+    }
+
+    func test_builder_returns_kimi_modern_resume_command_for_uppercase_session_prefixed_uuid() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "session_0CB916DB-26AA-40F2-86B5-1BA81B225FD2",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertEqual(
+            AgentResumeCommandBuilder.command(for: draft),
+            "kimi -S session_0cb916db-26aa-40f2-86b5-1ba81b225fd2"
+        )
+    }
+
+    func test_builder_returns_nil_for_kimi_modern_session_prefixed_invalid_uuid() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "session_not-a-uuid",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
+    }
+
+    func test_builder_returns_nil_for_kimi_modern_session_prefixed_empty_uuid() {
+        let draft = PaneRestoreDraft(
+            paneID: "pane-kimi",
+            kind: .agentResume,
+            toolName: "Kimi",
+            sessionID: "session_",
+            workingDirectory: "/tmp/project",
+            trackedPID: 4242
+        )
+
+        XCTAssertNil(AgentResumeCommandBuilder.command(for: draft))
+    }
+
     func test_builder_returns_nil_for_kimi_non_uuid_session_id() {
         let draft = PaneRestoreDraft(
             paneID: "pane-kimi",


### PR DESCRIPTION
Session restore rebuilt every Kimi resume command as `kimi -r <uuid>` and validated the id as a bare UUID. Modern kimi-code panes couldn't restore at all: their `session_<uuid>` id failed that check, so the builder returned nil and nothing resumed.

This picks the flag from the session-id shape:

- bare `<uuid>` (legacy kimi-cli) stays `kimi -r <uuid>`
- `session_<uuid>` (modern kimi-code) becomes `kimi -S session_<uuid>`
- anything else is still rejected

`session_<uuid>` is the canonical id the modern CLI mints. `createSessionId()` returns `session_${randomUUID()}`, which is what the SessionStart hook emits and what Zentty captures into the restore draft. I confirmed live that its session lookup accepts that form (`kimi export session_<uuid>` resolved a real session).

Tests: 44 pass in `AgentResumeCommandBuilderTests`, covering both flags, uppercase-uuid normalization, and the rejected `session_`-prefix cases.

Known limitation, left as-is: with both CLIs installed, restoring a legacy session runs `kimi -r <uuid>`, which the default-to-modern binary resolution sends to the modern binary. Legacy sessions age out as you move to modern, so this stays a transition-window edge.
