### PR TITLE
feat(panes): support custom pane titles

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		2646F473E8AB7B0F855F6857 /* AgentIPCClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C2498C39738D7E5DBC5BBC /* AgentIPCClient.swift */; };
 		267DEF07DD871705091F0BC8 /* SidebarMotionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3810175E866C6CB11A8C87 /* SidebarMotionCoordinatorTests.swift */; };
 		269DD148F3D616460B3E5DE2 /* ScrollSwitchGestureHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905DD9FD69FFEA7991390EA4 /* ScrollSwitchGestureHandler.swift */; };
+		26AFF78C52733C2ABCCE4B5C /* PaneRenameIPCParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A3D22F97BFF48E29B7A666 /* PaneRenameIPCParserTests.swift */; };
 		26D68604F3403C3BC9299DEC /* SidebarVisibilityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A34A831CA0E3FE65355578 /* SidebarVisibilityControllerTests.swift */; };
 		27194631879427B37A7F8D2A /* VibeCanonicalReEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC868A8CEBD7DF0E0D47542 /* VibeCanonicalReEmitter.swift */; };
 		2835550C9EC2274B56BB12EC /* GrokCanonicalReEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC1382544ECD4896FE2CBD /* GrokCanonicalReEmitter.swift */; };
@@ -157,6 +158,7 @@
 		482312E708B429D8A516E5A8 /* TmuxCompatStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAFE9100510CB50EB0AD11C /* TmuxCompatStore.swift */; };
 		48390CEFB72081A23FE98E4F /* SidebarWorklaneRowDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91986D1792E0A3DD28D3A244 /* SidebarWorklaneRowDebugging.swift */; };
 		48AAE3252CEE1E6E73CE2046 /* SparkleAppUpdateControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96218BAE51D065EB4C3DF588 /* SparkleAppUpdateControllerTests.swift */; };
+		48ECF9EAFA83C8B95CB644E3 /* PaneDisplayIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC039C620770B29A8DC711C1 /* PaneDisplayIdentityResolver.swift */; };
 		493E2A5FDF88B1B75E958F29 /* ServerListenerScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C4B3E5FFC590B5695ACC9C /* ServerListenerScannerTests.swift */; };
 		4A014221A3B9A8CFCCBA0DCF /* VibeHooksInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A549AF1327C02BFFB274EB /* VibeHooksInstallerTests.swift */; };
 		4A3471E1B0600EF1412C3932 /* SparkleAppUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C47104BD130C28676BA079 /* SparkleAppUpdateController.swift */; };
@@ -384,6 +386,7 @@
 		BBE3CA1DD7CB1D184F81DDE2 /* TaskfileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27305922B447A5738166829F /* TaskfileParser.swift */; };
 		BC0AC74F991917A3539038CB /* LeadingChromeControlsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A236782CF61D4D5B4FC361 /* LeadingChromeControlsBar.swift */; };
 		BD7EA4AEE8EB280F5A855B2C /* AmpPluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */; };
+		BE15E3FF2C4F6086140D2445 /* WorklaneStorePaneTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C39B34C7E0AF1C0999DDDB /* WorklaneStorePaneTitleTests.swift */; };
 		BE30B813EC32158B648F52B1 /* SidebarShimmerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE256725D568E7583890592B /* SidebarShimmerCoordinatorTests.swift */; };
 		BE5DF3CB1463B823867F64C8 /* WorklanePeekKeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F238040A6D3B645944F5AB0 /* WorklanePeekKeyMonitor.swift */; };
 		BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
@@ -415,6 +418,7 @@
 		CBA82B1C9557F98AD04A8672 /* SidebarPaneRowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9407DEA6B0DE6363B46DE0A /* SidebarPaneRowViews.swift */; };
 		CC3E9AE062D12B88458DA88B /* FuzzyMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0EFB8B00D5CA9A67589A3A /* FuzzyMatcher.swift */; };
 		CD00F629DE6FF4C470C1879C /* DragReorderHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712CB2F8BC16BB3B666A085 /* DragReorderHapticFeedback.swift */; };
+		CD53494A66CC5B4B0CDF23BA /* PaneDisplayIdentityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA2D0CE5BE10DFD7CDB4CBC /* PaneDisplayIdentityResolverTests.swift */; };
 		CDA589887C4F0F21EEE4A1DF /* FileManager+SymlinkWrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */; };
 		CDF1BF1E9C25A9C932CF64CC /* ServerBrowserCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD55E4B84C3278A35AB5B50B /* ServerBrowserCatalogTests.swift */; };
 		CE2B404DBF241C89DDD59410 /* WorkspaceTemplateExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AE87CC3F4EB591D08B9A7 /* WorkspaceTemplateExporterTests.swift */; };
@@ -503,6 +507,7 @@
 		F33474EA4FEC1975F4FB4754 /* KeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D348923237491F345AB193 /* KeyboardShortcut.swift */; };
 		F3EEEE8B6ACBE33992176FD2 /* ThemeCatalogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315E199A7E5DFC5BA83F6225 /* ThemeCatalogServiceTests.swift */; };
 		F3F3318AA0694EE3F01EAD10 /* WorklaneColorMenuItemViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BE69D7119B24F57979F982 /* WorklaneColorMenuItemViewTests.swift */; };
+		F4066A607FBA2CC7C916B2A3 /* WorklaneStore+PaneTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EBE8808BB466A980EFC89A /* WorklaneStore+PaneTitle.swift */; };
 		F41BF0F2213D63594DF10864 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36884D94E01C92231D935C87 /* CommandPaletteView.swift */; };
 		F42E958471B9D597F85A3894 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43EC896B9EA214B488CDCD09 /* GhosttyKit.xcframework */; };
 		F4EDBFDE9C214BF1696D73C7 /* PaneDragFloatingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B38F7B707F0B39645C8BA1 /* PaneDragFloatingContainer.swift */; };
@@ -513,6 +518,7 @@
 		F7341AA3719ED1FB2D7B3739 /* TerminalScrollFrameSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFCA2B8C7CCCEF9A040B1D1 /* TerminalScrollFrameSampler.swift */; };
 		F75C8D5EDC0772F56DE54C52 /* PaneStripStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB4690A6E06FB3FC4C1909E /* PaneStripStoreTests.swift */; };
 		F79914E37499F5FE7297C009 /* PresentationPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB40B6883D6232A52132FA30 /* PresentationPipeline.swift */; };
+		F816A0603E61CBBC198F657B /* WorklaneSidebarCustomTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFDC162D1B103A8097293EB /* WorklaneSidebarCustomTitleTests.swift */; };
 		F8250CEECD7700EA54A9687B /* AmpPluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */; };
 		F9041F8DDD50C06C4E5A89A8 /* WorklanePeekControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FFD1D69CCE5697BFE6636F /* WorklanePeekControllerTests.swift */; };
 		F97846ECF2EADD4484996415 /* DroidHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */; };
@@ -720,6 +726,7 @@
 		50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyView.swift; sourceTree = "<group>"; };
 		51BFAD9337055E61275E0F7D /* ThemeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCoordinatorTests.swift; sourceTree = "<group>"; };
 		51F182C0E58D8DC4249303AA /* GhosttyThemeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyThemeResolver.swift; sourceTree = "<group>"; };
+		52A3D22F97BFF48E29B7A666 /* PaneRenameIPCParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneRenameIPCParserTests.swift; sourceTree = "<group>"; };
 		52C47988FC977CAE87970482 /* SidebarWorklaneRowPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorklaneRowPresentationTests.swift; sourceTree = "<group>"; };
 		53055103EE2424B9E14A2878 /* PaneNotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneNotificationCoordinator.swift; sourceTree = "<group>"; };
 		53327B620C37CD8E0459EB7A /* ZenttyIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZenttyIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -759,6 +766,7 @@
 		65672683D929537DA2ACF986 /* TaskManagerProcessSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerProcessSampler.swift; sourceTree = "<group>"; };
 		65EC1382544ECD4896FE2CBD /* GrokCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokCanonicalReEmitter.swift; sourceTree = "<group>"; };
 		664E62FC352B56CA7B035AC1 /* TaskManagerPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerPresentationTests.swift; sourceTree = "<group>"; };
+		66EBE8808BB466A980EFC89A /* WorklaneStore+PaneTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneStore+PaneTitle.swift"; sourceTree = "<group>"; };
 		677818B56188202E6289EC96 /* WorklaneColorMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorMenuItemView.swift; sourceTree = "<group>"; };
 		68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+SymlinkWrite.swift"; sourceTree = "<group>"; };
 		691FE92E923A9E00EC8B6063 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -809,6 +817,7 @@
 		7F97C3054D1F1E57C716DCAB /* WorklaneDestinationCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneDestinationCatalogTests.swift; sourceTree = "<group>"; };
 		7FB9D05A6887CB439CE0E066 /* LibghosttyViewMiddleClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyViewMiddleClickTests.swift; sourceTree = "<group>"; };
 		8062E55664628AC4197A39C3 /* HermesTitleStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleStatusTests.swift; sourceTree = "<group>"; };
+		80C39B34C7E0AF1C0999DDDB /* WorklaneStorePaneTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStorePaneTitleTests.swift; sourceTree = "<group>"; };
 		810F6A39773D41286D4D344F /* FuzzyMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatcherTests.swift; sourceTree = "<group>"; };
 		8132E7564D882D85A155D2B5 /* DiscoveryIPCHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryIPCHandlerTests.swift; sourceTree = "<group>"; };
 		81A2C70428D2C375764E7ABC /* GhosttyAppearanceSettingsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAppearanceSettingsCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -870,6 +879,7 @@
 		9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStore.swift; sourceTree = "<group>"; };
 		9E981E6DAD0FE2A00554CEEA /* WorklaneStoreCrossWindowTransferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreCrossWindowTransferTests.swift; sourceTree = "<group>"; };
 		9E9E7AF610F36B91C077C324 /* WorklaneHeaderSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneHeaderSummary.swift; sourceTree = "<group>"; };
+		9EA2D0CE5BE10DFD7CDB4CBC /* PaneDisplayIdentityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDisplayIdentityResolverTests.swift; sourceTree = "<group>"; };
 		9F238040A6D3B645944F5AB0 /* WorklanePeekKeyMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklanePeekKeyMonitor.swift; sourceTree = "<group>"; };
 		9F8650021838A0AF48775312 /* CopilotOSCProgressReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotOSCProgressReducer.swift; sourceTree = "<group>"; };
 		A097B2335BF9F2F0D23A9148 /* TaskRunnerDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunnerDiscoveryService.swift; sourceTree = "<group>"; };
@@ -923,6 +933,8 @@
 		BA9DF527B186CAC92FE63473 /* AppUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateController.swift; sourceTree = "<group>"; };
 		BB190F0BEA7609493A5A1AB3 /* SettingsSidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarViewController.swift; sourceTree = "<group>"; };
 		BBC868A8CEBD7DF0E0D47542 /* VibeCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeCanonicalReEmitter.swift; sourceTree = "<group>"; };
+		BBFDC162D1B103A8097293EB /* WorklaneSidebarCustomTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneSidebarCustomTitleTests.swift; sourceTree = "<group>"; };
+		BC039C620770B29A8DC711C1 /* PaneDisplayIdentityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDisplayIdentityResolver.swift; sourceTree = "<group>"; };
 		BC0EFB8B00D5CA9A67589A3A /* FuzzyMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatcher.swift; sourceTree = "<group>"; };
 		BC1927429EEB90A74961D30D /* CommandPaletteItemBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteItemBuilderTests.swift; sourceTree = "<group>"; };
 		BD6DA3C31A354A563A4D7D63 /* SidebarListRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarListRenderer.swift; sourceTree = "<group>"; };
@@ -1173,6 +1185,7 @@
 				E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */,
 				9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */,
 				E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */,
+				BC039C620770B29A8DC711C1 /* PaneDisplayIdentityResolver.swift */,
 				54894343178398AA618315E4 /* PaneFocusHistory.swift */,
 				41CE6484C3A7D0F443F1FF10 /* PaneFocusHistoryController.swift */,
 				53055103EE2424B9E14A2878 /* PaneNotificationCoordinator.swift */,
@@ -1189,6 +1202,7 @@
 				431577B93D9FBB4CC61ADC41 /* WorklaneStore+Color.swift */,
 				AC4C1F56E8C3A787C0F4EAA8 /* WorklaneStore+DragDrop.swift */,
 				4225A0DF5039F2DBBAA2D91C /* WorklaneStore+Metadata.swift */,
+				66EBE8808BB466A980EFC89A /* WorklaneStore+PaneTitle.swift */,
 				201F759D378A9A4EC12F40A7 /* WorklaneStore+Reordering.swift */,
 				5362E171051471B00419EB85 /* WorklaneStore+Restore.swift */,
 				D0BE8EC74AF28891DF371409 /* WorklaneStore+ReviewState.swift */,
@@ -1842,6 +1856,7 @@
 				5E316EB04A90576B80F838D9 /* PaneAgentReducerTests.swift */,
 				37F4631D0A8465D807F16977 /* PaneContainerViewTests.swift */,
 				D468A4AAC25D668673CC51CE /* PaneContainerViewWorklaneBorderTests.swift */,
+				9EA2D0CE5BE10DFD7CDB4CBC /* PaneDisplayIdentityResolverTests.swift */,
 				7F6BDCBDE4E090275233D9D3 /* PaneDragHitTestingTests.swift */,
 				286127859CC1D0E1D6E24ECE /* PaneDragPreviewSizingTests.swift */,
 				3EEE5BDE38114E4E80B6C22A /* PaneDragSidebarEdgeScrollDriverTests.swift */,
@@ -1850,6 +1865,7 @@
 				DAA052B6DDCA1EE9D9F58BC0 /* PaneLayoutPreferencesTests.swift */,
 				15FE8B4E43D3F4D0F90BFE83 /* PaneNotificationCoordinatorTests.swift */,
 				017D80D8C20309A5F3A34381 /* PanePresentationStateTests.swift */,
+				52A3D22F97BFF48E29B7A666 /* PaneRenameIPCParserTests.swift */,
 				76857E75C1FF0BD95C889941 /* PaneRuntimeRegistryTests.swift */,
 				CDD7AA3458BBF1FAEFFC158A /* PaneStripMotionControllerTests.swift */,
 				E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */,
@@ -1923,6 +1939,7 @@
 				1A86E5437CA5FE9BF64605D3 /* WorklaneRenameIPCParserTests.swift */,
 				330B23C2AB3C9333615FF1F1 /* WorklaneReviewStateResolverTests.swift */,
 				475875CF8F562326EDD395B9 /* WorklaneSessionEnvironmentTests.swift */,
+				BBFDC162D1B103A8097293EB /* WorklaneSidebarCustomTitleTests.swift */,
 				BF6932CD53AF150CC4656051 /* WorklaneSidebarSummaryTests.swift */,
 				FFA39255E836211E35CAFF5F /* WorklaneState+Testing.swift */,
 				0B7DFA52E9F279C81A803C23 /* WorklaneStoreClosedPaneRestoreTests.swift */,
@@ -1931,6 +1948,7 @@
 				A78A6A6B85882097AFFAE3EE /* WorklaneStoreGitContextTests.swift */,
 				FCCEFAE8FF676F5051157D3E /* WorklaneStoreMetadataVolatileFastPathTests.swift */,
 				E5BD40F90473F37867AB07AF /* WorklaneStoreOpenWithTests.swift */,
+				80C39B34C7E0AF1C0999DDDB /* WorklaneStorePaneTitleTests.swift */,
 				599A5796CE02C9D0701F88B7 /* WorklaneStoreReorderingTests.swift */,
 				630B5B3D8685C9D8A186AC9B /* WorklaneStoreServerTests.swift */,
 				932855A80F09B46E2143378A /* WorklaneStoreShellExitTests.swift */,
@@ -2251,6 +2269,7 @@
 				8E847756B23CB6F02E3897BD /* PaneAgentReducerTests.swift in Sources */,
 				9305DFB3157057C5F774497D /* PaneContainerViewTests.swift in Sources */,
 				BB1BCADC002057CB2A8211ED /* PaneContainerViewWorklaneBorderTests.swift in Sources */,
+				CD53494A66CC5B4B0CDF23BA /* PaneDisplayIdentityResolverTests.swift in Sources */,
 				81AF86AEEA79AD53667ECBE3 /* PaneDragHitTestingTests.swift in Sources */,
 				A7D1705788C04A62E0EC684C /* PaneDragPreviewSizingTests.swift in Sources */,
 				4C3C71DA023EC44853BE4A14 /* PaneDragSidebarEdgeScrollDriverTests.swift in Sources */,
@@ -2259,6 +2278,7 @@
 				4FE322E96C1A232404A28D38 /* PaneLayoutPreferencesTests.swift in Sources */,
 				6288F3AE915459E59B5F2B42 /* PaneNotificationCoordinatorTests.swift in Sources */,
 				1041B5CDF3EA5C978F3580BC /* PanePresentationStateTests.swift in Sources */,
+				26AFF78C52733C2ABCCE4B5C /* PaneRenameIPCParserTests.swift in Sources */,
 				F1E79CD825C39C592E844B63 /* PaneRuntimeRegistryTests.swift in Sources */,
 				74A2DE5A0880B028476E3D8D /* PaneStripMotionControllerTests.swift in Sources */,
 				C1E6E40E7FEAE93149414E37 /* PaneStripStateTests.swift in Sources */,
@@ -2332,6 +2352,7 @@
 				B3EDFD781B2ECD9598AD51ED /* WorklaneRenameIPCParserTests.swift in Sources */,
 				6582FD0B7BCB91F3713E13CD /* WorklaneReviewStateResolverTests.swift in Sources */,
 				3A9A36F98D4A239EC59BF56B /* WorklaneSessionEnvironmentTests.swift in Sources */,
+				F816A0603E61CBBC198F657B /* WorklaneSidebarCustomTitleTests.swift in Sources */,
 				95A3A7116CE13BB739E4C940 /* WorklaneSidebarSummaryTests.swift in Sources */,
 				63EE5118B588FB5B28430AAF /* WorklaneState+Testing.swift in Sources */,
 				37683223FAC33E2284C333DB /* WorklaneStoreClosedPaneRestoreTests.swift in Sources */,
@@ -2340,6 +2361,7 @@
 				D3B45C25D1794724A766C6DA /* WorklaneStoreGitContextTests.swift in Sources */,
 				83951F6CBB1AEE312F1A0D68 /* WorklaneStoreMetadataVolatileFastPathTests.swift in Sources */,
 				31CD1FA7F8E072DCE331BBC6 /* WorklaneStoreOpenWithTests.swift in Sources */,
+				BE15E3FF2C4F6086140D2445 /* WorklaneStorePaneTitleTests.swift in Sources */,
 				0AAC15DA2853AA84E4CCF668 /* WorklaneStoreReorderingTests.swift in Sources */,
 				C9F0082D206C318AE7D98831 /* WorklaneStoreServerTests.swift in Sources */,
 				766C826241E2CACEEB8921EA /* WorklaneStoreShellExitTests.swift in Sources */,
@@ -2486,6 +2508,7 @@
 				840FDF34FA89D7BA5649AF0C /* PaneAuxiliaryState.swift in Sources */,
 				4777880E60AB7C29B7CD2E12 /* PaneCommand.swift in Sources */,
 				3F270AD6399CAA5729853F2D /* PaneContainerView.swift in Sources */,
+				48ECF9EAFA83C8B95CB644E3 /* PaneDisplayIdentityResolver.swift in Sources */,
 				624B1BB94834F08B1F75C877 /* PaneDragCoordinator.swift in Sources */,
 				65ADCFA85CAA56E91E14C014 /* PaneDragEdgeScrollDriver.swift in Sources */,
 				F4EDBFDE9C214BF1696D73C7 /* PaneDragFloatingContainer.swift in Sources */,
@@ -2643,6 +2666,7 @@
 				1221C29E07DBDEFBD68427E3 /* WorklaneStore+Color.swift in Sources */,
 				4BDC36B10F3277FC2645D57F /* WorklaneStore+DragDrop.swift in Sources */,
 				EF1455526F16B4FE4995D467 /* WorklaneStore+Metadata.swift in Sources */,
+				F4066A607FBA2CC7C916B2A3 /* WorklaneStore+PaneTitle.swift in Sources */,
 				53A5FEA4F303782A33EFB427 /* WorklaneStore+Reordering.swift in Sources */,
 				A3B9E7C21732F8FBD1AFF6B4 /* WorklaneStore+Restore.swift in Sources */,
 				23F41140FCDDF143E82EE86C /* WorklaneStore+ReviewState.swift in Sources */,

--- a/Zentty/AppState/Agent/PaneIPCHandler.swift
+++ b/Zentty/AppState/Agent/PaneIPCHandler.swift
@@ -5,6 +5,63 @@ import Foundation
 /// Returns nil when neither `--clear` nor a `--title` value is present.
 /// Tokens are consumed left to right so flag-looking strings in value
 /// position stay values: `--title --clear` names the lane "--clear".
+/// Parses `pane-rename` IPC arguments. `title == nil` means clear.
+/// Target pane uses `--rename-pane-id` (not `--pane-id`, which
+/// `ParsedPaneSelectors` consumes for IPC routing).
+enum PaneRenameIPCParser {
+    struct Parsed: Equatable {
+        var title: String?
+        var worklaneIDOverride: String?
+        var paneIDOverride: String?
+    }
+
+    static func parse(_ arguments: [String]) -> Parsed? {
+        var title: String?
+        var sawTitle = false
+        var sawClear = false
+        var worklaneIDOverride: String?
+        var paneIDOverride: String?
+
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--clear":
+                sawClear = true
+                index += 1
+            case "--title":
+                guard index + 1 < arguments.count else {
+                    return nil
+                }
+                title = arguments[index + 1]
+                sawTitle = true
+                index += 2
+            case "--id":
+                guard index + 1 < arguments.count else {
+                    return nil
+                }
+                worklaneIDOverride = arguments[index + 1]
+                index += 2
+            case "--rename-pane-id":
+                guard index + 1 < arguments.count else {
+                    return nil
+                }
+                paneIDOverride = arguments[index + 1]
+                index += 2
+            default:
+                index += 1
+            }
+        }
+
+        if sawClear {
+            return Parsed(title: nil, worklaneIDOverride: worklaneIDOverride, paneIDOverride: paneIDOverride)
+        }
+        guard sawTitle else {
+            return nil
+        }
+        return Parsed(title: title, worklaneIDOverride: worklaneIDOverride, paneIDOverride: paneIDOverride)
+    }
+}
+
 enum WorklaneRenameIPCParser {
     struct Parsed: Equatable {
         var title: String?
@@ -62,6 +119,7 @@ enum PaneIPCSubcommand: String {
     case notify
     case worklaneColor = "worklane-color"
     case worklaneRename = "worklane-rename"
+    case paneRename = "pane-rename"
     case theme
 }
 
@@ -361,7 +419,7 @@ enum PaneIPCHandler {
         }
 
         if subcommand != .list && subcommand != .worklaneColor && subcommand != .worklaneRename
-            && subcommand != .notify && subcommand != .theme {
+            && subcommand != .paneRename && subcommand != .notify && subcommand != .theme {
             windowController.focusPane(id: target.paneID, in: target.worklaneID)
         }
 
@@ -396,6 +454,13 @@ enum PaneIPCHandler {
             )
         case .worklaneRename:
             return try handleWorklaneRename(
+                arguments: request.arguments,
+                target: target,
+                windowController: windowController,
+                appDelegate: appDelegate
+            )
+        case .paneRename:
+            return try handlePaneRename(
                 arguments: request.arguments,
                 target: target,
                 windowController: windowController,
@@ -576,6 +641,47 @@ enum PaneIPCHandler {
             appDelegate: appDelegate
         )
         _ = resolved.windowController.setWorklaneTitle(parsed.title, on: resolved.worklaneID)
+        return AgentIPCResponseResult()
+    }
+
+    @MainActor
+    private static func handlePaneRename(
+        arguments: [String],
+        target: AgentIPCTarget,
+        windowController: MainWindowController,
+        appDelegate: AppDelegate
+    ) throws -> AgentIPCResponseResult {
+        guard let parsed = PaneRenameIPCParser.parse(arguments) else {
+            return AgentIPCResponseResult()
+        }
+
+        let resolved = try resolveWorklaneCommandTarget(
+            overrideID: parsed.worklaneIDOverride,
+            target: target,
+            callerWindowController: windowController,
+            appDelegate: appDelegate
+        )
+        let paneID: PaneID
+        if let paneIDOverride = parsed.paneIDOverride {
+            guard let resolvedPaneID = resolved.windowController.resolvePaneID(
+                paneIDOverride,
+                in: resolved.worklaneID
+            ) else {
+                throw PaneRoutingError.paneNotFound
+            }
+            paneID = resolvedPaneID
+        } else if parsed.worklaneIDOverride != nil {
+            guard let focusedPaneID = resolved.windowController.focusedPaneID(in: resolved.worklaneID) else {
+                throw PaneRoutingError.paneNotFound
+            }
+            paneID = focusedPaneID
+        } else {
+            paneID = target.paneID
+        }
+        guard resolved.windowController.containsPane(paneID) else {
+            throw PaneRoutingError.paneNotFound
+        }
+        _ = resolved.windowController.setPaneCustomTitle(parsed.title, on: paneID)
         return AgentIPCResponseResult()
     }
 

--- a/Zentty/AppState/PaneDisplayIdentityResolver.swift
+++ b/Zentty/AppState/PaneDisplayIdentityResolver.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+enum PaneDisplayIdentityResolver {
+    static func trimmedCustomTitle(for pane: PaneState) -> String? {
+        WorklaneContextFormatter.trimmed(pane.customTitle)
+    }
+
+    static func hasCustomTitle(for pane: PaneState) -> Bool {
+        trimmedCustomTitle(for: pane) != nil
+    }
+
+    static func borderLabelText(
+        pane: PaneState,
+        presentation: PanePresentationState
+    ) -> String? {
+        if let customTitle = trimmedCustomTitle(for: pane) {
+            return customTitle
+        }
+
+        return WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel)
+    }
+
+    static func primaryLabel(
+        pane: PaneState,
+        presentation: PanePresentationState,
+        metadata: TerminalMetadata?
+    ) -> String? {
+        if let customTitle = trimmedCustomTitle(for: pane) {
+            return customTitle
+        }
+
+        if let sshConnectionLabel = WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel) {
+            return sshConnectionLabel
+        }
+
+        if let recognizedTool = presentation.recognizedTool,
+           let volatileTitle = WorklaneContextFormatter.trimmed(metadata?.title),
+           TerminalMetadataChangeClassifier.isRealtimeAgentStatusTitle(
+               volatileTitle,
+               recognizedTool: recognizedTool
+           ) {
+            return volatileTitle
+        }
+
+        if let rememberedTitle = WorklaneContextFormatter.trimmed(presentation.rememberedTitle) {
+            if let decomposedTitle = decomposedRememberedTitle(
+                rememberedTitle,
+                presentation: presentation
+            ) {
+                return decomposedTitle
+            }
+            return rememberedTitle
+        }
+
+        return nil
+    }
+
+    private static func decomposedRememberedTitle(
+        _ rememberedTitle: String,
+        presentation: PanePresentationState
+    ) -> String? {
+        guard let branch = WorklaneContextFormatter.trimmed(presentation.branchDisplayText) else {
+            return nil
+        }
+
+        for separator in [" · ", " • "] {
+            let prefix = branch + separator
+            if rememberedTitle.hasPrefix(prefix) {
+                return WorklaneContextFormatter.trimmed(String(rememberedTitle.dropFirst(prefix.count)))
+            }
+        }
+
+        return nil
+    }
+}

--- a/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
+++ b/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
@@ -3,7 +3,11 @@ enum WorklaneHeaderSummaryBuilder {
         let focusedPaneContext = worklane.focusedPaneContext
         let presentation = focusedPaneContext?.presentation
         let metadata = focusedPaneContext?.metadata
-        let focusedLabel = visibleFocusedLabel(from: presentation, metadata: metadata)
+        let focusedLabel = visibleFocusedLabel(
+            from: focusedPaneContext?.pane,
+            presentation: presentation,
+            metadata: metadata
+        )
         let remoteContextLabel = visibleRemoteContextLabel(from: presentation)
         let branch = visibleBranch(from: presentation)
 
@@ -21,42 +25,20 @@ enum WorklaneHeaderSummaryBuilder {
     }
 
     private static func visibleFocusedLabel(
-        from presentation: PanePresentationState?,
+        from pane: PaneState?,
+        presentation: PanePresentationState?,
         metadata: TerminalMetadata?
     ) -> String? {
-        if let sshConnectionLabel = WorklaneContextFormatter.trimmed(presentation?.sshConnectionLabel) {
-            return sshConnectionLabel
-        }
-
-        // When the focused codex pane is in a volatile agent status state
-        // (e.g. "Working... (5s) · my-project"), surface the raw codex title
-        // in the chrome so the title bar ticks in realtime alongside the
-        // sidebar row. This mirrors WorklaneSidebarSummaryBuilder.paneIdentity
-        // which also reads metadata?.title directly for codex volatile titles.
-        if let recognizedTool = presentation?.recognizedTool,
-           let volatileTitle = WorklaneContextFormatter.trimmed(metadata?.title),
-           TerminalMetadataChangeClassifier.isRealtimeAgentStatusTitle(
-               volatileTitle,
-               recognizedTool: recognizedTool
+        if let pane, let presentation,
+           let primaryLabel = PaneDisplayIdentityResolver.primaryLabel(
+               pane: pane,
+               presentation: presentation,
+               metadata: metadata
            ) {
-            return volatileTitle
+            return primaryLabel
         }
 
-        guard
-            let presentation,
-            let rememberedTitle = WorklaneContextFormatter.trimmed(presentation.rememberedTitle)
-        else {
-            return presentation.flatMap(visibleFallbackLabel(from:))
-        }
-
-        if let decomposedTitle = decomposedRememberedTitle(
-            rememberedTitle,
-            presentation: presentation
-        ) {
-            return decomposedTitle
-        }
-
-        return rememberedTitle
+        return presentation.flatMap(visibleFallbackLabel(from:))
     }
 
     private static func visibleFallbackLabel(from presentation: PanePresentationState) -> String? {
@@ -108,23 +90,4 @@ enum WorklaneHeaderSummaryBuilder {
         return WorklaneContextFormatter.trimmed(presentation.cwd)
     }
 
-    private static func decomposedRememberedTitle(
-        _ rememberedTitle: String,
-        presentation: PanePresentationState
-    ) -> String? {
-        guard
-            let branch = WorklaneContextFormatter.trimmed(presentation.branchDisplayText)
-        else {
-            return nil
-        }
-
-        for separator in [" · ", " • "] {
-            let prefix = branch + separator
-            if rememberedTitle.hasPrefix(prefix) {
-                return WorklaneContextFormatter.trimmed(String(rememberedTitle.dropFirst(prefix.count)))
-            }
-        }
-
-        return nil
-    }
 }

--- a/Zentty/AppState/WorklaneStore+PaneTitle.swift
+++ b/Zentty/AppState/WorklaneStore+PaneTitle.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+extension WorklaneStore {
+    /// Sets or clears the optional user-visible pane title. The value is
+    /// trimmed; empty or whitespace-only input clears the title (nil).
+    @discardableResult
+    func setPaneCustomTitle(_ title: String?, on paneID: PaneID) -> Bool {
+        let resolved = WorklaneContextFormatter.trimmed(title)
+
+        for worklaneIndex in worklanes.indices {
+            for columnIndex in worklanes[worklaneIndex].paneStripState.columns.indices {
+                guard let paneIndex = worklanes[worklaneIndex].paneStripState.columns[columnIndex].panes
+                    .firstIndex(where: { $0.id == paneID }) else {
+                    continue
+                }
+
+                guard worklanes[worklaneIndex].paneStripState.columns[columnIndex].panes[paneIndex].customTitle
+                    != resolved else {
+                    return false
+                }
+
+                worklanes[worklaneIndex].paneStripState.columns[columnIndex].panes[paneIndex].customTitle = resolved
+                let worklaneID = worklanes[worklaneIndex].id
+                if worklaneID == activeWorklaneID {
+                    activeWorklane = worklanes[worklaneIndex]
+                }
+                notify(.paneStructure(worklaneID))
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/Zentty/AppState/WorklaneStore+Restore.swift
+++ b/Zentty/AppState/WorklaneStore+Restore.swift
@@ -64,6 +64,7 @@ extension WorklaneStore {
             originalColumnWidth: column.width,
             originalHeightInColumn: originalHeightInColumn,
             title: pane.title,
+            customTitle: pane.customTitle,
             workingDirectory: workingDirectory,
             originalNativeCommand: pane.sessionRequest.nativeCommand,
             originalCommand: pane.sessionRequest.command,
@@ -110,6 +111,7 @@ extension WorklaneStore {
         let restoredPane = PaneState(
             id: newPaneID,
             title: entry.title,
+            customTitle: entry.customTitle,
             sessionRequest: sessionRequest,
             width: entry.originalColumnWidth
         )
@@ -166,18 +168,19 @@ extension WorklaneStore {
             return ClosedPaneScrollbackArchive.write(scrollback: text, entryID: entry.id)
         }()
 
+        let displayName = entry.customTitle ?? entry.title
         let runCommand: String?
         let toastBody: String
         switch outcome {
         case .agentResume(let command, let tool, _):
             runCommand = command
-            toastBody = "Restored \"\(entry.title)\" — \(tool.displayName) resuming at \(cwdResolution.path)"
+            toastBody = "Restored \"\(displayName)\" — \(tool.displayName) resuming at \(cwdResolution.path)"
         case .replayCommand(let command):
             runCommand = command
-            toastBody = "Restored \"\(entry.title)\" at \(cwdResolution.path)"
+            toastBody = "Restored \"\(displayName)\" at \(cwdResolution.path)"
         case .plainShell:
             runCommand = nil
-            toastBody = "Restored \"\(entry.title)\" at \(cwdResolution.path)"
+            toastBody = "Restored \"\(displayName)\" at \(cwdResolution.path)"
         }
 
         let toastMessage = cwdResolution.originalMissing

--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -255,11 +255,20 @@ extension WorklaneState {
     }
 
     var paneBorderContextDisplayByPaneID: [PaneID: PaneBorderContextDisplayModel] {
-        auxiliaryStateByPaneID.compactMapValues { auxiliaryState in
-            let borderText = WorklaneContextFormatter.trimmed(auxiliaryState.presentation.sshConnectionLabel)
-                ?? auxiliaryState.shellContext?.borderContextDisplayText
-            return borderText.map { PaneBorderContextDisplayModel(text: $0) }
-        }
+        let panesByID = Dictionary(uniqueKeysWithValues: paneStripState.panes.map { ($0.id, $0) })
+        return Dictionary(uniqueKeysWithValues: auxiliaryStateByPaneID.compactMap { paneID, auxiliaryState in
+            if let pane = panesByID[paneID],
+               let borderText = PaneDisplayIdentityResolver.borderLabelText(
+                   pane: pane,
+                   presentation: auxiliaryState.presentation
+               ) {
+                return (paneID, PaneBorderContextDisplayModel(text: borderText))
+            }
+            guard let borderText = auxiliaryState.shellContext?.borderContextDisplayText else {
+                return nil
+            }
+            return (paneID, PaneBorderContextDisplayModel(text: borderText))
+        })
     }
 
     /// Variant of `paneBorderContextDisplayByPaneID` that flags the recorded

--- a/Zentty/Bookmarks/WorkspaceTemplate.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplate.swift
@@ -66,6 +66,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
 
     struct Pane: Codable, Equatable, Sendable {
         var id: String
+        var customTitle: String? = nil
         var titleSeed: String?
         var workingDirectory: String?
         var command: String?
@@ -74,6 +75,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
 
         init(
             id: String,
+            customTitle: String? = nil,
             titleSeed: String? = nil,
             workingDirectory: String? = nil,
             command: String? = nil,
@@ -81,6 +83,7 @@ struct WorkspaceTemplate: Codable, Equatable, Sendable, Identifiable {
             wasUserEdited: Bool = false
         ) {
             self.id = id
+            self.customTitle = customTitle
             self.titleSeed = titleSeed
             self.workingDirectory = workingDirectory
             self.command = command

--- a/Zentty/Bookmarks/WorkspaceTemplateCapture.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplateCapture.swift
@@ -68,6 +68,7 @@ enum WorkspaceTemplateCapture {
 
         return WorkspaceTemplate.Pane(
             id: pane.id.rawValue,
+            customTitle: trimmed(pane.customTitle),
             titleSeed: trimmed(auxiliary?.presentation.rememberedTitle) ?? trimmed(pane.title),
             workingDirectory: workingDirectory,
             command: detectedCommand(auxiliary: auxiliary, processTreeProvider: processTreeProvider),

--- a/Zentty/Bookmarks/WorkspaceTemplateImporter.swift
+++ b/Zentty/Bookmarks/WorkspaceTemplateImporter.swift
@@ -131,6 +131,7 @@ enum WorkspaceTemplateImporter {
 
         let inputs = PaneRestorationBuilder.PaneInputs(
             id: paneID,
+            customTitle: templatePane.customTitle,
             titleSeed: templatePane.titleSeed,
             lastActivityTitle: nil,
             requestedWorkingDirectory: requested,

--- a/Zentty/Input/KeyboardShortcutResolver.swift
+++ b/Zentty/Input/KeyboardShortcutResolver.swift
@@ -24,6 +24,7 @@ enum AppCommandID: String, CaseIterable, Equatable, Hashable, Sendable {
     case toggleSidebar = "sidebar.toggle"
     case newWorklane = "worklane.new"
     case renameCurrentWorklane = "worklane.rename"
+    case renameCurrentPane = "pane.rename"
     case nextWorklane = "worklane.next"
     case previousWorklane = "worklane.previous"
     case worklaneMoveUp = "worklane.move_up"
@@ -95,6 +96,7 @@ enum AppAction: Equatable, Sendable {
     case toggleSidebar
     case newWorklane
     case renameCurrentWorklane
+    case renameCurrentPane
     case nextWorklane
     case previousWorklane
     case moveWorklaneUp
@@ -230,6 +232,18 @@ enum AppCommandRegistry {
                 section: .file,
                 title: "Rename Worklane\u{2026}",
                 selector: #selector(MainWindowController.renameCurrentWorklane(_:))
+            )
+        ),
+        AppCommandDefinition(
+            id: .renameCurrentPane,
+            title: "Rename Pane\u{2026}",
+            category: .panes,
+            defaultShortcut: nil,
+            action: .renameCurrentPane,
+            menuItem: AppCommandMenuItem(
+                section: .file,
+                title: "Rename Pane\u{2026}",
+                selector: #selector(MainWindowController.renameCurrentPane(_:))
             )
         ),
         AppCommandDefinition(
@@ -876,6 +890,7 @@ enum AppCommandRegistry {
             .command(.newWindow),
             .command(.newWorklane),
             .command(.renameCurrentWorklane),
+            .command(.renameCurrentPane),
             .separator,
             .command(.closeFocusedPane),
             .command(.restoreClosedPane),
@@ -982,6 +997,8 @@ extension AppCommandDefinition {
             "Open a new worklane."
         case .renameCurrentWorklane:
             "Give the active worklane a custom name, or clear it."
+        case .renameCurrentPane:
+            "Give the focused pane a custom name, or clear it."
         case .nextWorklane:
             "Switch to the next worklane."
         case .previousWorklane:

--- a/Zentty/Layout/PaneStripState.swift
+++ b/Zentty/Layout/PaneStripState.swift
@@ -80,18 +80,23 @@ struct PaneMinimumSize: Equatable, Sendable {
 struct PaneState: Equatable, Sendable {
     let id: PaneID
     var title: String
+    /// Optional user-visible pane name. Invariant: either nil or a non-empty
+    /// trimmed string — never empty, never padded.
+    var customTitle: String?
     var sessionRequest: TerminalSessionRequest
     var width: CGFloat
 
     init(
         id: PaneID,
         title: String,
+        customTitle: String? = nil,
         sessionRequest: TerminalSessionRequest = TerminalSessionRequest(),
         width: CGFloat = PaneLayoutPreset.balanced.defaultPaneWidth(
             for: .largeDisplay, viewportWidth: 1280)
     ) {
         self.id = id
         self.title = title
+        self.customTitle = WorklaneContextFormatter.trimmed(customTitle)
         self.sessionRequest = sessionRequest
         self.width = width
     }

--- a/Zentty/MainWindowController.swift
+++ b/Zentty/MainWindowController.swift
@@ -492,6 +492,11 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     }
 
     @objc
+    func renameCurrentPane(_ sender: Any?) {
+        handle(.renameCurrentPane)
+    }
+
+    @objc
     func openBookmarksPopover(_ sender: Any?) {
         handle(.openBookmarksPopover)
     }
@@ -1093,6 +1098,10 @@ final class MainWindowController: NSObject, NSWindowDelegate {
         rootViewController.resolvePaneID(target, in: worklaneID)
     }
 
+    func focusedPaneID(in worklaneID: WorklaneID) -> PaneID? {
+        rootViewController.focusedPaneID(in: worklaneID)
+    }
+
     func focusPane(id: PaneID, in worklaneID: WorklaneID) {
         rootViewController.focusPaneByID(id, in: worklaneID)
     }
@@ -1147,6 +1156,11 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     @discardableResult
     func setWorklaneTitle(_ title: String?, on id: WorklaneID) -> Bool {
         rootViewController.setWorklaneTitle(title, on: id)
+    }
+
+    @discardableResult
+    func setPaneCustomTitle(_ title: String?, on paneID: PaneID) -> Bool {
+        rootViewController.setPaneCustomTitle(title, on: paneID)
     }
 
     func resizeFocusedColumnToFraction(_ fraction: CGFloat) {

--- a/Zentty/Restore/ClosedPaneEntry.swift
+++ b/Zentty/Restore/ClosedPaneEntry.swift
@@ -46,6 +46,8 @@ struct ClosedPaneEntry: Identifiable, Equatable, Sendable {
     /// only one in its column at close (no meaningful intra-column weight).
     let originalHeightInColumn: CGFloat?
     let title: String
+    /// User-visible pane name at close time, if any.
+    let customTitle: String?
     let workingDirectory: String?
     let originalNativeCommand: String?
     let originalCommand: String?
@@ -63,6 +65,7 @@ struct ClosedPaneEntry: Identifiable, Equatable, Sendable {
         originalColumnWidth: CGFloat,
         originalHeightInColumn: CGFloat?,
         title: String,
+        customTitle: String? = nil,
         workingDirectory: String?,
         originalNativeCommand: String?,
         originalCommand: String?,
@@ -79,6 +82,7 @@ struct ClosedPaneEntry: Identifiable, Equatable, Sendable {
         self.originalColumnWidth = originalColumnWidth
         self.originalHeightInColumn = originalHeightInColumn
         self.title = title
+        self.customTitle = WorklaneContextFormatter.trimmed(customTitle)
         self.workingDirectory = workingDirectory
         self.originalNativeCommand = originalNativeCommand
         self.originalCommand = originalCommand

--- a/Zentty/Restore/PaneRestorationBuilder.swift
+++ b/Zentty/Restore/PaneRestorationBuilder.swift
@@ -4,6 +4,7 @@ import Foundation
 enum PaneRestorationBuilder {
     struct PaneInputs: Equatable, Sendable {
         var id: PaneID
+        var customTitle: String? = nil
         var titleSeed: String?
         var lastActivityTitle: String?
         var requestedWorkingDirectory: String?
@@ -89,6 +90,7 @@ enum PaneRestorationBuilder {
         let pane = PaneState(
             id: inputs.id,
             title: title,
+            customTitle: trimmed(inputs.customTitle),
             sessionRequest: TerminalSessionRequest(
                 workingDirectory: resolvedDirectory,
                 command: trimmed(inputs.command),

--- a/Zentty/Restore/WorkspaceRecipe.swift
+++ b/Zentty/Restore/WorkspaceRecipe.swift
@@ -10,9 +10,10 @@ struct WorkspaceRecipe: Codable, Equatable, Sendable {
     /// Schema version 2 marks recipes whose worklane titles are stored
     /// verbatim. Unversioned (nil) recipes predate optional titles and carry
     /// auto-generated "MAIN"/"WS N" junk that gets sanitized once at import.
+    /// Schema version 3 adds optional per-pane `customTitle` fields.
     /// Synthesized Decodable ignores the property default for optionals, so
     /// legacy JSON without the key decodes as nil.
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
 
     var schemaVersion: Int?
     var windows: [Window]
@@ -100,6 +101,7 @@ struct WorkspaceRecipe: Codable, Equatable, Sendable {
 
     struct Pane: Codable, Equatable, Sendable {
         var id: String
+        var customTitle: String? = nil
         var titleSeed: String?
         var workingDirectory: String?
         var lastActivityTitle: String? = nil
@@ -183,6 +185,7 @@ enum WorkspaceRecipeExporter {
 
         return WorkspaceRecipe.Pane(
             id: pane.id.rawValue,
+            customTitle: WorklaneContextFormatter.trimmed(pane.customTitle),
             titleSeed: titleSeed,
             workingDirectory: workingDirectory,
             lastActivityTitle: lastActivityTitle,
@@ -500,6 +503,7 @@ enum WorkspaceRecipeImporter {
 
         let inputs = PaneRestorationBuilder.PaneInputs(
             id: paneID,
+            customTitle: trimmedTitle(recipe.customTitle),
             titleSeed: titleSeed,
             lastActivityTitle: lastActivityTitle,
             requestedWorkingDirectory: recipe.workingDirectory,
@@ -711,6 +715,10 @@ enum WorkspaceRecipeMeaningfulness {
         }
 
         if normalizedPath(pane.workingDirectory) != normalizedPath(defaultWorkingDirectory) {
+            return true
+        }
+
+        if WorklaneContextFormatter.trimmed(pane.customTitle) != nil {
             return true
         }
 

--- a/Zentty/UI/CommandPalette/CommandAvailabilityResolver.swift
+++ b/Zentty/UI/CommandPalette/CommandAvailabilityResolver.swift
@@ -150,6 +150,8 @@ enum CommandAvailabilityResolver {
             return context.worklaneCount > 1
         case .renameCurrentWorklane:
             return context.worklaneCount >= 1
+        case .renameCurrentPane:
+            return context.activePaneCount >= 1
         case .nextWorklane, .previousWorklane:
             // The Worklane Peek handles the single-worklane case (hold opens
             // peek for in-lane pane picking), so keep these available

--- a/Zentty/UI/CommandPalette/CommandPaletteItem.swift
+++ b/Zentty/UI/CommandPalette/CommandPaletteItem.swift
@@ -255,6 +255,7 @@ enum CommandPaletteItemBuilder {
                     worklane.title,
                     worklaneTitle,
                     pane.title,
+                    pane.customTitle,
                     presentation.cwd,
                     presentation.repoRoot,
                     presentation.branch,
@@ -275,6 +276,7 @@ enum CommandPaletteItemBuilder {
                     worklane.title,
                     worklaneTitle,
                     pane.title,
+                    pane.customTitle,
                     presentation.cwd,
                     presentation.repoRoot,
                     presentation.branch,
@@ -446,7 +448,8 @@ enum CommandPaletteItemBuilder {
     }
 
     private static func paneTitle(pane: PaneState, presentation: PanePresentationState) -> String {
-        WorklaneContextFormatter.trimmed(presentation.rememberedTitle)
+        WorklaneContextFormatter.trimmed(pane.customTitle)
+            ?? WorklaneContextFormatter.trimmed(presentation.rememberedTitle)
             ?? WorklaneContextFormatter.trimmed(presentation.visibleIdentityText)
             ?? WorklaneContextFormatter.trimmed(presentation.contextText)
             ?? WorklaneContextFormatter.trimmed(pane.title)

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -960,6 +960,10 @@ final class RootViewController: NSViewController {
         sidebarView.onRenameWorklaneRequested = { [weak self] worklaneID in
             self?.beginRenameWorklane(id: worklaneID)
         }
+        sidebarView.onRenamePaneRequested = { [weak self] worklaneID, paneID in
+            self?.worklaneStore.selectWorklaneAndFocusPane(worklaneID: worklaneID, paneID: paneID)
+            self?.beginRenamePane(id: paneID)
+        }
         sidebarView.onClosePaneRequested = { [weak self] worklaneID, paneID in
             guard let self else { return }
             if self.configStore.current.confirmations.confirmBeforeClosingPane,
@@ -1359,6 +1363,8 @@ final class RootViewController: NSViewController {
             worklaneStore.createWorklane()
         case .renameCurrentWorklane:
             beginRenameActiveWorklane()
+        case .renameCurrentPane:
+            beginRenameActivePane()
         case .nextWorklane:
             peekController.handleTab(forward: true)
         case .previousWorklane:
@@ -2647,6 +2653,10 @@ final class RootViewController: NSViewController {
         worklaneStore.worklanes.contains { $0.id == worklaneID }
     }
 
+    func focusedPaneID(in worklaneID: WorklaneID) -> PaneID? {
+        worklaneStore.worklanes.first { $0.id == worklaneID }?.paneStripState.focusedPaneID
+    }
+
     func containsPane(worklaneID: WorklaneID, paneID: PaneID) -> Bool {
         worklaneStore.worklanes.contains { worklane in
             worklane.id == worklaneID
@@ -2776,6 +2786,11 @@ final class RootViewController: NSViewController {
     @discardableResult
     func setWorklaneTitle(_ title: String?, on id: WorklaneID) -> Bool {
         worklaneStore.setTitle(title, on: id)
+    }
+
+    @discardableResult
+    func setPaneCustomTitle(_ title: String?, on paneID: PaneID) -> Bool {
+        worklaneStore.setPaneCustomTitle(title, on: paneID)
     }
 
     func resizeFocusedColumnToFraction(_ fraction: CGFloat) {
@@ -3149,7 +3164,7 @@ final class RootViewController: NSViewController {
                         index: index,
                         id: pane.id.rawValue,
                         column: columnIndex + 1,
-                        title: pane.title,
+                        title: WorklaneContextFormatter.trimmed(pane.customTitle) ?? pane.title,
                         workingDirectory: auxiliaryState?.shellContext?.path,
                         isFocused: isFocused,
                         agentTool: auxiliaryState?.agentStatus?.tool.displayName,
@@ -3171,7 +3186,9 @@ final class RootViewController: NSViewController {
                     worklaneID: worklane.id,
                     worklaneTitle: worklane.title ?? "Worklane \(worklaneIndex + 1)",
                     paneID: pane.id,
-                    paneTitle: auxiliaryState?.presentation.visibleIdentityText ?? pane.title,
+                    paneTitle: WorklaneContextFormatter.trimmed(pane.customTitle)
+                        ?? auxiliaryState?.presentation.visibleIdentityText
+                        ?? pane.title,
                     statusText: taskManagerStatusText(for: auxiliaryState),
                     rootPID: auxiliaryState?.raw.paneRootPID,
                     isRemote: auxiliaryState?.shellContext?.scope == .remote,
@@ -3879,6 +3896,37 @@ private extension RootViewController {
 
     private func beginRenameActiveWorklane() {
         beginRenameWorklane(id: worklaneStore.activeWorklaneID)
+    }
+
+    private func beginRenameActivePane() {
+        guard let paneID = worklaneStore.activeWorklane?.paneStripState.focusedPaneID else {
+            return
+        }
+        beginRenamePane(id: paneID)
+    }
+
+    func beginRenamePane(id paneID: PaneID) {
+        guard let window = view.window else {
+            return
+        }
+        let pane = worklaneStore.worklanes
+            .flatMap(\.paneStripState.panes)
+            .first(where: { $0.id == paneID })
+        let alert = NSAlert()
+        alert.messageText = "Rename Pane"
+        alert.informativeText = "Leave empty to remove the name."
+        alert.alertStyle = .informational
+        let textField = NSTextField(string: pane?.customTitle ?? "")
+        textField.frame = NSRect(x: 0, y: 0, width: 240, height: 24)
+        alert.accessoryView = textField
+        alert.window.initialFirstResponder = textField
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard response == .alertFirstButtonReturn else { return }
+            self?.worklaneStore.setPaneCustomTitle(textField.stringValue, on: paneID)
+        }
+        textField.selectText(nil)
     }
 
     func beginRenameWorklane(id worklaneID: WorklaneID) {

--- a/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
@@ -74,6 +74,7 @@ struct SidebarWorklaneContextMenuContext {
 struct SidebarWorklaneContextMenuActions {
     var target: AnyObject
     var runRestoredCommandAction: Selector?
+    var renamePaneAction: Selector?
     var renameWorklaneAction: Selector
     var closeWorklaneAction: Selector
     var closePaneAction: Selector?
@@ -188,6 +189,20 @@ enum SidebarWorklaneContextMenu {
             item.toolTip = restoredCommand
             menu.addItem(item)
             menu.addItem(.separator())
+        }
+
+        if case .paneRow = context.origin,
+           let renamePaneAction = actions.renamePaneAction
+        {
+            menu.addItem(
+                SidebarContextMenu.item(
+                    title: "Rename Pane\u{2026}",
+                    action: renamePaneAction,
+                    target: actions.target,
+                    symbolName: "character.cursor.ibeam",
+                    fallbackSymbolName: "pencil"
+                )
+            )
         }
 
         menu.addItem(
@@ -522,6 +537,7 @@ final class SidebarPaneRowButton: NSButton {
     var onHoverChanged: ((Bool) -> Void)?
     var onCloseWorklane: (() -> Void)?
     var onRenameWorklane: (() -> Void)?
+    var onRenamePane: ((PaneID) -> Void)?
     var onClosePane: ((PaneID) -> Void)?
     var onSplitHorizontal: ((PaneID) -> Void)?
     var onSplitVertical: ((PaneID) -> Void)?
@@ -797,6 +813,7 @@ final class SidebarPaneRowButton: NSButton {
             actions: SidebarWorklaneContextMenuActions(
                 target: self,
                 runRestoredCommandAction: #selector(handleRunRestoredCommand),
+                renamePaneAction: #selector(handleRenamePane),
                 renameWorklaneAction: #selector(handleRenameWorklane),
                 closeWorklaneAction: #selector(handleCloseWorklane),
                 closePaneAction: #selector(handleClosePane),
@@ -821,6 +838,10 @@ final class SidebarPaneRowButton: NSButton {
 
     @objc private func handleCloseWorklane() {
         onCloseWorklane?()
+    }
+
+    @objc private func handleRenamePane() {
+        onRenamePane?(paneID)
     }
 
     @objc private func handleRenameWorklane() {

--- a/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
@@ -6,6 +6,7 @@ final class SidebarPaneRowRenderer {
         var onPaneSelected: ((PaneID) -> Void)?
         var onCloseWorklaneRequested: (() -> Void)?
         var onRenameWorklaneRequested: (() -> Void)?
+        var onRenamePaneRequested: ((PaneID) -> Void)?
         var onClosePaneRequested: ((PaneID) -> Void)?
         var onSplitHorizontalRequested: ((PaneID) -> Void)?
         var onSplitVerticalRequested: ((PaneID) -> Void)?
@@ -115,6 +116,7 @@ final class SidebarPaneRowRenderer {
             button.onPaneClicked = callbacks.onPaneSelected
             button.onCloseWorklane = callbacks.onCloseWorklaneRequested
             button.onRenameWorklane = callbacks.onRenameWorklaneRequested
+            button.onRenamePane = callbacks.onRenamePaneRequested
             button.onClosePane = callbacks.onClosePaneRequested
             button.onSplitHorizontal = callbacks.onSplitHorizontalRequested
             button.onSplitVertical = callbacks.onSplitVerticalRequested

--- a/Zentty/UI/Sidebar/SidebarView.swift
+++ b/Zentty/UI/Sidebar/SidebarView.swift
@@ -197,6 +197,7 @@ final class SidebarView: NSView {
     var onPaneSelected: ((WorklaneID, PaneID) -> Void)?
     var onCloseWorklaneRequested: ((WorklaneID) -> Void)?
     var onRenameWorklaneRequested: ((WorklaneID) -> Void)?
+    var onRenamePaneRequested: ((WorklaneID, PaneID) -> Void)?
     var onClosePaneRequested: ((WorklaneID, PaneID) -> Void)?
     var onSplitHorizontalRequested: ((WorklaneID, PaneID) -> Void)?
     var onSplitVerticalRequested: ((WorklaneID, PaneID) -> Void)?
@@ -672,6 +673,9 @@ final class SidebarView: NSView {
         }
         button.onRenameWorklaneRequested = { [weak self] in
             self?.onRenameWorklaneRequested?(worklaneID)
+        }
+        button.onRenamePaneRequested = { [weak self] paneID in
+            self?.onRenamePaneRequested?(worklaneID, paneID)
         }
         button.onClosePaneRequested = { [weak self] paneID in
             self?.onClosePaneRequested?(worklaneID, paneID)

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -75,6 +75,7 @@ final class SidebarWorklaneRowButton: NSButton {
     var onPaneSelected: ((PaneID) -> Void)?
     var onCloseWorklaneRequested: (() -> Void)?
     var onRenameWorklaneRequested: (() -> Void)?
+    var onRenamePaneRequested: ((PaneID) -> Void)?
     var onClosePaneRequested: ((PaneID) -> Void)?
     var onSplitHorizontalRequested: ((PaneID) -> Void)?
     var onSplitVerticalRequested: ((PaneID) -> Void)?
@@ -757,6 +758,9 @@ final class SidebarWorklaneRowButton: NSButton {
                 },
                 onRenameWorklaneRequested: { [weak self] in
                     self?.onRenameWorklaneRequested?()
+                },
+                onRenamePaneRequested: { [weak self] paneID in
+                    self?.onRenamePaneRequested?(paneID)
                 },
                 onClosePaneRequested: { [weak self] paneID in
                     self?.onClosePaneRequested?(paneID)

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
@@ -18,6 +18,7 @@ struct WorklaneSidebarServerPort: Equatable {
 struct WorklaneSidebarPaneRow: Equatable {
     let paneID: PaneID
     let primaryText: String
+    let usesCustomTitle: Bool
     let trailingText: String?
     let detailText: String?
     let statusText: String?
@@ -34,6 +35,7 @@ struct WorklaneSidebarPaneRow: Equatable {
     init(
         paneID: PaneID,
         primaryText: String,
+        usesCustomTitle: Bool = false,
         trailingText: String?,
         detailText: String?,
         statusText: String?,
@@ -49,6 +51,7 @@ struct WorklaneSidebarPaneRow: Equatable {
     ) {
         self.paneID = paneID
         self.primaryText = primaryText
+        self.usesCustomTitle = usesCustomTitle
         self.trailingText = trailingText
         self.detailText = detailText
         self.statusText = statusText

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
@@ -36,12 +36,6 @@ enum WorklaneSidebarSummaryBuilder {
         let isCwdDerived: Bool
     }
 
-    private struct PaneSidebarIdentity {
-        let primaryText: String
-        let trailingText: String?
-        let detailText: String?
-    }
-
     private enum PaneIdentityStyle {
         case worklaneSummary
         case paneRow
@@ -252,6 +246,7 @@ enum WorklaneSidebarSummaryBuilder {
             let isFocused = focusedPaneID == paneContext.paneID
             let statusPresentation = paneSidebarStatusPresentation(for: paneContext.presentation)
             let paneIdentity = paneIdentity(
+                pane: paneContext.pane,
                 metadata: paneContext.metadata,
                 for: paneContext.presentation,
                 isSinglePane: isSinglePane,
@@ -262,6 +257,7 @@ enum WorklaneSidebarSummaryBuilder {
             return WorklaneSidebarPaneRow(
                 paneID: paneContext.paneID,
                 primaryText: paneIdentity.primaryText,
+                usesCustomTitle: paneIdentity.usesCustomTitle,
                 trailingText: paneIdentity.trailingText,
                 detailText: paneIdentity.detailText,
                 statusText: statusPresentation.statusText,
@@ -456,6 +452,7 @@ enum WorklaneSidebarSummaryBuilder {
     ) -> WorklaneSidebarIdentity? {
         let presentation = paneContext.presentation
         let paneIdentity = paneIdentity(
+            pane: paneContext.pane,
             metadata: paneContext.metadata,
             for: presentation,
             isSinglePane: isSinglePane,
@@ -468,17 +465,48 @@ enum WorklaneSidebarSummaryBuilder {
             paneID: paneContext.paneID,
             primaryText: primaryText,
             cwdPath: presentation.cwd,
-            isCwdDerived: primaryText == compactSidebarContextText(for: presentation)
+            isCwdDerived: !paneIdentity.usesCustomTitle
+                && primaryText == compactSidebarContextText(for: presentation)
         )
     }
 
+    private struct PaneSidebarIdentity {
+        let primaryText: String
+        let trailingText: String?
+        let detailText: String?
+        let usesCustomTitle: Bool
+    }
+
     private static func paneIdentity(
+        pane: PaneState,
         metadata: TerminalMetadata?,
         for presentation: PanePresentationState,
         isSinglePane: Bool,
         style: PaneIdentityStyle,
         fallbackTitle: String?
     ) -> PaneSidebarIdentity {
+        let branch = presentation.branchDisplayText
+        let workingDirectory = compactWorkingDirectory(for: presentation)
+        let lastActivityDetail = lastActivityDetailText(for: presentation)
+
+        if let customTitle = PaneDisplayIdentityResolver.trimmedCustomTitle(for: pane) {
+            if presentation.isRemoteShell {
+                return PaneSidebarIdentity(
+                    primaryText: customTitle,
+                    trailingText: WorklaneContextFormatter.trimmed(presentation.remoteHostLabel),
+                    detailText: WorklaneContextFormatter.trimmed(presentation.remotePathLabel),
+                    usesCustomTitle: true
+                )
+            }
+
+            return PaneSidebarIdentity(
+                primaryText: customTitle,
+                trailingText: branch,
+                detailText: workingDirectory,
+                usesCustomTitle: true
+            )
+        }
+
         if presentation.isRemoteShell {
             return remotePaneIdentity(
                 metadata: metadata,
@@ -491,13 +519,10 @@ enum WorklaneSidebarSummaryBuilder {
             return PaneSidebarIdentity(
                 primaryText: sshConnectionLabel,
                 trailingText: nil,
-                detailText: nil
+                detailText: nil,
+                usesCustomTitle: false
             )
         }
-
-        let branch = presentation.branchDisplayText
-        let workingDirectory = compactWorkingDirectory(for: presentation)
-        let lastActivityDetail = lastActivityDetailText(for: presentation)
 
         if let recognizedTool = presentation.recognizedTool,
            let volatileTitle = WorklaneContextFormatter.trimmed(metadata?.title),
@@ -508,7 +533,8 @@ enum WorklaneSidebarSummaryBuilder {
             return PaneSidebarIdentity(
                 primaryText: volatileTitle,
                 trailingText: branch,
-                detailText: workingDirectory
+                detailText: workingDirectory,
+                usesCustomTitle: false
             )
         }
 
@@ -517,14 +543,16 @@ enum WorklaneSidebarSummaryBuilder {
                 return PaneSidebarIdentity(
                     primaryText: rememberedTitle,
                     trailingText: branch,
-                    detailText: workingDirectory
+                    detailText: workingDirectory,
+                    usesCustomTitle: false
                 )
             }
 
             return PaneSidebarIdentity(
                 primaryText: rememberedTitle,
                 trailingText: branch,
-                detailText: workingDirectory
+                detailText: workingDirectory,
+                usesCustomTitle: false
             )
         }
 
@@ -533,14 +561,16 @@ enum WorklaneSidebarSummaryBuilder {
                 return PaneSidebarIdentity(
                     primaryText: workingDirectory,
                     trailingText: branch,
-                    detailText: lastActivityDetail
+                    detailText: lastActivityDetail,
+                    usesCustomTitle: false
                 )
             }
 
             return PaneSidebarIdentity(
                 primaryText: isSinglePane ? "\(branch) · \(workingDirectory)" : "\(branch) • \(workingDirectory)",
                 trailingText: nil,
-                detailText: nil
+                detailText: nil,
+                usesCustomTitle: false
             )
         }
 
@@ -548,7 +578,8 @@ enum WorklaneSidebarSummaryBuilder {
             return PaneSidebarIdentity(
                 primaryText: branch,
                 trailingText: nil,
-                detailText: style == .paneRow ? lastActivityDetail : nil
+                detailText: style == .paneRow ? lastActivityDetail : nil,
+                usesCustomTitle: false
             )
         }
 
@@ -556,14 +587,16 @@ enum WorklaneSidebarSummaryBuilder {
             return PaneSidebarIdentity(
                 primaryText: workingDirectory,
                 trailingText: nil,
-                detailText: style == .paneRow ? lastActivityDetail : nil
+                detailText: style == .paneRow ? lastActivityDetail : nil,
+                usesCustomTitle: false
             )
         }
 
         return PaneSidebarIdentity(
             primaryText: WorklaneContextFormatter.normalizeSidebarFallbackTitle(fallbackTitle) ?? "Shell",
             trailingText: nil,
-            detailText: style == .paneRow ? lastActivityDetail : nil
+            detailText: style == .paneRow ? lastActivityDetail : nil,
+            usesCustomTitle: false
         )
     }
 
@@ -592,7 +625,8 @@ enum WorklaneSidebarSummaryBuilder {
             return PaneSidebarIdentity(
                 primaryText: primaryText.isEmpty ? title : primaryText,
                 trailingText: nil,
-                detailText: path
+                detailText: path,
+                usesCustomTitle: false
             )
         }
 
@@ -601,7 +635,8 @@ enum WorklaneSidebarSummaryBuilder {
                 ?? WorklaneContextFormatter.normalizeSidebarFallbackTitle(fallbackTitle)
                 ?? "Shell",
             trailingText: nil,
-            detailText: nil
+            detailText: nil,
+            usesCustomTitle: false
         )
     }
 

--- a/Zentty/UI/WorklaneRenderCoordinator.swift
+++ b/Zentty/UI/WorklaneRenderCoordinator.swift
@@ -228,6 +228,8 @@ final class WorklaneRenderCoordinator {
     ) {
         guard let views,
               let worklane = worklaneStore.worklanes.first(where: { $0.id == worklaneID }),
+              let pane = worklane.paneStripState.panes.first(where: { $0.id == paneID }),
+              PaneDisplayIdentityResolver.hasCustomTitle(for: pane) == false,
               let metadata = worklane.auxiliaryStateByPaneID[paneID]?.metadata,
               let titleText = WorklaneContextFormatter.trimmed(metadata.title)
         else {

--- a/ZenttyCLI/ZenttyCLI.swift
+++ b/ZenttyCLI/ZenttyCLI.swift
@@ -616,6 +616,7 @@ struct PaneCommandGroup: ParsableCommand {
             PaneListCommand.self,
             PaneFocusCommand.self,
             PaneCloseCommand.self,
+            PaneRenameCommand.self,
             PaneZoomCommand.self,
             PaneResizeCommand.self,
         ]
@@ -666,6 +667,49 @@ struct PaneFocusCommand: ParsableCommand {
         }
         arguments += selection.selectorArguments()
         _ = try PaneIPC.send(subcommand: "focus", arguments: arguments)
+    }
+}
+
+struct PaneRenameCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rename",
+        abstract: "Set or clear the optional title of a pane.",
+        discussion: "The title replaces cwd-derived labels in the sidebar, titlebar, and pane border. Use --clear to remove it."
+    )
+
+    @Argument(help: "New pane title. Omit when using --clear.")
+    var title: String?
+
+    @Option(help: "Target a specific pane ID (defaults to the calling pane).")
+    var paneID: String?
+
+    @Option(help: "Target a specific worklane (defaults to the calling pane's worklane).")
+    var worklaneID: String?
+
+    @Flag(help: "Clear the pane title.")
+    var clear: Bool = false
+
+    mutating func run() throws {
+        if clear, title != nil {
+            throw ValidationError("Provide either a title or --clear, not both.")
+        }
+        var arguments: [String]
+        if clear {
+            arguments = ["--clear"]
+        } else if let title {
+            arguments = ["--title", title]
+        } else {
+            throw ValidationError("Missing title. Provide a title or use --clear.")
+        }
+        if let paneID {
+            // Use a handler-specific flag so ParsedPaneSelectors does not treat
+            // the rename target as the caller's IPC routing selector.
+            arguments.append(contentsOf: ["--rename-pane-id", paneID])
+        }
+        if let worklaneID {
+            arguments.append(contentsOf: ["--id", worklaneID])
+        }
+        _ = try PaneIPC.send(subcommand: "pane-rename", arguments: arguments)
     }
 }
 

--- a/ZenttyLogicTests/PaneDisplayIdentityResolverTests.swift
+++ b/ZenttyLogicTests/PaneDisplayIdentityResolverTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Zentty
+
+final class PaneDisplayIdentityResolverTests: XCTestCase {
+    func test_primaryLabel_prefers_custom_title_over_cwd_and_remembered_title() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: "Nimbu API")
+        let presentation = PanePresentationState(
+            cwd: "/Users/peter/proj/nimbu",
+            branchDisplayText: "main",
+            identityText: "nimbu",
+            contextText: "main · nimbu",
+            rememberedTitle: "Improve command palette"
+        )
+
+        XCTAssertEqual(
+            PaneDisplayIdentityResolver.primaryLabel(pane: pane, presentation: presentation, metadata: nil),
+            "Nimbu API"
+        )
+    }
+
+    func test_primaryLabel_custom_title_wins_over_volatile_agent_title() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: "Nimbu API")
+        let presentation = PanePresentationState(
+            rememberedTitle: "Improve command palette",
+            recognizedTool: .codex
+        )
+        let metadata = TerminalMetadata(title: "Working... (5s) · my-project")
+
+        XCTAssertEqual(
+            PaneDisplayIdentityResolver.primaryLabel(pane: pane, presentation: presentation, metadata: metadata),
+            "Nimbu API"
+        )
+    }
+
+    func test_primaryLabel_custom_title_wins_over_inferred_ssh_label() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: "Nimbu API")
+        let presentation = PanePresentationState(
+            cwd: "/srv/nimbu",
+            sshConnectionLabel: "deploy@api.example.com"
+        )
+
+        XCTAssertEqual(
+            PaneDisplayIdentityResolver.primaryLabel(pane: pane, presentation: presentation, metadata: nil),
+            "Nimbu API"
+        )
+    }
+
+    func test_borderLabelText_uses_custom_title() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: "Nimbu API")
+        let presentation = PanePresentationState(cwd: "/Users/peter/proj/nimbu")
+
+        XCTAssertEqual(
+            PaneDisplayIdentityResolver.borderLabelText(pane: pane, presentation: presentation),
+            "Nimbu API"
+        )
+    }
+
+    func test_hasCustomTitle_is_false_when_cleared() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: nil)
+        XCTAssertFalse(PaneDisplayIdentityResolver.hasCustomTitle(for: pane))
+    }
+}

--- a/ZenttyLogicTests/PaneRenameIPCParserTests.swift
+++ b/ZenttyLogicTests/PaneRenameIPCParserTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Zentty
+
+final class PaneRenameIPCParserTests: XCTestCase {
+    func test_parse_title() {
+        let parsed = PaneRenameIPCParser.parse(["--title", "Nimbu API"])
+        XCTAssertEqual(parsed, PaneRenameIPCParser.Parsed(title: "Nimbu API", worklaneIDOverride: nil, paneIDOverride: nil))
+    }
+
+    func test_parse_clear() {
+        let parsed = PaneRenameIPCParser.parse(["--clear"])
+        XCTAssertEqual(parsed, PaneRenameIPCParser.Parsed(title: nil, worklaneIDOverride: nil, paneIDOverride: nil))
+    }
+
+    func test_parse_with_overrides() {
+        XCTAssertEqual(
+            PaneRenameIPCParser.parse(["--title", "Docs", "--id", "wl_a", "--rename-pane-id", "pn_a"]),
+            PaneRenameIPCParser.Parsed(title: "Docs", worklaneIDOverride: "wl_a", paneIDOverride: "pn_a")
+        )
+        XCTAssertEqual(
+            PaneRenameIPCParser.parse(["--clear", "--rename-pane-id", "pn_b"]),
+            PaneRenameIPCParser.Parsed(title: nil, worklaneIDOverride: nil, paneIDOverride: "pn_b")
+        )
+    }
+
+    func test_parse_clear_wins_over_title() {
+        let parsed = PaneRenameIPCParser.parse(["--clear", "--title", "ignored"])
+        XCTAssertEqual(parsed?.title, nil)
+    }
+
+    func test_parse_rejects_invalid_arguments() {
+        XCTAssertNil(PaneRenameIPCParser.parse([]))
+        XCTAssertNil(PaneRenameIPCParser.parse(["--title"]))
+        XCTAssertNil(PaneRenameIPCParser.parse(["--rename-pane-id", "pn_a"]))
+        XCTAssertNil(PaneRenameIPCParser.parse(["--title", "Docs", "--rename-pane-id"]))
+    }
+
+    func test_parse_ignores_reserved_pane_selector_flag() {
+        // `--pane-id` is consumed by ParsedPaneSelectors before handler args
+        // reach PaneRenameIPCParser; it must not be treated as a rename target.
+        XCTAssertEqual(
+            PaneRenameIPCParser.parse(["--title", "Docs", "--pane-id", "pn_a"]),
+            PaneRenameIPCParser.Parsed(title: "Docs", worklaneIDOverride: nil, paneIDOverride: nil)
+        )
+    }
+}

--- a/ZenttyLogicTests/SessionRestoreStoreTests.swift
+++ b/ZenttyLogicTests/SessionRestoreStoreTests.swift
@@ -418,6 +418,21 @@ final class SessionRestoreStoreTests: XCTestCase {
         )
     }
 
+    func test_meaningfulness_classifier_treats_custom_pane_title_as_meaningful() {
+        var recipe = makeDefaultWorkspaceRecipe(
+            title: nil,
+            schemaVersion: WorkspaceRecipe.currentSchemaVersion
+        )
+        recipe.windows[0].worklanes[0].columns[0].panes[0].customTitle = "Nimbu API"
+
+        XCTAssertTrue(
+            WorkspaceRecipeMeaningfulness.isMeaningful(
+                recipe,
+                defaultWorkingDirectory: "/Users/peter"
+            )
+        )
+    }
+
     func test_meaningfulness_classifier_treats_titles_schema_aware() {
         // Legacy recipes carry auto-generated "MAIN"/"WS N" junk — not meaningful.
         let legacyJunk = makeDefaultWorkspaceRecipe(title: "MAIN", schemaVersion: nil)

--- a/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
+++ b/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
@@ -323,6 +323,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         XCTAssertEqual(
             menuTitles(menu),
             [
+                "Rename Pane…",
                 "Rename Worklane…",
                 "Close Worklane",
                 "Move Worklane Up",
@@ -408,6 +409,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         XCTAssertEqual(
             menuTitles(menu),
             [
+                "Rename Pane…",
                 "Rename Worklane…",
                 "Close Worklane",
                 "Close Pane",

--- a/ZenttyLogicTests/WorklaneSidebarCustomTitleTests.swift
+++ b/ZenttyLogicTests/WorklaneSidebarCustomTitleTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class WorklaneSidebarCustomTitleTests: XCTestCase {
+    func test_summary_uses_custom_title_as_primary_and_cwd_as_detail() throws {
+        let paneID = PaneID("pn_a")
+        let auxiliary = PaneAuxiliaryState(
+            raw: PaneRawState(
+                shellContext: PaneShellContext(
+                    scope: .local,
+                    path: "/Users/peter/proj/nimbu",
+                    home: "/Users/peter",
+                    user: "peter",
+                    host: nil
+                )
+            )
+        )
+        let worklane = WorklaneState(
+            id: WorklaneID("wl_a"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [
+                    PaneState(
+                        id: paneID,
+                        title: "shell",
+                        customTitle: "Nimbu API"
+                    ),
+                ],
+                focusedPaneID: paneID
+            ),
+            auxiliaryStateByPaneID: [paneID: auxiliary]
+        )
+
+        let summary = WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true)
+        let paneRow = try XCTUnwrap(summary.paneRows.first)
+
+        XCTAssertEqual(paneRow.primaryText, "Nimbu API")
+        XCTAssertTrue(paneRow.usesCustomTitle)
+        XCTAssertNotNil(paneRow.detailText)
+    }
+
+    func test_summary_uses_custom_title_as_primary_for_remote_shell() throws {
+        let paneID = PaneID("pn_remote")
+        let auxiliary = PaneAuxiliaryState(
+            presentation: PanePresentationState(
+                rememberedTitle: "ssh",
+                isRemoteShell: true,
+                remoteHostLabel: "api.example.com",
+                remotePathLabel: "/srv/nimbu",
+                remoteLocationLabel: "api.example.com:/srv/nimbu"
+            )
+        )
+        let worklane = WorklaneState(
+            id: WorklaneID("wl_remote"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [
+                    PaneState(
+                        id: paneID,
+                        title: "shell",
+                        customTitle: "Nimbu API"
+                    ),
+                ],
+                focusedPaneID: paneID
+            ),
+            auxiliaryStateByPaneID: [paneID: auxiliary]
+        )
+
+        let summary = WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true)
+        let paneRow = try XCTUnwrap(summary.paneRows.first)
+
+        XCTAssertEqual(summary.primaryText, "Nimbu API")
+        XCTAssertEqual(paneRow.primaryText, "Nimbu API")
+        XCTAssertEqual(paneRow.trailingText, "api.example.com")
+        XCTAssertEqual(paneRow.detailText, "/srv/nimbu")
+        XCTAssertTrue(paneRow.usesCustomTitle)
+    }
+}

--- a/ZenttyLogicTests/WorklaneStoreClosedPaneRestoreTests.swift
+++ b/ZenttyLogicTests/WorklaneStoreClosedPaneRestoreTests.swift
@@ -63,6 +63,30 @@ final class WorklaneStoreClosedPaneRestoreTests: XCTestCase {
         XCTAssertEqual(store.closedPaneStack.count, 0)
     }
 
+    func test_user_close_captures_custom_title_on_stack_entry() throws {
+        let store = makeMultiPaneStore()
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        _ = store.setPaneCustomTitle("Nimbu API", on: paneID)
+
+        _ = store.closePane(id: paneID)
+
+        XCTAssertEqual(store.closedPaneStack.peek()?.customTitle, "Nimbu API")
+    }
+
+    func test_restored_pane_preserves_custom_title() throws {
+        let store = makeMultiPaneStore()
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+        _ = store.setPaneCustomTitle("Nimbu API", on: paneID)
+
+        _ = store.closePane(id: paneID)
+        let result = try XCTUnwrap(store.restoreClosedPane())
+
+        let restored = try XCTUnwrap(
+            store.activeWorklane?.paneStripState.panes.first(where: { $0.id == result.restoredPaneID })
+        )
+        XCTAssertEqual(restored.customTitle, "Nimbu API")
+    }
+
     func test_restore_inserts_a_pane_back_into_active_worklane() throws {
         let store = makeMultiPaneStore()
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)

--- a/ZenttyLogicTests/WorklaneStorePaneTitleTests.swift
+++ b/ZenttyLogicTests/WorklaneStorePaneTitleTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class WorklaneStorePaneTitleTests: XCTestCase {
+    private func makeStore() -> WorklaneStore {
+        let store = WorklaneStore()
+        let paneA = PaneID("pn_a")
+        let paneB = PaneID("pn_b")
+        store.replaceWorklanes([
+            WorklaneState(
+                id: WorklaneID("wl_a"),
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: paneA, title: "shell")],
+                    focusedPaneID: paneA
+                )
+            ),
+            WorklaneState(
+                id: WorklaneID("wl_b"),
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: paneB, title: "shell")],
+                    focusedPaneID: paneB
+                )
+            ),
+        ])
+        return store
+    }
+
+    func test_setPaneCustomTitle_mutates_targeted_pane_only_and_emits_change() {
+        let store = makeStore()
+        var received: [WorklaneChange] = []
+        let subscription = store.subscribe { received.append($0) }
+        addTeardownBlock { store.unsubscribe(subscription) }
+
+        let applied = store.setPaneCustomTitle("Nimbu API", on: PaneID("pn_a"))
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(
+            store.worklanes.first { $0.id == WorklaneID("wl_a") }?
+                .paneStripState.panes.first?.customTitle,
+            "Nimbu API"
+        )
+        XCTAssertNil(
+            store.worklanes.first { $0.id == WorklaneID("wl_b") }?
+                .paneStripState.panes.first?.customTitle
+        )
+        XCTAssertTrue(received.contains {
+            if case .paneStructure(let worklaneID) = $0 {
+                return worklaneID == WorklaneID("wl_a")
+            }
+            return false
+        })
+    }
+
+    func test_setPaneCustomTitle_trims_whitespace() {
+        let store = makeStore()
+
+        let applied = store.setPaneCustomTitle("  Padded name  ", on: PaneID("pn_a"))
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(
+            store.worklanes.first { $0.id == WorklaneID("wl_a") }?
+                .paneStripState.panes.first?.customTitle,
+            "Padded name"
+        )
+    }
+
+    func test_setPaneCustomTitle_empty_and_whitespace_clear_the_title() {
+        let store = makeStore()
+        _ = store.setPaneCustomTitle("Nimbu API", on: PaneID("pn_a"))
+
+        let cleared = store.setPaneCustomTitle("", on: PaneID("pn_a"))
+
+        XCTAssertTrue(cleared)
+        XCTAssertNil(
+            store.worklanes.first { $0.id == WorklaneID("wl_a") }?
+                .paneStripState.panes.first?.customTitle
+        )
+
+        _ = store.setPaneCustomTitle("named again", on: PaneID("pn_a"))
+        let clearedByWhitespace = store.setPaneCustomTitle("   ", on: PaneID("pn_a"))
+
+        XCTAssertTrue(clearedByWhitespace)
+        XCTAssertNil(
+            store.worklanes.first { $0.id == WorklaneID("wl_a") }?
+                .paneStripState.panes.first?.customTitle
+        )
+    }
+
+    func test_setPaneCustomTitle_same_value_is_noop_and_emits_no_change() {
+        let store = makeStore()
+        _ = store.setPaneCustomTitle("Nimbu API", on: PaneID("pn_a"))
+
+        var emitted = 0
+        let subscription = store.subscribe { _ in emitted += 1 }
+        addTeardownBlock { store.unsubscribe(subscription) }
+
+        let applied = store.setPaneCustomTitle("Nimbu API", on: PaneID("pn_a"))
+        let clearedNoop = store.setPaneCustomTitle(nil, on: PaneID("pn_b"))
+
+        XCTAssertFalse(applied)
+        XCTAssertFalse(clearedNoop)
+        XCTAssertEqual(emitted, 0)
+    }
+
+    func test_setPaneCustomTitle_on_missing_id_returns_false_and_emits_no_change() {
+        let store = makeStore()
+        var emitted = 0
+        let subscription = store.subscribe { _ in emitted += 1 }
+        addTeardownBlock { store.unsubscribe(subscription) }
+
+        let applied = store.setPaneCustomTitle("anything", on: PaneID("pn_missing"))
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(emitted, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Users can name individual panes inside a worklane. The sidebar UI, command palette, and `zentty pane rename` all write the same per-pane title, and Zentty uses that title in the sidebar, focused titlebar label, and pane border until the user clears it.

Zentty stores the title on `PaneState` and carries it through workspace templates, session restore, closed-pane restore, and recipe serialization. The display resolver gives custom titles precedence over volatile terminal titles and remote/SSH labels while keeping host/path or cwd as secondary context when available.

Closes https://github.com/dedene/zentty/issues/33
