### PR TITLE
SSH-aware file paste: upload pasted/dropped files to remote panes

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		004B14255297EAF8D94B351A /* WorklaneColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D22B5BDA360AE3F6A96AE3 /* WorklaneColorTests.swift */; };
 		0129C725DE1BC687AA4B9EFF /* SidebarActiveWorklaneAutoScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C05F7BE9ED093DD4CC4CA4 /* SidebarActiveWorklaneAutoScrollerTests.swift */; };
+		01439B6BF3F83A663BC90F30 /* RemoteImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23E0F7DE3F0B5A6D98FF8EB /* RemoteImageUploader.swift */; };
 		028F1F462FC45BC0DFB33F15 /* TerminalClipboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F71D1415EE0BF0891E75B0 /* TerminalClipboardTests.swift */; };
 		033F73402D6B37BE6D34C0F6 /* ServerWatchRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B3AD9AA8F799603B573B28 /* ServerWatchRunner.swift */; };
 		0353FE3D437A0B9370A6261B /* TopologyCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0CE971B0D9FBD5D92A5E40 /* TopologyCLI.swift */; };
@@ -61,6 +62,7 @@
 		17245348FB36801D95C10395 /* ShellMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FEAF3CA4E96E1EB18692E8 /* ShellMetrics.swift */; };
 		173791FED7615617FAF34B05 /* CommandPaletteTaskRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D7092CD7460BABDBD68C6E /* CommandPaletteTaskRunnerTests.swift */; };
 		1831BA926C62620FC97C9D07 /* TaskManagerProcessSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B147E532F92E9849DAF51188 /* TaskManagerProcessSamplerTests.swift */; };
+		185DFF067ADC9207E76A7D03 /* RemoteImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D666096F56C2FA591E900FF4 /* RemoteImageUploaderTests.swift */; };
 		196932893F690C070D526631 /* MockTerminalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765B5594B1CFDD53C4A7C00B /* MockTerminalAdapter.swift */; };
 		1A296EF0C60861DCA54D8B8E /* LibghosttySurfaceActionCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20951EA69B03694C17C61738 /* LibghosttySurfaceActionCoalescerTests.swift */; };
 		1AAB70DF7B2347FC5AFE54B5 /* BundledGhosttyThemeResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312AF7E528937EA1BA1B5D84 /* BundledGhosttyThemeResourcesTests.swift */; };
@@ -268,6 +270,7 @@
 		8000FFBB2A9BB2606A89CD92 /* PaneLayoutSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF38754F46DCDAAF2D32B847 /* PaneLayoutSizing.swift */; };
 		80151BBA3E6C4EBB099460AB /* TerminalPaneHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F82AEDB8F3C8B3C5F014D8D /* TerminalPaneHostView.swift */; };
 		801ECD25402540B6F022BC3F /* KeyboardShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A94FD26FCD146425105D3FD /* KeyboardShortcutResolver.swift */; };
+		80C1EA098B400A4A8C8E3D6F /* PathCopiedToastViewProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7F1086D671D36900F2EF2F /* PathCopiedToastViewProgressTests.swift */; };
 		810BC207CB6B0D76DD422520 /* RecentCommandsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89BAAA51D175EA4CC9174AA /* RecentCommandsTracker.swift */; };
 		81AF86AEEA79AD53667ECBE3 /* PaneDragHitTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6BDCBDE4E090275233D9D3 /* PaneDragHitTestingTests.swift */; };
 		820A7E0C5B5B33F9FAA80699 /* AppearanceSettingsSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E4530192DE360F32303E65 /* AppearanceSettingsSectionViewController.swift */; };
@@ -307,6 +310,7 @@
 		9305DFB3157057C5F774497D /* PaneContainerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F4631D0A8465D807F16977 /* PaneContainerViewTests.swift */; };
 		939958A3691F37EB267EF560 /* RecentCommandsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3412D29DDE6DAF450D4E7CE /* RecentCommandsTrackerTests.swift */; };
 		942A7073EB30E8FDE967795E /* WorklaneHeaderSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9E7AF610F36B91C077C324 /* WorklaneHeaderSummary.swift */; };
+		948FF3321AF5D47C542A2297 /* RemoteImagePasteDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6082DFE772670E457EB1F4 /* RemoteImagePasteDecisionTests.swift */; };
 		954386A2A2B7468FA9D1EA45 /* AgentIPCProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1762B3BE208D5BC1F3BDA20 /* AgentIPCProtocol.swift */; };
 		956645D7FA3810989313C3A7 /* CodexTitlePromotionReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172E7F852B70FDD655345CF4 /* CodexTitlePromotionReducer.swift */; };
 		95A3A7116CE13BB739E4C940 /* WorklaneSidebarSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6932CD53AF150CC4656051 /* WorklaneSidebarSummaryTests.swift */; };
@@ -338,6 +342,7 @@
 		A313F3492C53D5CEF8A025F5 /* PaneFocusHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FE6D2FE3D589C3CEF772F6 /* PaneFocusHistoryTests.swift */; };
 		A31E0FD93C75D6B6059E3809 /* SidebarMotionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162C940D9CBDBBB47552AA86 /* SidebarMotionCoordinator.swift */; };
 		A3B9E7C21732F8FBD1AFF6B4 /* WorklaneStore+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5362E171051471B00419EB85 /* WorklaneStore+Restore.swift */; };
+		A3DF172F7DBD4AD8B215E680 /* PaneSSHProcessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */; };
 		A4A53654BC7A3139C0256836 /* AgyCanonicalReEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8E072C80D640FFB3D8E022 /* AgyCanonicalReEmitter.swift */; };
 		A4F9BA4052B89971F4897D09 /* ShortcutsSettingsSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02658BAF6F6B57713BBD05 /* ShortcutsSettingsSectionViewController.swift */; };
 		A524DA357EFACE58D38A111D /* WindowChromeRowLayoutPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7017B142217423B1126B8E2A /* WindowChromeRowLayoutPlanner.swift */; };
@@ -390,6 +395,7 @@
 		BE5DF3CB1463B823867F64C8 /* WorklanePeekKeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F238040A6D3B645944F5AB0 /* WorklanePeekKeyMonitor.swift */; };
 		BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C01A739643B858C0F3A69C88 /* PaneStripMotionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6261C82AADF1EDAAA09BC9 /* PaneStripMotionController.swift */; };
+		C02A4C3BC63E5516FBCF2DEA /* SidebarPanePrimaryRowViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F99D1FE29FEEA09DDD823A /* SidebarPanePrimaryRowViewTests.swift */; };
 		C038C6FB8A7F9335CC3AFB1A /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C5CDA1B0A63C72FE9048F9 /* AboutViewController.swift */; };
 		C1E6E40E7FEAE93149414E37 /* PaneStripStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */; };
 		C32E363F24F23C57C1320536 /* SessionRestoreStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEEA79E63463D7882B80FE0 /* SessionRestoreStore.swift */; };
@@ -445,10 +451,13 @@
 		D67B38252147AE7A878864E4 /* WorkspaceTemplateExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8B44C4FD096811C87A476 /* WorkspaceTemplateExporter.swift */; };
 		D6A5B756DD47B6E634574F47 /* CommandPaletteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C966AC83B20D437AA8281B3 /* CommandPaletteController.swift */; };
 		D6BBD9630859447254C3D903 /* CodexTranscriptQuestionExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9108D5844FE620ED92B7B5BC /* CodexTranscriptQuestionExtractor.swift */; };
+		D7D69913E6869588E74D6C25 /* PaneSSHProcessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4942E91A4F9D34EB0C281FA9 /* PaneSSHProcessProbeTests.swift */; };
 		D90B030DC3BB4F5D7E28FBAF /* ThemeCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB7FE3B87F05DE3D6B4426 /* ThemeCatalogService.swift */; };
 		DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0057216F25AA9654E5BDB87 /* ErrorReporting.swift */; };
 		DB21A0CF0DDA1220BC123F3B /* SidebarWorklaneDragGestureTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750C0A516E7016E42B94EC2 /* SidebarWorklaneDragGestureTracker.swift */; };
+		DB94D69E3A46FC2815951DAD /* RemoteImagePasteDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */; };
 		DB99D15DBBA9E04854EE979F /* DroidHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */; };
+		DBF5F754B4730FCFE58A70A4 /* TerminalClipboardImagePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE949F9F6F79A02AFD7A2864 /* TerminalClipboardImagePolicy.swift */; };
 		DC139F18052FBD8126678D7F /* TerminalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7FF718B0E0C3314C57BFC5 /* TerminalAdapter.swift */; };
 		DC6594609ADC8C26340A0B8A /* SidebarWorklaneRowButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4225E34022CEC2DFB9C70338 /* SidebarWorklaneRowButtonTests.swift */; };
 		DD1FBB3CA62ACE6EFBA1E7AD /* FuzzyMatch in Frameworks */ = {isa = PBXBuildFile; productRef = 1783CDCC7848CB005D3A519C /* FuzzyMatch */; };
@@ -694,6 +703,7 @@
 		43EC896B9EA214B488CDCD09 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = FrameworksLocal/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		441A77B729D56459A75D26C3 /* DetectedServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectedServer.swift; sourceTree = "<group>"; };
 		4483B8E7BA05745883A993C0 /* GlobalSearchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchCoordinatorTests.swift; sourceTree = "<group>"; };
+		457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImagePasteDecision.swift; sourceTree = "<group>"; };
 		45E5788E143BDA3D1DF37882 /* CommandAvailabilityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAvailabilityResolver.swift; sourceTree = "<group>"; };
 		46BA6D006A82BF48F127C85E /* TaskRunnerSourceScanner+Formats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaskRunnerSourceScanner+Formats.swift"; sourceTree = "<group>"; };
 		470B2E9611ABBDDD841438E9 /* PaneDragInsertionLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragInsertionLineView.swift; sourceTree = "<group>"; };
@@ -704,11 +714,13 @@
 		48846247312C42A929369E20 /* AppKitTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitTestCase.swift; sourceTree = "<group>"; };
 		48BB45FB1B15B96A8C195343 /* PaneSearchHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSearchHUDView.swift; sourceTree = "<group>"; };
 		48F435FA119C97C5F497FBD9 /* PaneLayoutSettingsWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutSettingsWindowControllerTests.swift; sourceTree = "<group>"; };
+		4942E91A4F9D34EB0C281FA9 /* PaneSSHProcessProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSSHProcessProbeTests.swift; sourceTree = "<group>"; };
 		49A456B5C222F30C2DB528E0 /* VibeHooksInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeHooksInstaller.swift; sourceTree = "<group>"; };
 		4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpResumeArgumentSanitizer.swift; sourceTree = "<group>"; };
 		4AB3C0ACB087A96811645CE3 /* AppMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMenuBuilder.swift; sourceTree = "<group>"; };
 		4ABED86877FD29F83E4196E0 /* TmuxCompatCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatCommand.swift; sourceTree = "<group>"; };
 		4B409385EC57C8C7A65441BD /* TmuxFormatRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxFormatRenderer.swift; sourceTree = "<group>"; };
+		4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSSHProcessProbe.swift; sourceTree = "<group>"; };
 		4B6F06FD570B9740CE7008CB /* SettingsSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarTests.swift; sourceTree = "<group>"; };
 		4B83CC56F8834AA75E2315BC /* ZenttyBreadcrumbs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenttyBreadcrumbs.swift; sourceTree = "<group>"; };
 		4C07D99A780805BBF2EC8E2C /* SidebarResizeHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeHandleView.swift; sourceTree = "<group>"; };
@@ -802,6 +814,7 @@
 		7C1BDFF2B71B2BDFF1DF60EA /* WorklaneAttentionSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionSummaryBuilder.swift; sourceTree = "<group>"; };
 		7CFD112F9402167A1785DB70 /* BookmarkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkStore.swift; sourceTree = "<group>"; };
 		7D19D665B0C99E8725E1E7AC /* ProjectIconResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconResolverTests.swift; sourceTree = "<group>"; };
+		7D7F1086D671D36900F2EF2F /* PathCopiedToastViewProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCopiedToastViewProgressTests.swift; sourceTree = "<group>"; };
 		7D85A32FF838B668D61586CA /* FuzzyMatch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FuzzyMatch; path = Vendor/FuzzyMatch; sourceTree = SOURCE_ROOT; };
 		7DCA45568C0DF115CFA41141 /* CommandPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalettePanel.swift; sourceTree = "<group>"; };
 		7DDF1EF89E46D6EEECB8A320 /* LibghosttyAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyAdapter.swift; sourceTree = "<group>"; };
@@ -845,6 +858,7 @@
 		8EF1C35E3E3441C4C57051CA /* TmuxCompatArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatArguments.swift; sourceTree = "<group>"; };
 		8F82AEDB8F3C8B3C5F014D8D /* TerminalPaneHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneHostView.swift; sourceTree = "<group>"; };
 		905DD9FD69FFEA7991390EA4 /* ScrollSwitchGestureHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollSwitchGestureHandler.swift; sourceTree = "<group>"; };
+		90F99D1FE29FEEA09DDD823A /* SidebarPanePrimaryRowViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPanePrimaryRowViewTests.swift; sourceTree = "<group>"; };
 		9108D5844FE620ED92B7B5BC /* CodexTranscriptQuestionExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTranscriptQuestionExtractor.swift; sourceTree = "<group>"; };
 		91380A1B682CF707751392D2 /* ServerListenerScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerListenerScanner.swift; sourceTree = "<group>"; };
 		9147BE310A4C4D3D61638835 /* CleanCopyPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanCopyPipeline.swift; sourceTree = "<group>"; };
@@ -904,6 +918,7 @@
 		ACD2AD71B143BD29FDAA48FF /* TmuxCompatIPCHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatIPCHandler.swift; sourceTree = "<group>"; };
 		AD7E300A778738FA99DF6B1B /* TaskRunnerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunnerModels.swift; sourceTree = "<group>"; };
 		AE8E072C80D640FFB3D8E022 /* AgyCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgyCanonicalReEmitter.swift; sourceTree = "<group>"; };
+		AE949F9F6F79A02AFD7A2864 /* TerminalClipboardImagePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClipboardImagePolicy.swift; sourceTree = "<group>"; };
 		AF38754F46DCDAAF2D32B847 /* PaneLayoutSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutSizing.swift; sourceTree = "<group>"; };
 		AF50EC996DD0097909E99875 /* AgentLaunchBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLaunchBootstrap.swift; sourceTree = "<group>"; };
 		B0057216F25AA9654E5BDB87 /* ErrorReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporting.swift; sourceTree = "<group>"; };
@@ -997,6 +1012,7 @@
 		D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeThemeSync.swift; sourceTree = "<group>"; };
 		D58B814CCB50A93D946D971E /* JSONKeyAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONKeyAccess.swift; sourceTree = "<group>"; };
 		D649A4BADA61361091434B5E /* GhosttyThemeLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyThemeLibraryTests.swift; sourceTree = "<group>"; };
+		D666096F56C2FA591E900FF4 /* RemoteImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageUploaderTests.swift; sourceTree = "<group>"; };
 		D66E9360C107E9A7D3F05652 /* ServerRelevance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelevance.swift; sourceTree = "<group>"; };
 		D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPillView.swift; sourceTree = "<group>"; };
 		D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPalette.swift; sourceTree = "<group>"; };
@@ -1008,6 +1024,7 @@
 		DC29DBB882ABDF747B9DDA76 /* SettingsNavigationHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationHistory.swift; sourceTree = "<group>"; };
 		DD55E4B84C3278A35AB5B50B /* ServerBrowserCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerBrowserCatalogTests.swift; sourceTree = "<group>"; };
 		DE51D9EBCFFBCD584611F064 /* SidebarCreateWorklaneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarCreateWorklaneButton.swift; sourceTree = "<group>"; };
+		DE6082DFE772670E457EB1F4 /* RemoteImagePasteDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImagePasteDecisionTests.swift; sourceTree = "<group>"; };
 		DEC764BCDC589B75DA78F658 /* SidebarPaneRowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPaneRowButton.swift; sourceTree = "<group>"; };
 		E0253BE7E0C15D8168A3491D /* LibghosttyViewScrollRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyViewScrollRoutingTests.swift; sourceTree = "<group>"; };
 		E0B5C0E6A8057294C72424F6 /* NotificationChromeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationChromeCoordinator.swift; sourceTree = "<group>"; };
@@ -1015,6 +1032,7 @@
 		E15503D22D3AC116573AA128 /* ServerOutputURLDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOutputURLDetectorTests.swift; sourceTree = "<group>"; };
 		E1A2BC275D0F7E90ACD593C6 /* PaneDragSplitOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragSplitOverlayView.swift; sourceTree = "<group>"; };
 		E1C2498C39738D7E5DBC5BBC /* AgentIPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIPCClient.swift; sourceTree = "<group>"; };
+		E23E0F7DE3F0B5A6D98FF8EB /* RemoteImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageUploader.swift; sourceTree = "<group>"; };
 		E263ECB14727930372689593 /* ServerBrowserCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerBrowserCatalog.swift; sourceTree = "<group>"; };
 		E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpPluginInstaller.swift; sourceTree = "<group>"; };
 		E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStripStateTests.swift; sourceTree = "<group>"; };
@@ -1594,9 +1612,13 @@
 				5EEF748059F59CD2590E1C2C /* LibghosttySurface.swift */,
 				50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */,
 				765B5594B1CFDD53C4A7C00B /* MockTerminalAdapter.swift */,
+				4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */,
+				457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */,
+				E23E0F7DE3F0B5A6D98FF8EB /* RemoteImageUploader.swift */,
 				20147088C6EEA07145EA0961 /* ShellEscaping.swift */,
 				AB7FF718B0E0C3314C57BFC5 /* TerminalAdapter.swift */,
 				4EB1561FD9C602B6D306155C /* TerminalClipboard.swift */,
+				AE949F9F6F79A02AFD7A2864 /* TerminalClipboardImagePolicy.swift */,
 				6D46D74C2BFDAC52C678BDB1 /* TerminalMetadata.swift */,
 				8F82AEDB8F3C8B3C5F014D8D /* TerminalPaneHostView.swift */,
 				5AFCA2B8C7CCCEF9A040B1D1 /* TerminalScrollFrameSampler.swift */,
@@ -1866,12 +1888,16 @@
 				15FE8B4E43D3F4D0F90BFE83 /* PaneNotificationCoordinatorTests.swift */,
 				017D80D8C20309A5F3A34381 /* PanePresentationStateTests.swift */,
 				76857E75C1FF0BD95C889941 /* PaneRuntimeRegistryTests.swift */,
+				4942E91A4F9D34EB0C281FA9 /* PaneSSHProcessProbeTests.swift */,
 				CDD7AA3458BBF1FAEFFC158A /* PaneStripMotionControllerTests.swift */,
 				E469BF2F5A021DBF256E8D20 /* PaneStripStateTests.swift */,
 				CFB4690A6E06FB3FC4C1909E /* PaneStripStoreTests.swift */,
 				94042661C850159F74FC9F69 /* PaneStripViewTests.swift */,
 				F2C9219C7C69529A79AE9EED /* PassiveServerDetectionTests.swift */,
+				7D7F1086D671D36900F2EF2F /* PathCopiedToastViewProgressTests.swift */,
 				7D19D665B0C99E8725E1E7AC /* ProjectIconResolverTests.swift */,
+				DE6082DFE772670E457EB1F4 /* RemoteImagePasteDecisionTests.swift */,
+				D666096F56C2FA591E900FF4 /* RemoteImageUploaderTests.swift */,
 				D24F62AFB71CBBAE4BC9B5A1 /* RootViewCompositionTests.swift */,
 				B50181BE811AE835D0DAAF33 /* RootViewControllerHeaderIntegrationTests.swift */,
 				CC28F1EA0D7841668F8DA676 /* RootViewControllerUpdateIntegrationTests.swift */,
@@ -1894,6 +1920,7 @@
 				E4C05F7BE9ED093DD4CC4CA4 /* SidebarActiveWorklaneAutoScrollerTests.swift */,
 				4C88D5D3BFE9433DCC2E7090 /* SidebarDropHitTestingTests.swift */,
 				CA3810175E866C6CB11A8C87 /* SidebarMotionCoordinatorTests.swift */,
+				90F99D1FE29FEEA09DDD823A /* SidebarPanePrimaryRowViewTests.swift */,
 				B308B03F54BFA5F3812B101D /* SidebarRowDiffTests.swift */,
 				BE256725D568E7583890592B /* SidebarShimmerCoordinatorTests.swift */,
 				15CCAA96572EBEF62BF5C4C0 /* SidebarStatusResolverTests.swift */,
@@ -2276,12 +2303,16 @@
 				6288F3AE915459E59B5F2B42 /* PaneNotificationCoordinatorTests.swift in Sources */,
 				1041B5CDF3EA5C978F3580BC /* PanePresentationStateTests.swift in Sources */,
 				F1E79CD825C39C592E844B63 /* PaneRuntimeRegistryTests.swift in Sources */,
+				D7D69913E6869588E74D6C25 /* PaneSSHProcessProbeTests.swift in Sources */,
 				74A2DE5A0880B028476E3D8D /* PaneStripMotionControllerTests.swift in Sources */,
 				C1E6E40E7FEAE93149414E37 /* PaneStripStateTests.swift in Sources */,
 				F75C8D5EDC0772F56DE54C52 /* PaneStripStoreTests.swift in Sources */,
 				53C04E574AF84DBCF050718B /* PaneStripViewTests.swift in Sources */,
 				9714DA808EA42C0AB29CF840 /* PassiveServerDetectionTests.swift in Sources */,
+				80C1EA098B400A4A8C8E3D6F /* PathCopiedToastViewProgressTests.swift in Sources */,
 				998FF66C07DB3D9D4BF99784 /* ProjectIconResolverTests.swift in Sources */,
+				948FF3321AF5D47C542A2297 /* RemoteImagePasteDecisionTests.swift in Sources */,
+				185DFF067ADC9207E76A7D03 /* RemoteImageUploaderTests.swift in Sources */,
 				8B1430D7C662CD2D1CC2E080 /* RootViewCompositionTests.swift in Sources */,
 				FB6421E478EA88F89ACE1603 /* RootViewControllerHeaderIntegrationTests.swift in Sources */,
 				CB79F077F87E4A504CBEA9B9 /* RootViewControllerUpdateIntegrationTests.swift in Sources */,
@@ -2304,6 +2335,7 @@
 				0129C725DE1BC687AA4B9EFF /* SidebarActiveWorklaneAutoScrollerTests.swift in Sources */,
 				D3987EA55548B9FB2FAF2535 /* SidebarDropHitTestingTests.swift in Sources */,
 				267DEF07DD871705091F0BC8 /* SidebarMotionCoordinatorTests.swift in Sources */,
+				C02A4C3BC63E5516FBCF2DEA /* SidebarPanePrimaryRowViewTests.swift in Sources */,
 				996B3F52A55E43059D1727A6 /* SidebarRowDiffTests.swift in Sources */,
 				BE30B813EC32158B648F52B1 /* SidebarShimmerCoordinatorTests.swift in Sources */,
 				11CC53B8D7E88E79372476A5 /* SidebarStatusResolverTests.swift in Sources */,
@@ -2523,6 +2555,7 @@
 				4BB0E4171C495664EF0324FE /* PaneNavigationButtons.swift in Sources */,
 				7C269AA7741BA793A8DD4BD7 /* PaneNotificationCoordinator.swift in Sources */,
 				8D4C37D86BAA9B1B23DF164B /* PaneRestorationBuilder.swift in Sources */,
+				A3DF172F7DBD4AD8B215E680 /* PaneSSHProcessProbe.swift in Sources */,
 				731E192A944AF30FB531F314 /* PaneSearchHUDView.swift in Sources */,
 				13A456B3644AB1AA586D10E9 /* PaneShellContext.swift in Sources */,
 				D11DCA299BC0C937EAED0001 /* PaneSplitBehaviorOptionView.swift in Sources */,
@@ -2542,6 +2575,8 @@
 				5C90188186788922397ADD4A /* ProjectFileResolver.swift in Sources */,
 				1216C817399FFC2FF0A5D3AB /* ProjectIconResolver.swift in Sources */,
 				810BC207CB6B0D76DD422520 /* RecentCommandsTracker.swift in Sources */,
+				DB94D69E3A46FC2815951DAD /* RemoteImagePasteDecision.swift in Sources */,
+				01439B6BF3F83A663BC90F30 /* RemoteImageUploader.swift in Sources */,
 				A9684C3ACA26BE7756C04436 /* RootViewController.swift in Sources */,
 				269DD148F3D616460B3E5DE2 /* ScrollSwitchGestureHandler.swift in Sources */,
 				8B9DF44D979391235B5F37A7 /* SentryErrorReportingClient.swift in Sources */,
@@ -2621,6 +2656,7 @@
 				BBE3CA1DD7CB1D184F81DDE2 /* TaskfileParser.swift in Sources */,
 				DC139F18052FBD8126678D7F /* TerminalAdapter.swift in Sources */,
 				21B5B2D8D083E4D952FD9E03 /* TerminalClipboard.swift in Sources */,
+				DBF5F754B4730FCFE58A70A4 /* TerminalClipboardImagePolicy.swift in Sources */,
 				AE15A3294DF80781A48DF69F /* TerminalMetadata.swift in Sources */,
 				80151BBA3E6C4EBB099460AB /* TerminalPaneHostView.swift in Sources */,
 				F7341AA3719ED1FB2D7B3739 /* TerminalScrollFrameSampler.swift in Sources */,

--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		2F66DA8093CA1E0590D3DD0F /* SidebarTextMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880AC8A873636B3675457AAD /* SidebarTextMetrics.swift */; };
 		308705984BE6FCCDC7CB25F8 /* MenuBarStatusPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6F1935CE1012DD80C4954D /* MenuBarStatusPresentationTests.swift */; };
 		30B9ACBE47351D6E5EF639C5 /* CommandPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA45568C0DF115CFA41141 /* CommandPalettePanel.swift */; };
+		30CB07863C026E27D0FF2BB9 /* RemoteFileUploadRequestResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB5D7EB3C3C6F4CA6325492 /* RemoteFileUploadRequestResolverTests.swift */; };
 		31CD1FA7F8E072DCE331BBC6 /* WorklaneStoreOpenWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BD40F90473F37867AB07AF /* WorklaneStoreOpenWithTests.swift */; };
 		326A9B40B1266ADE43A7BD7B /* MoveToWorklaneMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B77CE7C6471C7FFD211BFDF /* MoveToWorklaneMenuBuilder.swift */; };
 		358A6FA22378B781C3DCB43B /* SidebarGlobalSearchRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B07C000F905AC8E20E1648 /* SidebarGlobalSearchRowView.swift */; };
@@ -382,6 +383,7 @@
 		B38B8A60FEC01BE8385B6ED1 /* WorklaneGitContextResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D282138FCDC94B5D876B4D /* WorklaneGitContextResolverTests.swift */; };
 		B3EDFD781B2ECD9598AD51ED /* WorklaneRenameIPCParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A86E5437CA5FE9BF64605D3 /* WorklaneRenameIPCParserTests.swift */; };
 		B4C1005AD0D618DCB0A4C13D /* MoveToWorklaneMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AFF05A04C7107BED6423F8 /* MoveToWorklaneMenuBuilderTests.swift */; };
+		B78B6869AC1BB4C5B6AA60E4 /* RemoteFileUploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B504722337DBCB03722FD8 /* RemoteFileUploadRequest.swift */; };
 		B7EDD5E8FF2844DE47EF5D21 /* WorklanePeekKeyMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F1AF8D07B9B05151774B4F /* WorklanePeekKeyMonitorTests.swift */; };
 		B891884A0BB67B8A6BEE5C36 /* ServerWatchRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B3AD9AA8F799603B573B28 /* ServerWatchRunner.swift */; };
 		BA9D0265E08E22F14A7E1C8A /* AgentWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5C60D4800BDD040F2D5B12 /* AgentWrapperTests.swift */; };
@@ -422,6 +424,7 @@
 		CB79F077F87E4A504CBEA9B9 /* RootViewControllerUpdateIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC28F1EA0D7841668F8DA676 /* RootViewControllerUpdateIntegrationTests.swift */; };
 		CBA82B1C9557F98AD04A8672 /* SidebarPaneRowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9407DEA6B0DE6363B46DE0A /* SidebarPaneRowViews.swift */; };
 		CC3E9AE062D12B88458DA88B /* FuzzyMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0EFB8B00D5CA9A67589A3A /* FuzzyMatcher.swift */; };
+		CC77B8DAAD09EF142F0AAEDD /* RemoteImageUploadPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F39A834BE762EC026D1F87 /* RemoteImageUploadPath.swift */; };
 		CD00F629DE6FF4C470C1879C /* DragReorderHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712CB2F8BC16BB3B666A085 /* DragReorderHapticFeedback.swift */; };
 		CDA589887C4F0F21EEE4A1DF /* FileManager+SymlinkWrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CFF36A010130E00ACF80FB /* FileManager+SymlinkWrite.swift */; };
 		CDF1BF1E9C25A9C932CF64CC /* ServerBrowserCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD55E4B84C3278A35AB5B50B /* ServerBrowserCatalogTests.swift */; };
@@ -760,6 +763,7 @@
 		5A2F1C3E75DEE37361D3D7CB /* AgentEventAdapters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEventAdapters.swift; sourceTree = "<group>"; };
 		5AFCA2B8C7CCCEF9A040B1D1 /* TerminalScrollFrameSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScrollFrameSampler.swift; sourceTree = "<group>"; };
 		5B57876C4F8C1763BD4E8DBD /* SettingsSidebarRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarRowView.swift; sourceTree = "<group>"; };
+		5BB5D7EB3C3C6F4CA6325492 /* RemoteFileUploadRequestResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileUploadRequestResolverTests.swift; sourceTree = "<group>"; };
 		5D34EEFF128BAD9A9DEE0371 /* SidebarPaneRowRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPaneRowRenderer.swift; sourceTree = "<group>"; };
 		5E316EB04A90576B80F838D9 /* PaneAgentReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentReducerTests.swift; sourceTree = "<group>"; };
 		5EEF748059F59CD2590E1C2C /* LibghosttySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySurface.swift; sourceTree = "<group>"; };
@@ -836,6 +840,7 @@
 		8626016D68E310751E9D7E91 /* ClosedPaneStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedPaneStack.swift; sourceTree = "<group>"; };
 		86532A76726D9364B28994A8 /* AgentIntegrationConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationConsent.swift; sourceTree = "<group>"; };
 		86917D1F9201725F12438AD5 /* WindowChromeRowLayoutPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeRowLayoutPlannerTests.swift; sourceTree = "<group>"; };
+		86F39A834BE762EC026D1F87 /* RemoteImageUploadPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageUploadPath.swift; sourceTree = "<group>"; };
 		8747D7DA152CB73E2CF991C6 /* TmuxCompatArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatArgumentsTests.swift; sourceTree = "<group>"; };
 		880AC8A873636B3675457AAD /* SidebarTextMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTextMetrics.swift; sourceTree = "<group>"; };
 		88AFF05A04C7107BED6423F8 /* MoveToWorklaneMenuBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveToWorklaneMenuBuilderTests.swift; sourceTree = "<group>"; };
@@ -1015,6 +1020,7 @@
 		D666096F56C2FA591E900FF4 /* RemoteImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageUploaderTests.swift; sourceTree = "<group>"; };
 		D66E9360C107E9A7D3F05652 /* ServerRelevance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelevance.swift; sourceTree = "<group>"; };
 		D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPillView.swift; sourceTree = "<group>"; };
+		D7B504722337DBCB03722FD8 /* RemoteFileUploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileUploadRequest.swift; sourceTree = "<group>"; };
 		D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPalette.swift; sourceTree = "<group>"; };
 		D9B72357CA80C59A161F7BE2 /* WorklaneAttentionChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneAttentionChipView.swift; sourceTree = "<group>"; };
 		D9C47104BD130C28676BA079 /* SparkleAppUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleAppUpdateController.swift; sourceTree = "<group>"; };
@@ -1613,8 +1619,10 @@
 				50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */,
 				765B5594B1CFDD53C4A7C00B /* MockTerminalAdapter.swift */,
 				4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */,
+				D7B504722337DBCB03722FD8 /* RemoteFileUploadRequest.swift */,
 				457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */,
 				E23E0F7DE3F0B5A6D98FF8EB /* RemoteImageUploader.swift */,
+				86F39A834BE762EC026D1F87 /* RemoteImageUploadPath.swift */,
 				20147088C6EEA07145EA0961 /* ShellEscaping.swift */,
 				AB7FF718B0E0C3314C57BFC5 /* TerminalAdapter.swift */,
 				4EB1561FD9C602B6D306155C /* TerminalClipboard.swift */,
@@ -1896,6 +1904,7 @@
 				F2C9219C7C69529A79AE9EED /* PassiveServerDetectionTests.swift */,
 				7D7F1086D671D36900F2EF2F /* PathCopiedToastViewProgressTests.swift */,
 				7D19D665B0C99E8725E1E7AC /* ProjectIconResolverTests.swift */,
+				5BB5D7EB3C3C6F4CA6325492 /* RemoteFileUploadRequestResolverTests.swift */,
 				DE6082DFE772670E457EB1F4 /* RemoteImagePasteDecisionTests.swift */,
 				D666096F56C2FA591E900FF4 /* RemoteImageUploaderTests.swift */,
 				D24F62AFB71CBBAE4BC9B5A1 /* RootViewCompositionTests.swift */,
@@ -2311,6 +2320,7 @@
 				9714DA808EA42C0AB29CF840 /* PassiveServerDetectionTests.swift in Sources */,
 				80C1EA098B400A4A8C8E3D6F /* PathCopiedToastViewProgressTests.swift in Sources */,
 				998FF66C07DB3D9D4BF99784 /* ProjectIconResolverTests.swift in Sources */,
+				30CB07863C026E27D0FF2BB9 /* RemoteFileUploadRequestResolverTests.swift in Sources */,
 				948FF3321AF5D47C542A2297 /* RemoteImagePasteDecisionTests.swift in Sources */,
 				185DFF067ADC9207E76A7D03 /* RemoteImageUploaderTests.swift in Sources */,
 				8B1430D7C662CD2D1CC2E080 /* RootViewCompositionTests.swift in Sources */,
@@ -2575,7 +2585,9 @@
 				5C90188186788922397ADD4A /* ProjectFileResolver.swift in Sources */,
 				1216C817399FFC2FF0A5D3AB /* ProjectIconResolver.swift in Sources */,
 				810BC207CB6B0D76DD422520 /* RecentCommandsTracker.swift in Sources */,
+				B78B6869AC1BB4C5B6AA60E4 /* RemoteFileUploadRequest.swift in Sources */,
 				DB94D69E3A46FC2815951DAD /* RemoteImagePasteDecision.swift in Sources */,
+				CC77B8DAAD09EF142F0AAEDD /* RemoteImageUploadPath.swift in Sources */,
 				01439B6BF3F83A663BC90F30 /* RemoteImageUploader.swift in Sources */,
 				A9684C3ACA26BE7756C04436 /* RootViewController.swift in Sources */,
 				269DD148F3D616460B3E5DE2 /* ScrollSwitchGestureHandler.swift in Sources */,

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -121,6 +121,7 @@ struct PanePresentationState: Equatable, Sendable {
     var lastActivityTitle: String?
     var sshConnectionLabel: String? = nil
     var isRemoteShell = false
+    var foregroundSSHDestination: SSHDestination? = nil
     var remoteHostLabel: String? = nil
     var remotePathLabel: String? = nil
     var remoteLocationLabel: String? = nil
@@ -152,6 +153,14 @@ struct PanePresentationState: Equatable, Sendable {
         isRemoteShell == false && WorklaneContextFormatter.trimmed(sshConnectionLabel) != nil
     }
 
+    var hasForegroundSSHProcess: Bool {
+        foregroundSSHDestination != nil
+    }
+
+    var isRemotePane: Bool {
+        isRemoteShell || hasInferredSSHConnection || hasForegroundSSHProcess
+    }
+
     var prLookupKey: String? {
         guard let repoRoot, let lookupBranch else {
             return nil
@@ -170,6 +179,7 @@ struct PaneRawState: Equatable, Sendable {
     var metadata: TerminalMetadata?
     var shellContext: PaneShellContext?
     var paneRootPID: Int32? = nil
+    var foregroundSSHDestination: SSHDestination? = nil
     var agentStatus: PaneAgentStatus?
     var agentReducerState: PaneAgentReducerState = .init()
     var shellActivityState: PaneShellActivityState = .unknown
@@ -194,6 +204,7 @@ struct PaneRawState: Equatable, Sendable {
         metadata: TerminalMetadata? = nil,
         shellContext: PaneShellContext? = nil,
         paneRootPID: Int32? = nil,
+        foregroundSSHDestination: SSHDestination? = nil,
         agentStatus: PaneAgentStatus? = nil,
         agentReducerState: PaneAgentReducerState = .init(),
         shellActivityState: PaneShellActivityState = .unknown,
@@ -216,6 +227,7 @@ struct PaneRawState: Equatable, Sendable {
         self.metadata = metadata
         self.shellContext = shellContext
         self.paneRootPID = paneRootPID
+        self.foregroundSSHDestination = foregroundSSHDestination
         self.agentStatus = agentStatus
         self.agentReducerState = agentReducerState
         self.shellActivityState = shellActivityState
@@ -485,6 +497,7 @@ enum PanePresentationNormalizer {
             lastActivityTitle: lastActivityTitle,
             sshConnectionLabel: sshConnectionLabel,
             isRemoteShell: raw.shellContext?.scope == .remote,
+            foregroundSSHDestination: raw.foregroundSSHDestination,
             remoteHostLabel: remoteHostLabel,
             remotePathLabel: remotePathLabel,
             remoteLocationLabel: remoteLocationLabel,
@@ -988,6 +1001,8 @@ struct PaneAuxiliaryState: Equatable, Sendable {
     init(
         metadata: TerminalMetadata? = nil,
         shellContext: PaneShellContext? = nil,
+        paneRootPID: Int32? = nil,
+        foregroundSSHDestination: SSHDestination? = nil,
         agentStatus: PaneAgentStatus? = nil,
         agentReducerState: PaneAgentReducerState = .init(),
         terminalProgress: TerminalProgressReport? = nil,
@@ -998,6 +1013,8 @@ struct PaneAuxiliaryState: Equatable, Sendable {
         self.raw = PaneRawState(
             metadata: metadata,
             shellContext: shellContext,
+            paneRootPID: paneRootPID,
+            foregroundSSHDestination: foregroundSSHDestination,
             agentStatus: agentStatus,
             agentReducerState: agentReducerState,
             terminalProgress: terminalProgress,

--- a/Zentty/AppState/WorklaneContextFormatter.swift
+++ b/Zentty/AppState/WorklaneContextFormatter.swift
@@ -124,7 +124,36 @@ enum WorklaneContextFormatter {
             return true
         }
 
-        return looksLikeSSHTarget(target)
+        return target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    }
+
+    static func sshDestination(fromCommandTitle title: String) -> SSHDestination? {
+        guard looksLikeSSHCommandTitle(title) else {
+            return nil
+        }
+
+        let tokens = title.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard let rawTarget = firstSSHTargetArgument(in: tokens) else {
+            return nil
+        }
+
+        let normalizedTarget = normalizeSSHTarget(rawTarget)
+        guard !normalizedTarget.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        let parsedUser = sshUser(fromTarget: normalizedTarget)
+        let flagUser = parsedUser == nil ? sshUsernameArgument(in: tokens) : nil
+        let user = parsedUser ?? flagUser
+        let host = sshHost(fromTarget: normalizedTarget)
+        let target = user.map { "\($0)@\(host)" } ?? normalizedTarget
+
+        return SSHDestination(
+            target: target,
+            user: user,
+            host: host,
+            port: sshPortArgument(in: tokens)
+        )
     }
 
     static func formattedWorkingDirectory(
@@ -693,29 +722,7 @@ enum WorklaneContextFormatter {
     }
 
     private static func sshConnectionLabel(fromCommandTitle title: String) -> String? {
-        guard looksLikeSSHCommandTitle(title) else {
-            return nil
-        }
-
-        let tokens = title.split(whereSeparator: \.isWhitespace).map(String.init)
-        guard let target = firstSSHTargetArgument(in: tokens) else {
-            return nil
-        }
-
-        let normalizedTarget = normalizeSSHTarget(target)
-        guard looksLikeSSHTarget(normalizedTarget) else {
-            return nil
-        }
-
-        if normalizedTarget.contains("@") {
-            return normalizedTarget
-        }
-
-        if let username = sshUsernameArgument(in: tokens) {
-            return "\(username)@\(normalizedTarget)"
-        }
-
-        return normalizedTarget
+        sshDestination(fromCommandTitle: title)?.target
     }
 
     private static func sshConnectionLabel(fromRemoteSessionTitle title: String) -> String? {
@@ -763,9 +770,43 @@ enum WorklaneContextFormatter {
                 return trimmed(String(token.dropFirst(2)))
             }
 
-            let optionsRequiringValues = sshOptionsRequiringValues
             if token.hasPrefix("-") {
-                if optionsRequiringValues.contains(token) {
+                if sshOptionConsumesNextToken(token) {
+                    index += 2
+                } else {
+                    index += 1
+                }
+                continue
+            }
+
+            return nil
+        }
+
+        return nil
+    }
+
+    private static func sshPortArgument(in tokens: [String]) -> Int? {
+        guard tokens.count > 1 else {
+            return nil
+        }
+
+        var index = 1
+        while index < tokens.count {
+            let token = tokens[index]
+            if token == "--" {
+                return nil
+            }
+
+            if token == "-p" {
+                return index + 1 < tokens.count ? Int(tokens[index + 1]) : nil
+            }
+
+            if token.hasPrefix("-p"), token.count > 2 {
+                return Int(String(token.dropFirst(2)))
+            }
+
+            if token.hasPrefix("-") {
+                if sshOptionConsumesNextToken(token) {
                     index += 2
                 } else {
                     index += 1
@@ -802,7 +843,7 @@ enum WorklaneContextFormatter {
             }
 
             if token.hasPrefix("-") {
-                if sshOptionsRequiringValues.contains(token) {
+                if sshOptionConsumesNextToken(token) {
                     index += 2
                 } else {
                     index += 1
@@ -838,6 +879,23 @@ enum WorklaneContextFormatter {
             of: #"^\d{1,3}(?:\.\d{1,3}){3}$"#,
             options: .regularExpression
         ) != nil
+    }
+
+    private static func sshUser(fromTarget target: String) -> String? {
+        let components = target.split(separator: "@", maxSplits: 1).map(String.init)
+        guard components.count == 2 else {
+            return nil
+        }
+
+        return trimmed(components[0])
+    }
+
+    private static func sshHost(fromTarget target: String) -> String {
+        target.split(separator: "@", maxSplits: 1).last.map(String.init) ?? target
+    }
+
+    private static func sshOptionConsumesNextToken(_ token: String) -> Bool {
+        sshOptionsRequiringValues.contains(token)
     }
 
     private static func looksLikeSSHPromptIdentity(_ value: String) -> Bool {

--- a/Zentty/AppState/WorklaneStore+Metadata.swift
+++ b/Zentty/AppState/WorklaneStore+Metadata.swift
@@ -204,6 +204,34 @@ extension WorklaneStore {
         updateMetadata(paneID: id, metadata: metadata)
     }
 
+    func updateForegroundSSHDestination(
+        paneID: PaneID,
+        destination: SSHDestination?
+    ) {
+        guard let worklaneIndex = worklanes.firstIndex(where: { worklane in
+            worklane.paneStripState.panes.contains(where: { $0.id == paneID })
+        }) else {
+            return
+        }
+
+        var worklane = worklanes[worklaneIndex]
+        let previousWorklane = worklane
+        var auxiliaryState = worklane.auxiliaryStateByPaneID[paneID, default: PaneAuxiliaryState()]
+        guard auxiliaryState.raw.foregroundSSHDestination != destination else {
+            return
+        }
+
+        auxiliaryState.raw.foregroundSSHDestination = destination
+        worklane.auxiliaryStateByPaneID[paneID] = auxiliaryState
+        recomputePresentation(for: paneID, in: &worklane)
+        worklanes[worklaneIndex] = worklane
+
+        let impacts = auxiliaryInvalidation(for: paneID, previousWorklane: previousWorklane, nextWorklane: worklane)
+        if !impacts.isEmpty {
+            notify(.auxiliaryStateUpdated(worklane.id, paneID, impacts))
+        }
+    }
+
     /// Gate for the volatile-title early fast path. Declines the fast path
     /// when the current agent state requires human attention (e.g. approval,
     /// question, auth prompts) so the reducer can re-evaluate via the full

--- a/Zentty/MainWindowController.swift
+++ b/Zentty/MainWindowController.swift
@@ -348,6 +348,9 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     }
 
     deinit {
+        MainActorShim.assumeIsolated {
+            rootViewController.cancelAllRemoteImageUploads()
+        }
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -399,6 +402,7 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
+        rootViewController.cancelAllRemoteImageUploads()
         runtimeRegistry.destroyAll()
         onWindowDidClose?(self)
     }
@@ -1181,6 +1185,7 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     }
 
     func tearDownRuntime() {
+        rootViewController.cancelAllRemoteImageUploads()
         runtimeRegistry.destroyAll()
     }
 

--- a/Zentty/TaskManager/TaskManagerProcessSampler.swift
+++ b/Zentty/TaskManager/TaskManagerProcessSampler.swift
@@ -196,7 +196,8 @@ struct DarwinProcessProbe: TaskManagerProcessProbing {
     }
 
     private func processName(pid: Int32) -> String {
-        var buffer = [CChar](repeating: 0, count: Int(MAXCOMLEN))
+        // proc_name requires >= 2*MAXCOMLEN or it fails with ENOMEM.
+        var buffer = [CChar](repeating: 0, count: 2 * Int(MAXCOMLEN))
         let result = proc_name(pid, &buffer, UInt32(buffer.count))
         guard result > 0 else {
             return "pid \(pid)"

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -421,7 +421,7 @@ private final class LibghosttyScrollView: NSScrollView {
 }
 
 @MainActor
-final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControlling, TerminalFocusReporting, TerminalFocusTargetProviding, TerminalOverlayHosting, TerminalScrollRouting, TerminalSmoothScrollConfiguring, TerminalMouseInteractionSuppressionControlling, TerminalContextMenuConfiguring, TerminalViewportDiagnosticsContextConfiguring, LibghosttyScrollbarHandling {
+final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControlling, TerminalFocusReporting, TerminalFocusTargetProviding, TerminalOverlayHosting, TerminalScrollRouting, TerminalSmoothScrollConfiguring, TerminalMouseInteractionSuppressionControlling, TerminalContextMenuConfiguring, TerminalRemoteImagePasteConfiguring, TerminalViewportDiagnosticsContextConfiguring, LibghosttyScrollbarHandling {
     private struct ScrollHostSyncMetrics {
         let geometryApplied: Bool
         let documentHeightChanged: Bool
@@ -513,6 +513,11 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     var contextMenuBuilder: ((NSEvent, NSMenu?) -> NSMenu?)? {
         get { surfaceView.contextMenuBuilder }
         set { surfaceView.contextMenuBuilder = newValue }
+    }
+
+    var remoteImagePasteHandler: ((NSPasteboard, RemoteImagePasteSource) -> Bool)? {
+        get { surfaceView.remoteImagePasteHandler }
+        set { surfaceView.remoteImagePasteHandler = newValue }
     }
 
     init(
@@ -1579,6 +1584,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     var onCellSizeDidChange: (() -> Void)?
     var contextMenuBuilder: ((NSEvent, NSMenu?) -> NSMenu?)?
     var contextMenuPresenter: ((NSMenu, NSEvent, NSView) -> Void)?
+    var remoteImagePasteHandler: ((NSPasteboard, RemoteImagePasteSource) -> Bool)?
     private var terminalCellSizeInPoints: CGSize?
 
     override var acceptsFirstResponder: Bool {
@@ -2156,6 +2162,10 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     }
 
     @IBAction func paste(_ sender: Any?) {
+        if remoteImagePasteHandler?(NSPasteboard.general, .keyboard) == true {
+            return
+        }
+
         _ = surfaceController?.performBindingAction(TerminalBindingAction.pasteFromClipboard)
     }
 
@@ -2613,6 +2623,9 @@ extension LibghosttyView {
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         let pasteboard = sender.draggingPasteboard
+        if remoteImagePasteHandler?(pasteboard, .drag) == true {
+            return true
+        }
 
         let content: String?
         if let url = pasteboard.string(forType: .URL) {

--- a/Zentty/Terminal/PaneSSHProcessProbe.swift
+++ b/Zentty/Terminal/PaneSSHProcessProbe.swift
@@ -1,0 +1,219 @@
+import Darwin
+import Foundation
+import os
+
+protocol PaneSSHProcessTreeProviding: Sendable {
+    func treePIDs(rootPID: Int32) -> [Int32]
+    func processName(pid: Int32) -> String?
+}
+
+protocol PaneSSHProcessArgvProviding: Sendable {
+    func argv(pid: Int32) -> [String]?
+}
+
+struct PaneSSHProcessProbe: Sendable {
+    private let processTreeProvider: any PaneSSHProcessTreeProviding
+    private let argvProvider: any PaneSSHProcessArgvProviding
+
+    init(
+        processTreeProvider: any PaneSSHProcessTreeProviding = DarwinPaneSSHProcessTreeProvider(),
+        argvProvider: any PaneSSHProcessArgvProviding = DarwinPaneSSHProcessArgvProvider()
+    ) {
+        self.processTreeProvider = processTreeProvider
+        self.argvProvider = argvProvider
+    }
+
+    func scan(rootPID: Int32) -> SSHDestination? {
+        guard rootPID > 0 else {
+            return nil
+        }
+
+        let pids = processTreeProvider.treePIDs(rootPID: rootPID)
+        for pid in pids.reversed() {
+            guard WorklaneContextFormatter.isSSHProcess(processTreeProvider.processName(pid: pid)),
+                  let argv = argvProvider.argv(pid: pid),
+                  let destination = Self.destination(fromArgv: argv) else {
+                continue
+            }
+
+            return destination
+        }
+
+        return nil
+    }
+
+    func hasSSH(rootPID: Int32) -> Bool {
+        scan(rootPID: rootPID) != nil
+    }
+
+    static func destination(fromArgv argv: [String]) -> SSHDestination? {
+        guard argv.count > 1 else {
+            return nil
+        }
+
+        let args = Array(argv.dropFirst())
+        var index = 0
+        var explicitUser: String?
+        var port: Int?
+        var rawTarget: String?
+
+        while index < args.count {
+            let token = args[index]
+            if token == "--" {
+                rawTarget = index + 1 < args.count ? args[index + 1] : nil
+                break
+            }
+
+            if token == "-l" {
+                explicitUser = index + 1 < args.count
+                    ? WorklaneContextFormatter.trimmed(args[index + 1])
+                    : nil
+                index += 2
+                continue
+            }
+
+            if token.hasPrefix("-l"), token.count > 2 {
+                explicitUser = WorklaneContextFormatter.trimmed(String(token.dropFirst(2)))
+                index += 1
+                continue
+            }
+
+            if token == "-p" {
+                port = index + 1 < args.count ? Int(args[index + 1]) : nil
+                index += 2
+                continue
+            }
+
+            if token.hasPrefix("-p"), token.count > 2 {
+                port = Int(String(token.dropFirst(2)))
+                index += 1
+                continue
+            }
+
+            if token.hasPrefix("-") {
+                index += sshOptionConsumesNextToken(token) ? 2 : 1
+                continue
+            }
+
+            rawTarget = token
+            break
+        }
+
+        guard let normalizedTarget = rawTarget.map(normalizeSSHTarget),
+              !normalizedTarget.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        let parsedUser = sshUser(fromTarget: normalizedTarget)
+        let user = parsedUser ?? explicitUser
+        let host = sshHost(fromTarget: normalizedTarget)
+        let target = user.map { "\($0)@\(host)" } ?? normalizedTarget
+
+        return SSHDestination(target: target, user: user, host: host, port: port)
+    }
+
+    private static func normalizeSSHTarget(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func sshUser(fromTarget target: String) -> String? {
+        let components = target.split(separator: "@", maxSplits: 1).map(String.init)
+        guard components.count == 2 else {
+            return nil
+        }
+
+        return WorklaneContextFormatter.trimmed(components[0])
+    }
+
+    private static func sshHost(fromTarget target: String) -> String {
+        target.split(separator: "@", maxSplits: 1).last.map(String.init) ?? target
+    }
+
+    private static func sshOptionConsumesNextToken(_ token: String) -> Bool {
+        sshOptionsRequiringValues.contains(token)
+    }
+
+    private static let sshOptionsRequiringValues: Set<String> = [
+        "-B", "-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-J", "-L",
+        "-l", "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w"
+    ]
+}
+
+struct DarwinPaneSSHProcessTreeProvider: PaneSSHProcessTreeProviding {
+    func treePIDs(rootPID: Int32) -> [Int32] {
+        DarwinProcessProbe().treePIDs(rootPID: rootPID)
+    }
+
+    func processName(pid: Int32) -> String? {
+        // proc_name requires >= 2*MAXCOMLEN or it fails with ENOMEM.
+        var buffer = [CChar](repeating: 0, count: 2 * Int(MAXCOMLEN))
+        let result = proc_name(pid, &buffer, UInt32(buffer.count))
+        guard result > 0 else {
+            return nil
+        }
+
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+struct DarwinPaneSSHProcessArgvProvider: PaneSSHProcessArgvProviding {
+    private static let logger = Logger(subsystem: "be.zenjoy.zentty", category: "PaneSSHProcessProbe")
+
+    func argv(pid: Int32) -> [String]? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else {
+            Self.logger.debug("Could not read process argv size pid=\(pid, privacy: .public) errno=\(errno, privacy: .public)")
+            return nil
+        }
+
+        var buffer = [UInt8](repeating: 0, count: size)
+        let result = buffer.withUnsafeMutableBytes { rawBuffer in
+            sysctl(&mib, u_int(mib.count), rawBuffer.baseAddress, &size, nil, 0)
+        }
+        guard result == 0, size > MemoryLayout<Int32>.size else {
+            Self.logger.debug("Could not read process argv pid=\(pid, privacy: .public) errno=\(errno, privacy: .public)")
+            return nil
+        }
+
+        return parseProcArgsBuffer(Array(buffer.prefix(size)))
+    }
+
+    private func parseProcArgsBuffer(_ buffer: [UInt8]) -> [String]? {
+        guard buffer.count > MemoryLayout<Int32>.size else {
+            return nil
+        }
+
+        let argc = buffer.withUnsafeBytes { rawBuffer in
+            rawBuffer.loadUnaligned(fromByteOffset: 0, as: Int32.self)
+        }
+        guard argc > 0 else {
+            return nil
+        }
+
+        var cursor = MemoryLayout<Int32>.size
+        while cursor < buffer.count, buffer[cursor] != 0 {
+            cursor += 1
+        }
+        while cursor < buffer.count, buffer[cursor] == 0 {
+            cursor += 1
+        }
+
+        var arguments: [String] = []
+        while cursor < buffer.count, arguments.count < Int(argc) {
+            let start = cursor
+            while cursor < buffer.count, buffer[cursor] != 0 {
+                cursor += 1
+            }
+
+            if cursor > start,
+               let argument = String(bytes: buffer[start..<cursor], encoding: .utf8) {
+                arguments.append(argument)
+            }
+            cursor += 1
+        }
+
+        return arguments.isEmpty ? nil : arguments
+    }
+}

--- a/Zentty/Terminal/RemoteFileUploadRequest.swift
+++ b/Zentty/Terminal/RemoteFileUploadRequest.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+struct RemoteFileResourceValues: Equatable, Sendable {
+    let isDirectory: Bool
+    let fileSize: Int64?
+}
+
+protocol RemoteFileResourceResolving: Sendable {
+    func values(for fileURL: URL) throws -> RemoteFileResourceValues
+}
+
+struct FileManagerRemoteFileResourceResolver: RemoteFileResourceResolving {
+    func values(for fileURL: URL) throws -> RemoteFileResourceValues {
+        let resourceValues = try fileURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey])
+        return RemoteFileResourceValues(
+            isDirectory: resourceValues.isDirectory == true,
+            fileSize: resourceValues.fileSize.map(Int64.init)
+        )
+    }
+}
+
+struct RemoteFileUploadRequest: Equatable, Sendable {
+    let localURL: URL
+    let originalFilename: String
+    let byteCount: Int64
+}
+
+enum RemoteFileUploadRequestResolution: Equatable, Sendable {
+    case noFiles
+    case files([RemoteFileUploadRequest])
+    case foldersOnly
+    case fileTooLarge
+    case failedToResolve
+}
+
+enum RemoteFileUploadRequestResolver {
+    static let maxFileByteCount: Int64 = 500 * 1024 * 1024
+
+    static func resolve(
+        fileURLs: [URL],
+        resourceResolver: any RemoteFileResourceResolving = FileManagerRemoteFileResourceResolver()
+    ) -> RemoteFileUploadRequestResolution {
+        guard !fileURLs.isEmpty else {
+            return .noFiles
+        }
+
+        var requests: [RemoteFileUploadRequest] = []
+        var skippedDirectoryCount = 0
+        var sawNonDirectory = false
+
+        for fileURL in fileURLs {
+            let values: RemoteFileResourceValues
+            do {
+                values = try resourceResolver.values(for: fileURL)
+            } catch {
+                return .failedToResolve
+            }
+
+            if values.isDirectory {
+                skippedDirectoryCount += 1
+                continue
+            }
+
+            sawNonDirectory = true
+            guard let byteCount = values.fileSize else {
+                return .failedToResolve
+            }
+            guard byteCount <= maxFileByteCount else {
+                return .fileTooLarge
+            }
+
+            let filename = fileURL.lastPathComponent.isEmpty ? "file" : fileURL.lastPathComponent
+            requests.append(
+                RemoteFileUploadRequest(
+                    localURL: fileURL,
+                    originalFilename: filename,
+                    byteCount: byteCount
+                )
+            )
+        }
+
+        if !requests.isEmpty {
+            return .files(requests)
+        }
+
+        if skippedDirectoryCount > 0 && !sawNonDirectory {
+            return .foldersOnly
+        }
+
+        return .failedToResolve
+    }
+}
+
+struct RemoteFileUploadProgress: Equatable, Sendable {
+    let filename: String
+    let fileIndex: Int
+    let fileCount: Int
+    let fraction: Double
+}
+
+struct RemoteFileUploadBatchResult: Equatable, Sendable {
+    let successfulRemotePaths: [String]
+    let failedCount: Int
+    let totalCount: Int
+    let firstFailure: RemoteImageUploadError?
+
+    var pasteText: String {
+        successfulRemotePaths
+            .map { ShellEscaping.escapePath($0) }
+            .joined(separator: " ")
+    }
+}
+
+struct RemoteFileUploadBatch: Sendable {
+    let uploader: RemoteImageUploader
+
+    func uploadFiles(
+        _ requests: [RemoteFileUploadRequest],
+        destination: SSHDestination,
+        progress: @escaping @MainActor @Sendable (RemoteFileUploadProgress) -> Void
+    ) async throws -> RemoteFileUploadBatchResult {
+        var successfulRemotePaths: [String] = []
+        var failedCount = 0
+        var firstFailure: RemoteImageUploadError?
+        let totalCount = requests.count
+
+        for (index, request) in requests.enumerated() {
+            do {
+                let remotePath = try await uploader.upload(
+                    fileURL: request.localURL,
+                    originalFilename: request.originalFilename,
+                    byteCount: request.byteCount,
+                    destination: destination,
+                    progress: { fraction in
+                        progress(
+                            RemoteFileUploadProgress(
+                                filename: request.originalFilename,
+                                fileIndex: index + 1,
+                                fileCount: totalCount,
+                                fraction: fraction
+                            )
+                        )
+                    }
+                )
+                successfulRemotePaths.append(remotePath)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as RemoteImageUploadError {
+                failedCount += 1
+                if firstFailure == nil {
+                    firstFailure = error
+                }
+            } catch {
+                failedCount += 1
+                if firstFailure == nil {
+                    firstFailure = .transferFailed
+                }
+            }
+
+            try Task.checkCancellation()
+        }
+
+        return RemoteFileUploadBatchResult(
+            successfulRemotePaths: successfulRemotePaths,
+            failedCount: failedCount,
+            totalCount: totalCount,
+            firstFailure: firstFailure
+        )
+    }
+}

--- a/Zentty/Terminal/RemoteImagePasteDecision.swift
+++ b/Zentty/Terminal/RemoteImagePasteDecision.swift
@@ -1,0 +1,61 @@
+enum RemoteImagePasteboardContents: Equatable, Sendable {
+    case empty
+    case text
+    case imageData
+    case imageFileURL
+    case imageTooLarge
+    case nonImageFileURL
+
+    var containsImage: Bool {
+        switch self {
+        case .imageData, .imageFileURL, .imageTooLarge:
+            return true
+        case .empty, .text, .nonImageFileURL:
+            return false
+        }
+    }
+}
+
+struct RemoteImagePastePaneState: Equatable, Sendable {
+    let isRemotePane: Bool
+    let destination: SSHDestination?
+}
+
+enum RemoteImagePasteDestination {
+    static func destination(from auxiliaryState: PaneAuxiliaryState) -> SSHDestination? {
+        if let destination = auxiliaryState.raw.foregroundSSHDestination {
+            return destination
+        }
+
+        if let title = WorklaneContextFormatter.trimmed(auxiliaryState.raw.metadata?.title),
+           let destination = WorklaneContextFormatter.sshDestination(fromCommandTitle: title) {
+            return destination
+        }
+
+        if let label = WorklaneContextFormatter.trimmed(auxiliaryState.presentation.sshConnectionLabel) {
+            return SSHDestination(target: label)
+        }
+
+        if let shellContext = auxiliaryState.raw.shellContext,
+           shellContext.scope == .remote,
+           let host = WorklaneContextFormatter.trimmed(shellContext.host) {
+            let user = WorklaneContextFormatter.trimmed(shellContext.user)
+            return SSHDestination(
+                target: user.map { "\($0)@\(host)" } ?? host,
+                user: user,
+                host: host
+            )
+        }
+
+        return nil
+    }
+}
+
+enum RemoteImagePasteDecision {
+    static func shouldUploadRemotely(
+        paneState: RemoteImagePastePaneState,
+        pasteboardContents: RemoteImagePasteboardContents
+    ) -> Bool {
+        paneState.isRemotePane && pasteboardContents.containsImage
+    }
+}

--- a/Zentty/Terminal/RemoteImagePasteDecision.swift
+++ b/Zentty/Terminal/RemoteImagePasteDecision.swift
@@ -2,15 +2,14 @@ enum RemoteImagePasteboardContents: Equatable, Sendable {
     case empty
     case text
     case imageData
-    case imageFileURL
+    case fileURL
     case imageTooLarge
-    case nonImageFileURL
 
-    var containsImage: Bool {
+    var shouldUpload: Bool {
         switch self {
-        case .imageData, .imageFileURL, .imageTooLarge:
+        case .imageData, .fileURL, .imageTooLarge:
             return true
-        case .empty, .text, .nonImageFileURL:
+        case .empty, .text:
             return false
         }
     }
@@ -56,6 +55,6 @@ enum RemoteImagePasteDecision {
         paneState: RemoteImagePastePaneState,
         pasteboardContents: RemoteImagePasteboardContents
     ) -> Bool {
-        paneState.isRemotePane && pasteboardContents.containsImage
+        paneState.isRemotePane && pasteboardContents.shouldUpload
     }
 }

--- a/Zentty/Terminal/RemoteImageUploadPath.swift
+++ b/Zentty/Terminal/RemoteImageUploadPath.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+enum RemoteImageUploadPath {
+    static func generate(
+        fileExtension: String,
+        date: Date = Date(),
+        uuid: UUID = UUID()
+    ) -> String {
+        let timestamp = Int(date.timeIntervalSince1970)
+        let uuidPrefix = uuid.uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .prefix(8)
+            .lowercased()
+        let ext = TerminalClipboardImagePolicy.normalizedFileExtension(fileExtension)
+        return "/tmp/zentty-paste-\(timestamp)-\(uuidPrefix).\(ext)"
+    }
+
+    static func path(
+        forOriginalFilename originalFilename: String,
+        date: Date = Date(),
+        uuid: UUID = UUID()
+    ) -> String {
+        let timestamp = Int(date.timeIntervalSince1970)
+        let uuidPrefix = uuid.uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .prefix(8)
+            .lowercased()
+        let sanitizedFilename = sanitizedOriginalFilename(originalFilename)
+        return "/tmp/zentty-paste-\(timestamp)-\(uuidPrefix)-\(sanitizedFilename)"
+    }
+
+    static func isSafeRemotePath(_ path: String) -> Bool {
+        path.range(
+            of: #"^/tmp/zentty-paste-[A-Za-z0-9._-]+$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func sanitizedOriginalFilename(_ originalFilename: String) -> String {
+        let filename = originalFilename.isEmpty ? "file" : originalFilename
+        let split = splitFilename(filename)
+        let sanitizedStem = sanitizedFilenameComponent(split.stem)
+        let sanitizedExtension = split.extension.map(sanitizedFilenameComponent)
+
+        let stem = sanitizedStem.isEmpty ? "file" : sanitizedStem
+        guard let ext = sanitizedExtension, !ext.isEmpty else {
+            return capped(stem, limit: 128)
+        }
+
+        let extensionWithDot = ".\(capped(ext, limit: 64))"
+        let stemLimit = max(1, 128 - extensionWithDot.count)
+        return "\(capped(stem, limit: stemLimit))\(extensionWithDot)"
+    }
+
+    private static func splitFilename(_ filename: String) -> (stem: String, extension: String?) {
+        let scalars = Array(filename.unicodeScalars)
+        if scalars.first?.value == 46,
+           scalars.dropFirst().allSatisfy({ $0.value != 46 }) {
+            return (filename, nil)
+        }
+
+        guard let dotIndex = filename.lastIndex(of: "."),
+              dotIndex != filename.startIndex,
+              dotIndex < filename.index(before: filename.endIndex)
+        else {
+            return (filename, nil)
+        }
+
+        return (
+            String(filename[..<dotIndex]),
+            String(filename[filename.index(after: dotIndex)...])
+        )
+    }
+
+    private static func sanitizedFilenameComponent(_ component: String) -> String {
+        var result = ""
+        var previousWasDash = false
+        for scalar in component.unicodeScalars {
+            if scalar.value == 45 {
+                if !previousWasDash {
+                    result.append("-")
+                }
+                previousWasDash = true
+            } else if isAllowedFilenameScalar(scalar) {
+                result.unicodeScalars.append(scalar)
+                previousWasDash = false
+            } else if !previousWasDash {
+                result.append("-")
+                previousWasDash = true
+            }
+        }
+
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: ".-"))
+    }
+
+    private static func isAllowedFilenameScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 48...57, 65...90, 97...122:
+            return true
+        case 45, 46, 95:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func capped(_ value: String, limit: Int) -> String {
+        guard value.count > limit else {
+            return value
+        }
+
+        return String(value.prefix(limit))
+    }
+}

--- a/Zentty/Terminal/RemoteImageUploader.swift
+++ b/Zentty/Terminal/RemoteImageUploader.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+struct SSHDestination: Equatable, Sendable {
+    let target: String
+    let user: String?
+    let host: String
+    let port: Int?
+
+    init(target: String, user: String? = nil, host: String? = nil, port: Int? = nil) {
+        self.target = target
+        self.user = user
+        self.host = host ?? Self.host(from: target)
+        self.port = port
+    }
+
+    private static func host(from target: String) -> String {
+        target.split(separator: "@", maxSplits: 1).last.map(String.init) ?? target
+    }
+}
+
+enum RemoteImageUploadError: Error, Equatable, Sendable {
+    case authRequired
+    case hostUnreachable
+    case timeout
+    case transferFailed
+    case invalidRemotePath
+}
+
+struct RemoteImageUploadProcessResult: Equatable, Sendable {
+    let exitStatus: Int32
+    let stderr: String
+    let timedOut: Bool
+}
+
+protocol RemoteImageUploadProcess: AnyObject, Sendable {
+    func run() throws
+    func write(_ data: Data) throws
+    func closeStandardInput()
+    func waitUntilExit(timeout: TimeInterval) -> RemoteImageUploadProcessResult
+    func terminate()
+}
+
+protocol RemoteImageUploadProcessFactory: Sendable {
+    func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess
+}
+
+struct ProcessRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory {
+    func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess {
+        ProcessRemoteImageUploadProcess(executableURL: executableURL, arguments: arguments)
+    }
+}
+
+struct RemoteImageUploader: Sendable {
+    private let processFactory: any RemoteImageUploadProcessFactory
+    private let remotePathProvider: @Sendable (String) -> String
+    private let chunkSize: Int
+    private let timeout: TimeInterval
+
+    init(
+        processFactory: any RemoteImageUploadProcessFactory = ProcessRemoteImageUploadProcessFactory(),
+        remotePathProvider: @escaping @Sendable (String) -> String = { fileExtension in
+            RemoteImageUploadPath.generate(fileExtension: fileExtension)
+        },
+        chunkSize: Int = 64 * 1024,
+        timeout: TimeInterval = 60
+    ) {
+        self.processFactory = processFactory
+        self.remotePathProvider = remotePathProvider
+        self.chunkSize = max(1, chunkSize)
+        self.timeout = timeout
+    }
+
+    func upload(
+        imageData: Data,
+        fileExtension: String,
+        destination: SSHDestination,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> String {
+        let normalizedExtension = TerminalClipboardImagePolicy.normalizedFileExtension(fileExtension)
+        let remotePath = remotePathProvider(normalizedExtension)
+        guard RemoteImageUploadPath.isSafeRemotePath(remotePath) else {
+            throw RemoteImageUploadError.invalidRemotePath
+        }
+
+        let arguments = Self.sshArguments(destination: destination, remotePath: remotePath)
+        let executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        let processFactory = processFactory
+        let chunkSize = chunkSize
+        let timeout = timeout
+
+        let uploadTask = Task<String, Error>.detached(priority: .utility) {
+            let process = processFactory.makeProcess(
+                executableURL: executableURL,
+                arguments: arguments
+            )
+            let timeoutState = TimeoutState()
+            let timeoutTask = Self.startTimeout(
+                seconds: timeout,
+                process: process,
+                timeoutState: timeoutState
+            )
+            defer {
+                timeoutTask.cancel()
+            }
+
+            return try await withTaskCancellationHandler(operation: {
+                try await Self.writeAndValidateUpload(
+                    imageData: imageData,
+                    process: process,
+                    chunkSize: chunkSize,
+                    timeout: timeout,
+                    timeoutState: timeoutState,
+                    progress: progress
+                )
+                return remotePath
+            }, onCancel: {
+                process.terminate()
+                process.closeStandardInput()
+            })
+        }
+
+        return try await withTaskCancellationHandler(operation: {
+            try await uploadTask.value
+        }, onCancel: {
+            uploadTask.cancel()
+        })
+    }
+
+    private static func writeAndValidateUpload(
+        imageData: Data,
+        process: any RemoteImageUploadProcess,
+        chunkSize: Int,
+        timeout: TimeInterval,
+        timeoutState: TimeoutState,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws {
+        var didRunProcess = false
+        do {
+            try process.run()
+            didRunProcess = true
+            try Task.checkCancellation()
+            try await write(
+                imageData,
+                to: process,
+                chunkSize: chunkSize,
+                progress: progress
+            )
+            let result = process.waitUntilExit(timeout: timeout)
+            if timeoutState.timedOut {
+                throw RemoteImageUploadError.timeout
+            }
+
+            try validate(result)
+        } catch let uploadError as RemoteImageUploadError {
+            process.closeStandardInput()
+            if timeoutState.timedOut {
+                throw RemoteImageUploadError.timeout
+            }
+            throw uploadError
+        } catch is CancellationError {
+            process.terminate()
+            process.closeStandardInput()
+            throw CancellationError()
+        } catch {
+            process.closeStandardInput()
+            if timeoutState.timedOut {
+                throw RemoteImageUploadError.timeout
+            }
+
+            if didRunProcess {
+                let result = process.waitUntilExit(timeout: timeout)
+                if timeoutState.timedOut || result.timedOut {
+                    throw RemoteImageUploadError.timeout
+                }
+
+                if result.exitStatus != 0 {
+                    throw classifiedError(stderr: result.stderr)
+                }
+            }
+
+            throw RemoteImageUploadError.transferFailed
+        }
+    }
+
+    static func sshArguments(destination: SSHDestination, remotePath: String) -> [String] {
+        var arguments = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=10",
+        ]
+        if let port = destination.port {
+            arguments += ["-p", "\(port)"]
+        }
+        arguments += [
+            "--",
+            destination.target,
+            "sh",
+            "-c",
+            "umask 077; cat > \(remotePath)",
+        ]
+        return arguments
+    }
+
+    private static func write(
+        _ imageData: Data,
+        to process: any RemoteImageUploadProcess,
+        chunkSize: Int,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws {
+        var offset = 0
+        let totalBytes = imageData.count
+        while offset < totalBytes {
+            try Task.checkCancellation()
+            let end = min(offset + chunkSize, totalBytes)
+            try process.write(imageData.subdata(in: offset..<end))
+            offset = end
+            await MainActor.run {
+                progress(Double(offset) / Double(totalBytes))
+            }
+        }
+        try Task.checkCancellation()
+        process.closeStandardInput()
+    }
+
+    private static func validate(_ result: RemoteImageUploadProcessResult) throws {
+        if result.timedOut {
+            throw RemoteImageUploadError.timeout
+        }
+
+        guard result.exitStatus == 0 else {
+            throw classifiedError(stderr: result.stderr)
+        }
+    }
+
+    private static func classifiedError(stderr: String) -> RemoteImageUploadError {
+        let lowered = stderr.lowercased()
+        if lowered.contains("permission denied")
+            || lowered.contains("publickey")
+            || lowered.contains("authentication")
+        {
+            return .authRequired
+        }
+
+        if lowered.contains("operation timed out")
+            || lowered.contains("connection timed out")
+            || lowered.contains("could not resolve hostname")
+            || lowered.contains("no route to host")
+            || lowered.contains("connection refused")
+            || lowered.contains("host is down")
+        {
+            return .hostUnreachable
+        }
+
+        return .transferFailed
+    }
+
+    private static func startTimeout(
+        seconds: TimeInterval,
+        process: any RemoteImageUploadProcess,
+        timeoutState: TimeoutState
+    ) -> Task<Void, Never> {
+        let nanoseconds = UInt64(max(0.001, seconds) * 1_000_000_000)
+        return Task.detached(priority: .utility) {
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+            } catch {
+                return
+            }
+
+            timeoutState.markTimedOut()
+            process.terminate()
+            process.closeStandardInput()
+        }
+    }
+}
+
+enum RemoteImageUploadPath {
+    static func generate(
+        fileExtension: String,
+        date: Date = Date(),
+        uuid: UUID = UUID()
+    ) -> String {
+        let timestamp = Int(date.timeIntervalSince1970)
+        let uuidPrefix = uuid.uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .prefix(8)
+            .lowercased()
+        let ext = TerminalClipboardImagePolicy.normalizedFileExtension(fileExtension)
+        return "/tmp/zentty-paste-\(timestamp)-\(uuidPrefix).\(ext)"
+    }
+
+    static func isSafeRemotePath(_ path: String) -> Bool {
+        path.range(
+            of: #"^/tmp/zentty-paste-[A-Za-z0-9._-]+$"#,
+            options: .regularExpression
+        ) != nil
+    }
+}
+
+private final class ProcessRemoteImageUploadProcess: RemoteImageUploadProcess, @unchecked Sendable {
+    private let process = Process()
+    private let inputPipe = Pipe()
+    private let stderrPipe = Pipe()
+
+    init(executableURL: URL, arguments: [String]) {
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardInput = inputPipe
+        process.standardError = stderrPipe
+    }
+
+    func run() throws {
+        try process.run()
+    }
+
+    func write(_ data: Data) throws {
+        try inputPipe.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    func closeStandardInput() {
+        try? inputPipe.fileHandleForWriting.close()
+    }
+
+    func waitUntilExit(timeout: TimeInterval) -> RemoteImageUploadProcessResult {
+        let timeoutState = TimeoutState()
+        let timeoutWorkItem = DispatchWorkItem { [weak self] in
+            timeoutState.markTimedOut()
+            self?.process.terminate()
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + timeout,
+            execute: timeoutWorkItem
+        )
+
+        process.waitUntilExit()
+        timeoutWorkItem.cancel()
+
+        let stderrData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+        return RemoteImageUploadProcessResult(
+            exitStatus: process.terminationStatus,
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            timedOut: timeoutState.timedOut
+        )
+    }
+
+    func terminate() {
+        process.terminate()
+    }
+}
+
+private final class TimeoutState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var timedOut: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func markTimedOut() {
+        lock.lock()
+        value = true
+        lock.unlock()
+    }
+}

--- a/Zentty/Terminal/RemoteImageUploader.swift
+++ b/Zentty/Terminal/RemoteImageUploader.swift
@@ -44,6 +44,11 @@ protocol RemoteImageUploadProcessFactory: Sendable {
     func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess
 }
 
+private enum UploadSource: Sendable {
+    case data(Data)
+    case file(url: URL, byteCount: Int64)
+}
+
 struct ProcessRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory {
     func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess {
         ProcessRemoteImageUploadProcess(executableURL: executableURL, arguments: arguments)
@@ -53,6 +58,7 @@ struct ProcessRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory {
 struct RemoteImageUploader: Sendable {
     private let processFactory: any RemoteImageUploadProcessFactory
     private let remotePathProvider: @Sendable (String) -> String
+    private let fileRemotePathProvider: @Sendable (String) -> String
     private let chunkSize: Int
     private let timeout: TimeInterval
 
@@ -61,11 +67,15 @@ struct RemoteImageUploader: Sendable {
         remotePathProvider: @escaping @Sendable (String) -> String = { fileExtension in
             RemoteImageUploadPath.generate(fileExtension: fileExtension)
         },
+        fileRemotePathProvider: @escaping @Sendable (String) -> String = { originalFilename in
+            RemoteImageUploadPath.path(forOriginalFilename: originalFilename)
+        },
         chunkSize: Int = 64 * 1024,
         timeout: TimeInterval = 60
     ) {
         self.processFactory = processFactory
         self.remotePathProvider = remotePathProvider
+        self.fileRemotePathProvider = fileRemotePathProvider
         self.chunkSize = max(1, chunkSize)
         self.timeout = timeout
     }
@@ -78,6 +88,36 @@ struct RemoteImageUploader: Sendable {
     ) async throws -> String {
         let normalizedExtension = TerminalClipboardImagePolicy.normalizedFileExtension(fileExtension)
         let remotePath = remotePathProvider(normalizedExtension)
+        return try await upload(
+            source: .data(imageData),
+            remotePath: remotePath,
+            destination: destination,
+            progress: progress
+        )
+    }
+
+    func upload(
+        fileURL: URL,
+        originalFilename: String,
+        byteCount: Int64,
+        destination: SSHDestination,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> String {
+        let remotePath = fileRemotePathProvider(originalFilename)
+        return try await upload(
+            source: .file(url: fileURL, byteCount: byteCount),
+            remotePath: remotePath,
+            destination: destination,
+            progress: progress
+        )
+    }
+
+    private func upload(
+        source: UploadSource,
+        remotePath: String,
+        destination: SSHDestination,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws -> String {
         guard RemoteImageUploadPath.isSafeRemotePath(remotePath) else {
             throw RemoteImageUploadError.invalidRemotePath
         }
@@ -105,7 +145,7 @@ struct RemoteImageUploader: Sendable {
 
             return try await withTaskCancellationHandler(operation: {
                 try await Self.writeAndValidateUpload(
-                    imageData: imageData,
+                    source: source,
                     process: process,
                     chunkSize: chunkSize,
                     timeout: timeout,
@@ -127,7 +167,7 @@ struct RemoteImageUploader: Sendable {
     }
 
     private static func writeAndValidateUpload(
-        imageData: Data,
+        source: UploadSource,
         process: any RemoteImageUploadProcess,
         chunkSize: Int,
         timeout: TimeInterval,
@@ -140,7 +180,7 @@ struct RemoteImageUploader: Sendable {
             didRunProcess = true
             try Task.checkCancellation()
             try await write(
-                imageData,
+                source,
                 to: process,
                 chunkSize: chunkSize,
                 progress: progress
@@ -201,6 +241,31 @@ struct RemoteImageUploader: Sendable {
     }
 
     private static func write(
+        _ source: UploadSource,
+        to process: any RemoteImageUploadProcess,
+        chunkSize: Int,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws {
+        switch source {
+        case .data(let imageData):
+            try await write(
+                imageData,
+                to: process,
+                chunkSize: chunkSize,
+                progress: progress
+            )
+        case .file(let url, let byteCount):
+            try await writeFile(
+                at: url,
+                byteCount: byteCount,
+                to: process,
+                chunkSize: chunkSize,
+                progress: progress
+            )
+        }
+    }
+
+    private static func write(
         _ imageData: Data,
         to process: any RemoteImageUploadProcess,
         chunkSize: Int,
@@ -208,6 +273,14 @@ struct RemoteImageUploader: Sendable {
     ) async throws {
         var offset = 0
         let totalBytes = imageData.count
+        guard totalBytes > 0 else {
+            await MainActor.run {
+                progress(1)
+            }
+            process.closeStandardInput()
+            return
+        }
+
         while offset < totalBytes {
             try Task.checkCancellation()
             let end = min(offset + chunkSize, totalBytes)
@@ -217,6 +290,45 @@ struct RemoteImageUploader: Sendable {
                 progress(Double(offset) / Double(totalBytes))
             }
         }
+        try Task.checkCancellation()
+        process.closeStandardInput()
+    }
+
+    private static func writeFile(
+        at fileURL: URL,
+        byteCount: Int64,
+        to process: any RemoteImageUploadProcess,
+        chunkSize: Int,
+        progress: @escaping @MainActor @Sendable (Double) -> Void
+    ) async throws {
+        let fileHandle = try FileHandle(forReadingFrom: fileURL)
+        defer {
+            try? fileHandle.close()
+        }
+
+        guard byteCount > 0 else {
+            await MainActor.run {
+                progress(1)
+            }
+            process.closeStandardInput()
+            return
+        }
+
+        var writtenByteCount: Int64 = 0
+        while true {
+            try Task.checkCancellation()
+            let chunk = try fileHandle.read(upToCount: chunkSize) ?? Data()
+            if chunk.isEmpty {
+                break
+            }
+
+            try process.write(chunk)
+            writtenByteCount += Int64(chunk.count)
+            await MainActor.run {
+                progress(Double(writtenByteCount) / Double(byteCount))
+            }
+        }
+
         try Task.checkCancellation()
         process.closeStandardInput()
     }
@@ -270,29 +382,6 @@ struct RemoteImageUploader: Sendable {
             process.terminate()
             process.closeStandardInput()
         }
-    }
-}
-
-enum RemoteImageUploadPath {
-    static func generate(
-        fileExtension: String,
-        date: Date = Date(),
-        uuid: UUID = UUID()
-    ) -> String {
-        let timestamp = Int(date.timeIntervalSince1970)
-        let uuidPrefix = uuid.uuidString
-            .replacingOccurrences(of: "-", with: "")
-            .prefix(8)
-            .lowercased()
-        let ext = TerminalClipboardImagePolicy.normalizedFileExtension(fileExtension)
-        return "/tmp/zentty-paste-\(timestamp)-\(uuidPrefix).\(ext)"
-    }
-
-    static func isSafeRemotePath(_ path: String) -> Bool {
-        path.range(
-            of: #"^/tmp/zentty-paste-[A-Za-z0-9._-]+$"#,
-            options: .regularExpression
-        ) != nil
     }
 }
 

--- a/Zentty/Terminal/TerminalAdapter.swift
+++ b/Zentty/Terminal/TerminalAdapter.swift
@@ -174,6 +174,11 @@ enum TerminalSearchEvent: Equatable, Sendable {
     case selected(Int)
 }
 
+enum RemoteImagePasteSource: Equatable, Sendable {
+    case keyboard
+    case drag
+}
+
 @MainActor
 protocol TerminalAdapter: AnyObject {
     var hasScrollback: Bool { get }
@@ -252,6 +257,11 @@ protocol TerminalMouseInteractionSuppressionControlling: AnyObject {
 @MainActor
 protocol TerminalContextMenuConfiguring: AnyObject {
     var contextMenuBuilder: ((NSEvent, NSMenu?) -> NSMenu?)? { get set }
+}
+
+@MainActor
+protocol TerminalRemoteImagePasteConfiguring: AnyObject {
+    var remoteImagePasteHandler: ((NSPasteboard, RemoteImagePasteSource) -> Bool)? { get set }
 }
 
 @MainActor

--- a/Zentty/Terminal/TerminalClipboard.swift
+++ b/Zentty/Terminal/TerminalClipboard.swift
@@ -28,13 +28,7 @@ enum TerminalClipboard {
     // MARK: - Public
 
     static func pastedString(from pasteboard: NSPasteboard) -> String? {
-        let fileURLReadOptions: [NSPasteboard.ReadingOptionKey: Any] = [
-            .urlReadingFileURLsOnly: true,
-        ]
-        if let fileURLs = pasteboard.readObjects(
-            forClasses: [NSURL.self],
-            options: fileURLReadOptions
-        ) as? [URL], fileURLs.isEmpty == false {
+        if !fileURLs(from: pasteboard).isEmpty {
             return nil
         }
 
@@ -43,13 +37,8 @@ enum TerminalClipboard {
 
     static func pastedContent(from pasteboard: NSPasteboard) -> PastedContent? {
         // 1. File URLs — escape paths
-        let fileURLReadOptions: [NSPasteboard.ReadingOptionKey: Any] = [
-            .urlReadingFileURLsOnly: true,
-        ]
-        if let fileURLs = pasteboard.readObjects(
-            forClasses: [NSURL.self],
-            options: fileURLReadOptions
-        ) as? [URL], !fileURLs.isEmpty {
+        let fileURLs = fileURLs(from: pasteboard)
+        if !fileURLs.isEmpty {
             let escaped = fileURLs
                 .map { ShellEscaping.escapePath($0.path) }
                 .joined(separator: " ")
@@ -70,14 +59,8 @@ enum TerminalClipboard {
     }
 
     static func imageUploadContent(from pasteboard: NSPasteboard) -> ImageUploadContent {
-        let fileURLReadOptions: [NSPasteboard.ReadingOptionKey: Any] = [
-            .urlReadingFileURLsOnly: true,
-        ]
-        if let fileURLs = pasteboard.readObjects(
-            forClasses: [NSURL.self],
-            options: fileURLReadOptions
-        ) as? [URL], !fileURLs.isEmpty {
-            return imageUploadContent(fromFileURLs: fileURLs)
+        if !fileURLs(from: pasteboard).isEmpty {
+            return .noImage
         }
 
         guard hasImageData(in: pasteboard) else {
@@ -94,6 +77,16 @@ enum TerminalClipboard {
         }
 
         return .image(pastedImage)
+    }
+
+    static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
+        let fileURLReadOptions: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        return pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: fileURLReadOptions
+        ) as? [URL] ?? []
     }
 
     // MARK: - Image helpers
@@ -174,61 +167,4 @@ enum TerminalClipboard {
         return nil
     }
 
-    private static func imageUploadContent(fromFileURLs fileURLs: [URL]) -> ImageUploadContent {
-        let imageFileURLs = fileURLs.filter { imageType(forFileURL: $0) != nil }
-        guard let imageFileURL = imageFileURLs.first else {
-            return .noImage
-        }
-
-        if imageFileURLs.count > 1 {
-            logger.info("Uploading first pasted image file and ignoring \(imageFileURLs.count - 1) additional image files")
-        }
-
-        do {
-            if let fileSize = imageFileSize(for: imageFileURL),
-               fileSize > TerminalClipboardImagePolicy.maxImageByteCount {
-                logger.warning("Pasted image file too large: \(fileSize) bytes")
-                return .imageTooLarge
-            }
-
-            let data = try Data(contentsOf: imageFileURL)
-            guard data.count <= TerminalClipboardImagePolicy.maxImageByteCount else {
-                logger.warning("Pasted image file too large: \(data.count) bytes")
-                return .imageTooLarge
-            }
-
-            return .image(
-                PastedImage(
-                    data: data,
-                    fileExtension: TerminalClipboardImagePolicy.fileExtension(
-                        for: imageType(forFileURL: imageFileURL)
-                    )
-                )
-            )
-        } catch {
-            logger.error("Failed to read pasted image file: \(error.localizedDescription)")
-            return .failedToReadImage
-        }
-    }
-
-    private static func imageFileSize(for fileURL: URL) -> Int? {
-        (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
-    }
-
-    private static func imageType(forFileURL fileURL: URL) -> UTType? {
-        if let values = try? fileURL.resourceValues(forKeys: [.contentTypeKey]),
-           let contentType = values.contentType,
-           contentType.conforms(to: .image) {
-            return contentType
-        }
-
-        let pathExtension = fileURL.pathExtension
-        guard !pathExtension.isEmpty,
-              let type = UTType(filenameExtension: pathExtension),
-              type.conforms(to: .image) else {
-            return nil
-        }
-
-        return type
-    }
 }

--- a/Zentty/Terminal/TerminalClipboard.swift
+++ b/Zentty/Terminal/TerminalClipboard.swift
@@ -8,12 +8,22 @@ enum TerminalClipboard {
         case filePath(String)
     }
 
+    struct PastedImage {
+        let data: Data
+        let fileExtension: String
+    }
+
+    enum ImageUploadContent {
+        case image(PastedImage)
+        case imageTooLarge
+        case failedToReadImage
+        case noImage
+    }
+
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "be.zenjoy.zentty",
         category: "TerminalClipboard"
     )
-
-    private static let maxClipboardImageSize = 10 * 1024 * 1024 // 10 MB
 
     // MARK: - Public
 
@@ -59,6 +69,33 @@ enum TerminalClipboard {
         return nil
     }
 
+    static func imageUploadContent(from pasteboard: NSPasteboard) -> ImageUploadContent {
+        let fileURLReadOptions: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        if let fileURLs = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: fileURLReadOptions
+        ) as? [URL], !fileURLs.isEmpty {
+            return imageUploadContent(fromFileURLs: fileURLs)
+        }
+
+        guard hasImageData(in: pasteboard) else {
+            return .noImage
+        }
+
+        guard let pastedImage = pastedImageData(from: pasteboard) else {
+            return .noImage
+        }
+
+        guard pastedImage.data.count <= TerminalClipboardImagePolicy.maxImageByteCount else {
+            logger.warning("Clipboard image too large: \(pastedImage.data.count) bytes")
+            return .imageTooLarge
+        }
+
+        return .image(pastedImage)
+    }
+
     // MARK: - Image helpers
 
     private static func hasImageData(in pasteboard: NSPasteboard) -> Bool {
@@ -85,8 +122,8 @@ enum TerminalClipboard {
                   let utType = UTType(type.rawValue),
                   utType.conforms(to: .image),
                   let imageData = pasteboard.data(forType: type),
-                  let fileExtension = utType.preferredFilenameExtension,
-                  !fileExtension.isEmpty else { continue }
+                  imageData.isEmpty == false else { continue }
+            let fileExtension = TerminalClipboardImagePolicy.fileExtension(for: utType)
             return (imageData, fileExtension)
         }
 
@@ -96,24 +133,12 @@ enum TerminalClipboard {
     private static func saveClipboardImagePath(from pasteboard: NSPasteboard) -> String? {
         guard hasImageData(in: pasteboard) else { return nil }
 
-        let imageData: Data
-        let fileExtension: String
-
-        if let direct = directImageData(from: pasteboard) {
-            imageData = direct.data
-            fileExtension = direct.fileExtension
-        } else if let image = NSImage(pasteboard: pasteboard),
-                  let tiffData = image.tiffRepresentation,
-                  let bitmap = NSBitmapImageRep(data: tiffData),
-                  let pngData = bitmap.representation(using: .png, properties: [:]) {
-            imageData = pngData
-            fileExtension = "png"
-        } else {
+        guard let pastedImage = pastedImageData(from: pasteboard) else {
             return nil
         }
 
-        guard imageData.count <= maxClipboardImageSize else {
-            logger.warning("Clipboard image too large: \(imageData.count) bytes")
+        guard pastedImage.data.count <= TerminalClipboardImagePolicy.maxImageByteCount else {
+            logger.warning("Clipboard image too large: \(pastedImage.data.count) bytes")
             return nil
         }
 
@@ -121,16 +146,89 @@ enum TerminalClipboard {
         formatter.dateFormat = "yyyy-MM-dd-HHmmss"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         let timestamp = formatter.string(from: Date())
-        let filename = "clipboard-\(timestamp)-\(UUID().uuidString.prefix(8)).\(fileExtension)"
+        let filename = "clipboard-\(timestamp)-\(UUID().uuidString.prefix(8)).\(pastedImage.fileExtension)"
         let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
 
         do {
-            try imageData.write(to: fileURL)
+            try pastedImage.data.write(to: fileURL)
         } catch {
             logger.error("Failed to save clipboard image: \(error.localizedDescription)")
             return nil
         }
 
         return ShellEscaping.escapePath(fileURL.path)
+    }
+
+    private static func pastedImageData(from pasteboard: NSPasteboard) -> PastedImage? {
+        if let direct = directImageData(from: pasteboard) {
+            return PastedImage(data: direct.data, fileExtension: direct.fileExtension)
+        }
+
+        if let image = NSImage(pasteboard: pasteboard),
+           let tiffData = image.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let pngData = bitmap.representation(using: .png, properties: [:]) {
+            return PastedImage(data: pngData, fileExtension: "png")
+        }
+
+        return nil
+    }
+
+    private static func imageUploadContent(fromFileURLs fileURLs: [URL]) -> ImageUploadContent {
+        let imageFileURLs = fileURLs.filter { imageType(forFileURL: $0) != nil }
+        guard let imageFileURL = imageFileURLs.first else {
+            return .noImage
+        }
+
+        if imageFileURLs.count > 1 {
+            logger.info("Uploading first pasted image file and ignoring \(imageFileURLs.count - 1) additional image files")
+        }
+
+        do {
+            if let fileSize = imageFileSize(for: imageFileURL),
+               fileSize > TerminalClipboardImagePolicy.maxImageByteCount {
+                logger.warning("Pasted image file too large: \(fileSize) bytes")
+                return .imageTooLarge
+            }
+
+            let data = try Data(contentsOf: imageFileURL)
+            guard data.count <= TerminalClipboardImagePolicy.maxImageByteCount else {
+                logger.warning("Pasted image file too large: \(data.count) bytes")
+                return .imageTooLarge
+            }
+
+            return .image(
+                PastedImage(
+                    data: data,
+                    fileExtension: TerminalClipboardImagePolicy.fileExtension(
+                        for: imageType(forFileURL: imageFileURL)
+                    )
+                )
+            )
+        } catch {
+            logger.error("Failed to read pasted image file: \(error.localizedDescription)")
+            return .failedToReadImage
+        }
+    }
+
+    private static func imageFileSize(for fileURL: URL) -> Int? {
+        (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+    }
+
+    private static func imageType(forFileURL fileURL: URL) -> UTType? {
+        if let values = try? fileURL.resourceValues(forKeys: [.contentTypeKey]),
+           let contentType = values.contentType,
+           contentType.conforms(to: .image) {
+            return contentType
+        }
+
+        let pathExtension = fileURL.pathExtension
+        guard !pathExtension.isEmpty,
+              let type = UTType(filenameExtension: pathExtension),
+              type.conforms(to: .image) else {
+            return nil
+        }
+
+        return type
     }
 }

--- a/Zentty/Terminal/TerminalClipboardImagePolicy.swift
+++ b/Zentty/Terminal/TerminalClipboardImagePolicy.swift
@@ -1,0 +1,77 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum TerminalClipboardImagePolicy {
+    static let maxImageByteCount = 10 * 1024 * 1024
+
+    static func fileExtension(forUTIIdentifier identifier: String?) -> String {
+        guard let identifier,
+              let type = UTType(identifier) else {
+            return "png"
+        }
+
+        return fileExtension(for: type)
+    }
+
+    static func fileExtension(for type: UTType?) -> String {
+        guard let type else {
+            return "png"
+        }
+
+        if type.conforms(to: .png) {
+            return "png"
+        }
+
+        if type.conforms(to: .jpeg) {
+            return "jpeg"
+        }
+
+        if type.conforms(to: .tiff) {
+            return "tiff"
+        }
+
+        if type.conforms(to: .gif) {
+            return "gif"
+        }
+
+        let identifier = type.identifier.lowercased()
+        let preferredExtension = type.preferredFilenameExtension?.lowercased()
+        if identifier.contains("webp") || preferredExtension == "webp" {
+            return "webp"
+        }
+
+        if let safeExtension = safeFilenameExtension(preferredExtension) {
+            return safeExtension
+        }
+
+        return "png"
+    }
+
+    static func normalizedFileExtension(_ fileExtension: String) -> String {
+        let normalized = fileExtension
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".").union(.whitespacesAndNewlines))
+            .lowercased()
+        switch normalized {
+        case "png", "jpeg", "jpg", "tiff", "tif", "gif", "webp":
+            return normalized == "jpg" ? "jpeg" : normalized == "tif" ? "tiff" : normalized
+        default:
+            return safeFilenameExtension(normalized) ?? "png"
+        }
+    }
+
+    private static func safeFilenameExtension(_ fileExtension: String?) -> String? {
+        guard let fileExtension else {
+            return nil
+        }
+
+        let normalized = fileExtension
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".").union(.whitespacesAndNewlines))
+            .lowercased()
+        guard !normalized.isEmpty,
+              normalized.range(of: #"^[a-z0-9]+$"#, options: .regularExpression) != nil else {
+            return nil
+        }
+
+        return normalized
+    }
+}

--- a/Zentty/Terminal/TerminalPaneHostView.swift
+++ b/Zentty/Terminal/TerminalPaneHostView.swift
@@ -63,6 +63,14 @@ final class TerminalPaneHostView: NSView, TerminalViewportDiagnosticsContextConf
             (terminalView as? any TerminalContextMenuConfiguring)?.contextMenuBuilder = contextMenuBuilder
         }
     }
+    var remoteImagePasteHandler: ((NSPasteboard, RemoteImagePasteSource) -> Bool)? {
+        didSet {
+            if remoteImagePasteHandler != nil, !(terminalView is any TerminalRemoteImagePasteConfiguring) {
+                Self.logger.warning("terminalView must conform to TerminalRemoteImagePasteConfiguring to forward remoteImagePasteHandler")
+            }
+            (terminalView as? any TerminalRemoteImagePasteConfiguring)?.remoteImagePasteHandler = remoteImagePasteHandler
+        }
+    }
 
     init(adapter: any TerminalAdapter) {
         self.adapter = adapter
@@ -74,6 +82,7 @@ final class TerminalPaneHostView: NSView, TerminalViewportDiagnosticsContextConf
         (terminalView as? any TerminalScrollRouting)?.onScrollWheel = onScrollWheel
         (terminalView as? any TerminalSmoothScrollConfiguring)?.smoothScrollingEnabled = smoothScrollingEnabled
         (terminalView as? any TerminalContextMenuConfiguring)?.contextMenuBuilder = contextMenuBuilder
+        (terminalView as? any TerminalRemoteImagePasteConfiguring)?.remoteImagePasteHandler = remoteImagePasteHandler
         setup()
     }
 
@@ -784,6 +793,12 @@ final class PaneRuntime {
         hostViewValue.updateSearchHUDShortcutTooltips(shortcutManager)
     }
 
+    func setRemoteImagePasteHandler(
+        _ handler: ((NSPasteboard, RemoteImagePasteSource) -> Bool)?
+    ) {
+        hostViewValue.remoteImagePasteHandler = handler
+    }
+
     func addObserver(_ observer: @escaping (PaneRuntimeSnapshot) -> Void) -> UUID {
         let observerID = UUID()
         observers[observerID] = observer
@@ -1007,6 +1022,7 @@ final class PaneRuntimeRegistry {
     var onMetadataDidChange: ((PaneID, TerminalMetadata) -> Void)?
     var onEventDidOccur: ((PaneID, TerminalEvent) -> Void)?
     var onGlobalSearchDidChange: ((PaneID, TerminalSearchEvent) -> Void)?
+    var onRuntimeDidCreate: ((PaneRuntime) -> Void)?
 
     init(
         diagnostics: TerminalDiagnostics = .shared,
@@ -1040,6 +1056,7 @@ final class PaneRuntimeRegistry {
             bindSinks(to: runtime)
             runtime.updateSearchHUDShortcutTooltips(shortcutManager)
             runtimes[pane.id] = runtime
+            onRuntimeDidCreate?(runtime)
             return runtime
         }
     }
@@ -1075,6 +1092,7 @@ final class PaneRuntimeRegistry {
         bindSinks(to: runtime)
         runtime.updateSearchHUDShortcutTooltips(shortcutManager)
         runtimes[paneID] = runtime
+        onRuntimeDidCreate?(runtime)
     }
 
     func updateShortcutTooltips(_ shortcutManager: ShortcutManager) {

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -27,6 +27,77 @@ enum FocusedTerminalInterruptBridge {
     }
 }
 
+private enum RemoteImagePasteFailure: Equatable {
+    case authRequired
+    case hostUnreachable
+    case transferFailed
+    case unknownDestination
+    case imageTooLarge
+    case uploadAlreadyInProgress
+
+    init(error: RemoteImageUploadError) {
+        switch error {
+        case .authRequired:
+            self = .authRequired
+        case .hostUnreachable:
+            self = .hostUnreachable
+        case .timeout, .transferFailed, .invalidRemotePath:
+            self = .transferFailed
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .authRequired:
+            return "Couldn't upload image — ssh key auth required"
+        case .hostUnreachable:
+            return "Couldn't upload image — host unreachable"
+        case .transferFailed:
+            return "Couldn't upload image — transfer failed"
+        case .unknownDestination:
+            return "Couldn't upload image — unknown ssh destination"
+        case .imageTooLarge:
+            return "Image too large to upload (max 10 MB)"
+        case .uploadAlreadyInProgress:
+            return "Upload already in progress"
+        }
+    }
+
+    var displayDuration: TimeInterval {
+        2.5
+    }
+}
+
+private extension TerminalClipboard.ImageUploadContent {
+    var remoteImagePasteboardContents: RemoteImagePasteboardContents {
+        switch self {
+        case .image:
+            return .imageData
+        case .imageTooLarge, .failedToReadImage:
+            return .imageTooLarge
+        case .noImage:
+            return .empty
+        }
+    }
+}
+
+private final class LockedSSHScanResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var destination: SSHDestination?
+
+    func set(_ destination: SSHDestination?) {
+        lock.lock()
+        self.destination = destination
+        lock.unlock()
+    }
+
+    func get() -> SSHDestination? {
+        lock.lock()
+        defer { lock.unlock() }
+        return destination
+    }
+}
+
 #if DEBUG
 struct SidebarChromeFrameMotionRecord: Equatable {
     let duration: TimeInterval
@@ -66,6 +137,23 @@ extension CAMediaTimingFunction {
 
 @MainActor
 final class RootViewController: NSViewController {
+    private struct ForegroundSSHProbeSource: Sendable {
+        let paneID: PaneID
+        let rootPID: Int32?
+    }
+
+    private struct ForegroundSSHProbeResult: Sendable {
+        let paneID: PaneID
+        let destination: SSHDestination?
+    }
+
+    private static let remoteImagePasteLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "be.zenjoy.zentty",
+        category: "RemoteImagePaste"
+    )
+    private static let foregroundSSHProbeIntervalNanoseconds: UInt64 = 2_000_000_000
+    private static let foregroundSSHOnDemandTimeout: TimeInterval = 1
+
     private final class LocalEventMonitor {
         private let token: Any
 
@@ -174,6 +262,10 @@ final class RootViewController: NSViewController {
     private var isFullScreen = false
     private var trafficLightAnchor = SidebarLayout.defaultTrafficLightAnchor
     private var pathCopiedToastView: PathCopiedToastView?
+    private let remoteImageUploader = RemoteImageUploader()
+    private let sshProcessProbe = PaneSSHProcessProbe()
+    private var remoteImageUploadTasksByPaneID: [PaneID: Task<Void, Never>] = [:]
+    private var foregroundSSHProbeTask: Task<Void, Never>?
     private var globalSearchNavigationFocusPreservationToken: Int?
     private var globalSearchNavigationFocusPreservationSequence = 0
     private var globalSearchNavigationFocusReleaseWorkItem: DispatchWorkItem?
@@ -442,8 +534,10 @@ final class RootViewController: NSViewController {
 
     deinit {
         MainActorShim.assumeIsolated {
+            cancelAllRemoteImageUploads()
             invalidateStaleAgentSweepTimer()
             passiveServerDetectionTask?.cancel()
+            foregroundSSHProbeTask?.cancel()
             agentCaffeinationController.removeSource(id: windowID)
             if let appUpdateObserverID {
                 appUpdateStateStore.removeObserver(appUpdateObserverID)
@@ -483,6 +577,7 @@ final class RootViewController: NSViewController {
         refreshShortcutTooltips()
         applyInitialState()
         syncAgentCaffeinationState()
+        startForegroundSSHProbeLoop()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleCleanCopyDidModifyPasteboard),
@@ -632,6 +727,7 @@ final class RootViewController: NSViewController {
 
             switch change {
             case .paneStructure, .worklaneListChanged:
+                self.cancelRemoteImageUploadsForRemovedPanes()
                 if self.isGlobalSearchSessionActive {
                     self.globalSearchCoordinator.end()
                 } else {
@@ -1115,6 +1211,9 @@ final class RootViewController: NSViewController {
         }
         runtimeRegistry.onGlobalSearchDidChange = { [weak self] paneID, event in
             self?.globalSearchCoordinator.handleSearchEvent(for: paneID, event: event)
+        }
+        runtimeRegistry.onRuntimeDidCreate = { [weak self] runtime in
+            self?.configureRemoteImagePaste(for: runtime)
         }
         agentStatusCenter.onPayload = { [weak self] payload in
             self?.worklaneStore.applyAgentStatusPayload(payload)
@@ -1603,10 +1702,7 @@ final class RootViewController: NSViewController {
     }
 
     private func showRestoreToast(message: String) {
-        pathCopiedToastView?.removeFromSuperview()
-        let toast = PathCopiedToastView()
-        pathCopiedToastView = toast
-        toast.show(message: message, in: appCanvasView, theme: currentTheme)
+        showToast(message: message)
     }
 
     private func closeFocusedPane() {
@@ -1937,9 +2033,7 @@ final class RootViewController: NSViewController {
     }
 
     private func showCommandFailureToast() {
-        let toast = PathCopiedToastView()
-        pathCopiedToastView = toast
-        toast.show(message: "Couldn’t run command", in: appCanvasView, theme: currentTheme)
+        showToast(message: "Couldn’t run command")
     }
 
     private func openWithFromPalette(stableID: String, workingDirectory: String) {
@@ -2061,10 +2155,7 @@ final class RootViewController: NSViewController {
     }
 
     private func showPathCopiedToast() {
-        pathCopiedToastView?.removeFromSuperview()
-        let toast = PathCopiedToastView()
-        pathCopiedToastView = toast
-        toast.show(in: appCanvasView, theme: currentTheme)
+        showToast(message: "Path copied")
     }
 
     private func performCleanCopy() {
@@ -2092,10 +2183,209 @@ final class RootViewController: NSViewController {
     }
 
     private func showCopyToast(message: String) {
+        showToast(message: message)
+    }
+
+    private func configureRemoteImagePaste(for runtime: PaneRuntime) {
+        let paneID = runtime.paneID
+        runtime.setRemoteImagePasteHandler { [weak self] pasteboard, _ in
+            self?.handleRemoteImagePaste(paneID: paneID, pasteboard: pasteboard) ?? false
+        }
+    }
+
+    private func handleRemoteImagePaste(paneID: PaneID, pasteboard: NSPasteboard) -> Bool {
+        let imageContent = TerminalClipboard.imageUploadContent(from: pasteboard)
+        guard imageContent.remoteImagePasteboardContents.containsImage else {
+            return false
+        }
+
+        guard let paneState = remoteImagePastePaneState(for: paneID, refreshForegroundSSH: true) else {
+            return false
+        }
+
+        guard RemoteImagePasteDecision.shouldUploadRemotely(
+            paneState: paneState,
+            pasteboardContents: imageContent.remoteImagePasteboardContents
+        ) else {
+            return false
+        }
+
+        guard remoteImageUploadTasksByPaneID[paneID] == nil else {
+            showRemoteImagePasteFailure(.uploadAlreadyInProgress, paneID: paneID)
+            return true
+        }
+
+        guard let destination = paneState.destination else {
+            showRemoteImagePasteFailure(.unknownDestination, paneID: paneID)
+            return true
+        }
+
+        let pastedImage: TerminalClipboard.PastedImage
+        switch imageContent {
+        case .image(let image):
+            pastedImage = image
+        case .imageTooLarge:
+            showRemoteImagePasteFailure(.imageTooLarge, paneID: paneID)
+            return true
+        case .failedToReadImage:
+            showRemoteImagePasteFailure(.transferFailed, paneID: paneID)
+            return true
+        case .noImage:
+            return false
+        }
+
+        let toastHandle = beginRemoteImageUploadToast()
+        let task = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                remoteImageUploadTasksByPaneID[paneID] = nil
+            }
+
+            do {
+                let remotePath = try await remoteImageUploader.upload(
+                    imageData: pastedImage.data,
+                    fileExtension: pastedImage.fileExtension,
+                    destination: destination,
+                    progress: { fraction in
+                        toastHandle.updateProgress(
+                            fraction: fraction,
+                            message: Self.remoteImageUploadProgressMessage(fraction: fraction)
+                        )
+                    }
+                )
+
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                toastHandle.finish(message: "Pasted remote path", icon: "checkmark.circle.fill")
+                runtimeRegistry.runtime(for: paneID)?.adapter.sendText(ShellEscaping.escapePath(remotePath))
+            } catch let error as RemoteImageUploadError {
+                let failure = RemoteImagePasteFailure(error: error)
+                Self.remoteImagePasteLogger.error("Remote image upload failed for pane \(paneID.rawValue): \(String(describing: error))")
+                toastHandle.fail(message: failure.message)
+            } catch is CancellationError {
+                Self.remoteImagePasteLogger.debug("Remote image upload cancelled for pane \(paneID.rawValue)")
+            } catch {
+                Self.remoteImagePasteLogger.error("Remote image upload failed for pane \(paneID.rawValue): \(error.localizedDescription)")
+                toastHandle.fail(message: RemoteImagePasteFailure.transferFailed.message)
+            }
+
+        }
+        remoteImageUploadTasksByPaneID[paneID] = task
+        return true
+    }
+
+    private func remoteImagePastePaneState(
+        for paneID: PaneID,
+        refreshForegroundSSH: Bool = false
+    ) -> RemoteImagePastePaneState? {
+        guard let worklane = worklaneStore.worklanes.first(where: { worklane in
+            worklane.paneStripState.panes.contains(where: { $0.id == paneID })
+        }),
+            var auxiliaryState = worklane.auxiliaryStateByPaneID[paneID]
+        else {
+            return nil
+        }
+
+        if refreshForegroundSSH {
+            let destination = auxiliaryState.raw.paneRootPID
+                .flatMap { scanForegroundSSHDestinationForPaste(rootPID: $0) }
+            if auxiliaryState.raw.foregroundSSHDestination != destination {
+                worklaneStore.updateForegroundSSHDestination(
+                    paneID: paneID,
+                    destination: destination
+                )
+            }
+            auxiliaryState.raw.foregroundSSHDestination = destination
+            auxiliaryState.presentation.foregroundSSHDestination = destination
+        }
+
+        let presentation = auxiliaryState.presentation
+        return RemoteImagePastePaneState(
+            isRemotePane: presentation.isRemotePane,
+            destination: remoteImageDestination(from: auxiliaryState)
+        )
+    }
+
+    private func remoteImageDestination(from auxiliaryState: PaneAuxiliaryState) -> SSHDestination? {
+        RemoteImagePasteDestination.destination(from: auxiliaryState)
+    }
+
+    func cancelAllRemoteImageUploads() {
+        let tasks = Array(remoteImageUploadTasksByPaneID.values)
+        remoteImageUploadTasksByPaneID.removeAll()
+        tasks.forEach { $0.cancel() }
+        pathCopiedToastView?.removeFromSuperview()
+        pathCopiedToastView = nil
+    }
+
+    private func cancelRemoteImageUploadsForRemovedPanes() {
+        let livePaneIDs = Set(worklaneStore.worklanes.flatMap { worklane in
+            worklane.paneStripState.panes.map(\.id)
+        })
+        for paneID in Array(remoteImageUploadTasksByPaneID.keys) where !livePaneIDs.contains(paneID) {
+            cancelRemoteImageUpload(for: paneID)
+        }
+    }
+
+    private func cancelRemoteImageUpload(for paneID: PaneID) {
+        guard let task = remoteImageUploadTasksByPaneID.removeValue(forKey: paneID) else {
+            return
+        }
+
+        task.cancel()
+        if remoteImageUploadTasksByPaneID.isEmpty {
+            pathCopiedToastView?.removeFromSuperview()
+            pathCopiedToastView = nil
+        }
+    }
+
+    private func beginRemoteImageUploadToast() -> PathCopiedToastView.ProgressHandle {
         pathCopiedToastView?.removeFromSuperview()
         let toast = PathCopiedToastView()
         pathCopiedToastView = toast
-        toast.show(message: message, in: appCanvasView, theme: currentTheme)
+        return toast.beginProgress(
+            message: Self.remoteImageUploadProgressMessage(fraction: 0),
+            in: appCanvasView,
+            theme: currentTheme
+        )
+    }
+
+    private func showRemoteImagePasteFailure(_ failure: RemoteImagePasteFailure, paneID: PaneID) {
+        Self.remoteImagePasteLogger.error("Remote image paste failed for pane \(paneID.rawValue): \(failure.message)")
+        if failure == .uploadAlreadyInProgress, pathCopiedToastView?.isProgressActive == true {
+            pathCopiedToastView?.temporarilyShowProgressMessage(failure.message, duration: failure.displayDuration)
+            return
+        }
+
+        showToast(message: failure.message, duration: failure.displayDuration)
+    }
+
+    private func showToast(
+        message: String,
+        duration: TimeInterval? = nil
+    ) {
+        guard pathCopiedToastView?.isProgressActive != true else {
+            return
+        }
+
+        pathCopiedToastView?.removeFromSuperview()
+        let toast = PathCopiedToastView()
+        pathCopiedToastView = toast
+        if let duration {
+            let handle = toast.beginProgress(message: message, in: appCanvasView, theme: currentTheme)
+            handle.fail(message: message)
+        } else {
+            toast.show(message: message, in: appCanvasView, theme: currentTheme)
+        }
+    }
+
+    private static func remoteImageUploadProgressMessage(fraction: Double) -> String {
+        let percent = Int((max(0, min(1, fraction)) * 100).rounded())
+        return "Uploading pasted image (\(percent)%)"
     }
 
     private func keyboardResizeStep(for axis: PaneResizeAxis) -> CGFloat {
@@ -2906,6 +3196,73 @@ final class RootViewController: NSViewController {
         worklaneStore.register(server: server)
     }
 
+    private func startForegroundSSHProbeLoop() {
+        foregroundSSHProbeTask?.cancel()
+        foregroundSSHProbeTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.sampleForegroundSSHProcesses()
+                try? await Task.sleep(nanoseconds: Self.foregroundSSHProbeIntervalNanoseconds)
+            }
+        }
+    }
+
+    private func sampleForegroundSSHProcesses() async {
+        let sources = foregroundSSHProbeSources()
+        guard !sources.isEmpty else {
+            return
+        }
+
+        let probe = sshProcessProbe
+        let results = await Task.detached(priority: .utility) {
+            sources.map { source in
+                ForegroundSSHProbeResult(
+                    paneID: source.paneID,
+                    destination: source.rootPID.flatMap { probe.scan(rootPID: $0) }
+                )
+            }
+        }.value
+
+        guard !Task.isCancelled else {
+            return
+        }
+
+        for result in results {
+            worklaneStore.updateForegroundSSHDestination(
+                paneID: result.paneID,
+                destination: result.destination
+            )
+        }
+    }
+
+    private func foregroundSSHProbeSources() -> [ForegroundSSHProbeSource] {
+        worklaneStore.worklanes.flatMap { worklane in
+            worklane.paneStripState.panes.map { pane in
+                ForegroundSSHProbeSource(
+                    paneID: pane.id,
+                    rootPID: worklane.auxiliaryStateByPaneID[pane.id]?.raw.paneRootPID
+                )
+            }
+        }
+    }
+
+    private func scanForegroundSSHDestinationForPaste(rootPID: Int32) -> SSHDestination? {
+        let probe = sshProcessProbe
+        let result = LockedSSHScanResult()
+        let semaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            result.set(probe.scan(rootPID: rootPID))
+            semaphore.signal()
+        }
+
+        let timeout = DispatchTime.now() + Self.foregroundSSHOnDemandTimeout
+        guard semaphore.wait(timeout: timeout) == .success else {
+            Self.remoteImagePasteLogger.error("Timed out scanning foreground ssh process for rootPID \(rootPID, privacy: .public)")
+            return nil
+        }
+
+        return result.get()
+    }
+
     private func schedulePassiveServerDetectionRefresh() {
         passiveServerDetectionTask?.cancel()
 
@@ -3320,6 +3677,17 @@ final class RootViewController: NSViewController {
 
         var pathCopiedToastViewForTesting: PathCopiedToastView? {
             pathCopiedToastView
+        }
+
+        func insertRemoteImageUploadTaskForTesting(
+            _ task: Task<Void, Never>,
+            for paneID: PaneID
+        ) {
+            remoteImageUploadTasksByPaneID[paneID] = task
+        }
+
+        func hasRemoteImageUploadTaskForTesting(for paneID: PaneID) -> Bool {
+            remoteImageUploadTasksByPaneID[paneID] != nil
         }
 
         func handleTerminalEventForTesting(paneID: PaneID, event: TerminalEvent) {

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -33,6 +33,8 @@ private enum RemoteImagePasteFailure: Equatable {
     case transferFailed
     case unknownDestination
     case imageTooLarge
+    case fileTooLarge
+    case foldersCannotUpload
     case uploadAlreadyInProgress
 
     init(error: RemoteImageUploadError) {
@@ -49,15 +51,19 @@ private enum RemoteImagePasteFailure: Equatable {
     var message: String {
         switch self {
         case .authRequired:
-            return "Couldn't upload image — ssh key auth required"
+            return "Couldn't upload file — ssh key auth required"
         case .hostUnreachable:
-            return "Couldn't upload image — host unreachable"
+            return "Couldn't upload file — host unreachable"
         case .transferFailed:
-            return "Couldn't upload image — transfer failed"
+            return "Couldn't upload file — transfer failed"
         case .unknownDestination:
-            return "Couldn't upload image — unknown ssh destination"
+            return "Couldn't upload file — unknown ssh destination"
         case .imageTooLarge:
             return "Image too large to upload (max 10 MB)"
+        case .fileTooLarge:
+            return "File too large to upload (max 500 MB)"
+        case .foldersCannotUpload:
+            return "Folders can't be uploaded"
         case .uploadAlreadyInProgress:
             return "Upload already in progress"
         }
@@ -262,7 +268,7 @@ final class RootViewController: NSViewController {
     private var isFullScreen = false
     private var trafficLightAnchor = SidebarLayout.defaultTrafficLightAnchor
     private var pathCopiedToastView: PathCopiedToastView?
-    private let remoteImageUploader = RemoteImageUploader()
+    private let remoteImageUploader: RemoteImageUploader
     private let sshProcessProbe = PaneSSHProcessProbe()
     private var remoteImageUploadTasksByPaneID: [PaneID: Task<Void, Never>] = [:]
     private var foregroundSSHProbeTask: Task<Void, Never>?
@@ -349,6 +355,7 @@ final class RootViewController: NSViewController {
         serverListenerScanner: ServerListenerScanner = ServerListenerScanner(),
         dockerServerDiscovery: DockerServerDiscovery = DockerServerDiscovery(),
         runtimeRegistry: PaneRuntimeRegistry = PaneRuntimeRegistry(),
+        remoteImageUploader: RemoteImageUploader = RemoteImageUploader(),
         notificationStore: NotificationStore = NotificationStore(),
         reviewStateResolver: WorklaneReviewStateResolver = WorklaneReviewStateResolver(),
         gitContextResolver: any PaneGitContextResolving = WorklaneGitContextResolver(),
@@ -363,6 +370,7 @@ final class RootViewController: NSViewController {
         self.serverOpenService = serverOpenService
         self.serverListenerScanner = serverListenerScanner
         self.dockerServerDiscovery = dockerServerDiscovery
+        self.remoteImageUploader = remoteImageUploader
         self.paneLayoutPreferences = configStore.current.paneLayout
         self.shortcutManager = ShortcutManager(shortcuts: configStore.current.shortcuts)
         self.lastAppliedAppearanceSettings = configStore.current.appearance
@@ -2194,8 +2202,15 @@ final class RootViewController: NSViewController {
     }
 
     private func handleRemoteImagePaste(paneID: PaneID, pasteboard: NSPasteboard) -> Bool {
-        let imageContent = TerminalClipboard.imageUploadContent(from: pasteboard)
-        guard imageContent.remoteImagePasteboardContents.containsImage else {
+        let fileURLs = TerminalClipboard.fileURLs(from: pasteboard)
+        let imageContent: TerminalClipboard.ImageUploadContent = fileURLs.isEmpty
+            ? TerminalClipboard.imageUploadContent(from: pasteboard)
+            : .noImage
+        let pasteboardContents: RemoteImagePasteboardContents = fileURLs.isEmpty
+            ? imageContent.remoteImagePasteboardContents
+            : .fileURL
+
+        guard pasteboardContents.shouldUpload else {
             return false
         }
 
@@ -2205,7 +2220,7 @@ final class RootViewController: NSViewController {
 
         guard RemoteImagePasteDecision.shouldUploadRemotely(
             paneState: paneState,
-            pasteboardContents: imageContent.remoteImagePasteboardContents
+            pasteboardContents: pasteboardContents
         ) else {
             return false
         }
@@ -2218,6 +2233,14 @@ final class RootViewController: NSViewController {
         guard let destination = paneState.destination else {
             showRemoteImagePasteFailure(.unknownDestination, paneID: paneID)
             return true
+        }
+
+        if !fileURLs.isEmpty {
+            return handleRemoteFileURLPaste(
+                paneID: paneID,
+                fileURLs: fileURLs,
+                destination: destination
+            )
         }
 
         let pastedImage: TerminalClipboard.PastedImage
@@ -2234,7 +2257,9 @@ final class RootViewController: NSViewController {
             return false
         }
 
-        let toastHandle = beginRemoteImageUploadToast()
+        let toastHandle = beginRemoteImageUploadToast(
+            message: Self.remoteImageUploadProgressMessage(fraction: 0)
+        )
         let task = Task { [weak self] in
             guard let self else {
                 return
@@ -2273,6 +2298,95 @@ final class RootViewController: NSViewController {
                 toastHandle.fail(message: RemoteImagePasteFailure.transferFailed.message)
             }
 
+        }
+        remoteImageUploadTasksByPaneID[paneID] = task
+        return true
+    }
+
+    private func handleRemoteFileURLPaste(
+        paneID: PaneID,
+        fileURLs: [URL],
+        destination: SSHDestination
+    ) -> Bool {
+        let resolution = RemoteFileUploadRequestResolver.resolve(fileURLs: fileURLs)
+        let uploadRequests: [RemoteFileUploadRequest]
+        switch resolution {
+        case .files(let requests):
+            uploadRequests = requests
+        case .noFiles:
+            return false
+        case .foldersOnly:
+            showRemoteImagePasteFailure(.foldersCannotUpload, paneID: paneID)
+            return true
+        case .fileTooLarge:
+            showRemoteImagePasteFailure(.fileTooLarge, paneID: paneID)
+            return true
+        case .failedToResolve:
+            showRemoteImagePasteFailure(.transferFailed, paneID: paneID)
+            return true
+        }
+
+        guard let firstRequest = uploadRequests.first else {
+            return false
+        }
+
+        let toastHandle = beginRemoteImageUploadToast(
+            message: Self.remoteFileUploadProgressMessage(
+                filename: firstRequest.originalFilename,
+                fileIndex: 1,
+                fileCount: uploadRequests.count,
+                fraction: 0
+            )
+        )
+        let task = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                remoteImageUploadTasksByPaneID[paneID] = nil
+            }
+
+            do {
+                let batch = RemoteFileUploadBatch(uploader: remoteImageUploader)
+                let result = try await batch.uploadFiles(
+                    uploadRequests,
+                    destination: destination,
+                    progress: { progress in
+                        toastHandle.updateProgress(
+                            fraction: progress.fraction,
+                            message: Self.remoteFileUploadProgressMessage(progress)
+                        )
+                    }
+                )
+
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                guard !result.successfulRemotePaths.isEmpty else {
+                    let failure = result.firstFailure.map(RemoteImagePasteFailure.init(error:)) ?? .transferFailed
+                    toastHandle.fail(message: failure.message)
+                    return
+                }
+
+                if result.failedCount > 0 {
+                    toastHandle.finish(
+                        message: "Uploaded \(result.successfulRemotePaths.count) of \(result.totalCount) files",
+                        icon: "checkmark.circle.fill"
+                    )
+                } else {
+                    toastHandle.finish(
+                        message: result.totalCount == 1 ? "Pasted remote path" : "Pasted remote paths",
+                        icon: "checkmark.circle.fill"
+                    )
+                }
+                runtimeRegistry.runtime(for: paneID)?.adapter.sendText(result.pasteText)
+            } catch is CancellationError {
+                Self.remoteImagePasteLogger.debug("Remote file upload cancelled for pane \(paneID.rawValue)")
+            } catch {
+                Self.remoteImagePasteLogger.error("Remote file upload failed for pane \(paneID.rawValue): \(error.localizedDescription)")
+                toastHandle.fail(message: RemoteImagePasteFailure.transferFailed.message)
+            }
         }
         remoteImageUploadTasksByPaneID[paneID] = task
         return true
@@ -2343,12 +2457,12 @@ final class RootViewController: NSViewController {
         }
     }
 
-    private func beginRemoteImageUploadToast() -> PathCopiedToastView.ProgressHandle {
+    private func beginRemoteImageUploadToast(message: String) -> PathCopiedToastView.ProgressHandle {
         pathCopiedToastView?.removeFromSuperview()
         let toast = PathCopiedToastView()
         pathCopiedToastView = toast
         return toast.beginProgress(
-            message: Self.remoteImageUploadProgressMessage(fraction: 0),
+            message: message,
             in: appCanvasView,
             theme: currentTheme
         )
@@ -2386,6 +2500,29 @@ final class RootViewController: NSViewController {
     private static func remoteImageUploadProgressMessage(fraction: Double) -> String {
         let percent = Int((max(0, min(1, fraction)) * 100).rounded())
         return "Uploading pasted image (\(percent)%)"
+    }
+
+    private static func remoteFileUploadProgressMessage(_ progress: RemoteFileUploadProgress) -> String {
+        remoteFileUploadProgressMessage(
+            filename: progress.filename,
+            fileIndex: progress.fileIndex,
+            fileCount: progress.fileCount,
+            fraction: progress.fraction
+        )
+    }
+
+    private static func remoteFileUploadProgressMessage(
+        filename: String,
+        fileIndex: Int,
+        fileCount: Int,
+        fraction: Double
+    ) -> String {
+        let percent = Int((max(0, min(1, fraction)) * 100).rounded())
+        if fileCount > 1 {
+            return "Uploading \(filename) (\(fileIndex)/\(fileCount), \(percent)%)"
+        }
+
+        return "Uploading \(filename) (\(percent)%)"
     }
 
     private func keyboardResizeStep(for axis: PaneResizeAxis) -> CGFloat {

--- a/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
@@ -90,6 +90,10 @@ final class SidebarPaneRowRenderer {
                 presentationMode: panePresentation.presentationMode,
                 lineCount: 1
             )
+            panePrimaryRows[index].configureRemoteIndicator(
+                isRemote: panePresentation.isRemotePane,
+                label: panePresentation.remotePaneLabel
+            )
             panePrimaryRows[index].setShimmerPhaseOffset(panePhaseOffset)
 
             paneDetailLabels[index].stringValue = paneRow.detailText ?? ""

--- a/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
@@ -626,6 +626,12 @@ final class SidebarTaskProgressRevealLineView: NSView {
 
 @MainActor
 final class SidebarPanePrimaryRowView: NSView {
+    private static let remoteSymbolName = "cloud.fill"
+    private static let remoteSymbolPointSize: CGFloat = 11
+    private static let remoteIconSide: CGFloat = 13
+    private static let remoteAccessibilityLabel = "Remote session"
+
+    private let remoteIconView = NSImageView()
     private let textContainer = SidebarPrimaryTextContainerView()
     private let baseLabel = SidebarStaticLabel()
     private let shimmerLabel = SidebarShimmerTextView()
@@ -650,6 +656,26 @@ final class SidebarPanePrimaryRowView: NSView {
 
     var renderedTrailingTextColorForTesting: NSColor {
         trailingLabelView.textColor ?? .clear
+    }
+
+    var remoteIconIsVisibleForTesting: Bool {
+        remoteIconView.isHidden == false
+    }
+
+    var remoteIconToolTipForTesting: String? {
+        remoteIconView.toolTip
+    }
+
+    var remoteIconAccessibilityLabelForTesting: String {
+        remoteIconView.accessibilityLabel() ?? ""
+    }
+
+    var remoteIconSymbolNameForTesting: String? {
+        remoteIconView.image == nil ? nil : Self.remoteSymbolName
+    }
+
+    var remoteIconTintColorForTesting: NSColor? {
+        remoteIconView.contentTintColor
     }
 
     override var intrinsicContentSize: NSSize {
@@ -679,6 +705,19 @@ final class SidebarPanePrimaryRowView: NSView {
         setContentHuggingPriority(.required, for: .vertical)
         setContentCompressionResistancePriority(.required, for: .vertical)
 
+        remoteIconView.translatesAutoresizingMaskIntoConstraints = false
+        remoteIconView.image = NSImage(
+            systemSymbolName: Self.remoteSymbolName,
+            accessibilityDescription: Self.remoteAccessibilityLabel
+        )?.withSymbolConfiguration(
+            .init(pointSize: Self.remoteSymbolPointSize, weight: .semibold, scale: .medium)
+        )
+        remoteIconView.imageScaling = .scaleProportionallyDown
+        remoteIconView.isHidden = true
+        remoteIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        remoteIconView.setContentHuggingPriority(.required, for: .horizontal)
+        remoteIconView.setAccessibilityRole(.image)
+
         textContainer.translatesAutoresizingMaskIntoConstraints = false
         textContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -707,6 +746,7 @@ final class SidebarPanePrimaryRowView: NSView {
         stack.alignment = .top
         stack.spacing = SidebarPaneRowPresentationMode.inlineSpacing
         stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.addArrangedSubview(remoteIconView)
         stack.addArrangedSubview(textContainer)
         stack.addArrangedSubview(trailingLabelView)
         addSubview(stack)
@@ -715,6 +755,8 @@ final class SidebarPanePrimaryRowView: NSView {
         heightConstraint.priority = .defaultHigh
         self.heightConstraint = heightConstraint
         NSLayoutConstraint.activate([
+            remoteIconView.widthAnchor.constraint(equalToConstant: Self.remoteIconSide),
+            remoteIconView.heightAnchor.constraint(equalToConstant: Self.remoteIconSide),
             baseLabel.topAnchor.constraint(equalTo: textContainer.topAnchor),
             baseLabel.leadingAnchor.constraint(equalTo: textContainer.leadingAnchor),
             baseLabel.trailingAnchor.constraint(equalTo: textContainer.trailingAnchor),
@@ -758,6 +800,14 @@ final class SidebarPanePrimaryRowView: NSView {
         applyPresentationMode(lineCount: lineCount)
     }
 
+    func configureRemoteIndicator(isRemote: Bool, label: String?) {
+        remoteIconView.isHidden = isRemote == false
+
+        let accessibilityText = Self.remoteAccessibilityText(label: label)
+        remoteIconView.toolTip = isRemote ? accessibilityText : nil
+        remoteIconView.setAccessibilityLabel(isRemote ? accessibilityText : "")
+    }
+
     func applyColors(
         primaryColor: NSColor,
         trailingColor: NSColor,
@@ -769,6 +819,7 @@ final class SidebarPanePrimaryRowView: NSView {
         self.trailingColor = trailingColor
         baseLabel.textColor = primaryColor
         trailingLabelView.textColor = trailingColor
+        remoteIconView.contentTintColor = trailingColor
         // The pane row primary stays single-line with tail truncation (see
         // `applyPresentationMode`) so the shimmer overlay always has a line
         // to clip against — hiding it on wrap would kill the shimmer on
@@ -819,6 +870,14 @@ final class SidebarPanePrimaryRowView: NSView {
 
     private func updateAdaptiveHeight() {
         // The pane row primary is always single-line — no adaptive height.
+    }
+
+    private static func remoteAccessibilityText(label: String?) -> String {
+        guard let label = WorklaneContextFormatter.trimmed(label) else {
+            return remoteAccessibilityLabel
+        }
+
+        return "\(remoteAccessibilityLabel): \(label)"
     }
 }
 

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowPresentation.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowPresentation.swift
@@ -9,6 +9,8 @@ struct SidebarWorklaneRowRenderPlan: Equatable {
         let statusTrailingLayout: SidebarPaneStatusTrailingLayout
         let statusLineCount: Int
         let serverPorts: [WorklaneSidebarServerPort]
+        let isRemotePane: Bool
+        let remotePaneLabel: String?
     }
 
     let summary: WorklaneSidebarSummary
@@ -84,7 +86,9 @@ struct SidebarWorklaneRowRenderPlan: Equatable {
                     for: paneRow,
                     availableWidth: availableWidth
                 ),
-                serverPorts: paneRow.serverPorts
+                serverPorts: paneRow.serverPorts,
+                isRemotePane: paneRow.isRemotePane,
+                remotePaneLabel: paneRow.remotePaneLabel
             )
         }
     }

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
@@ -30,6 +30,8 @@ struct WorklaneSidebarPaneRow: Equatable {
     let isWorking: Bool
     let taskProgress: PaneAgentTaskProgress?
     let serverPorts: [WorklaneSidebarServerPort]
+    let isRemotePane: Bool
+    let remotePaneLabel: String?
 
     init(
         paneID: PaneID,
@@ -45,7 +47,9 @@ struct WorklaneSidebarPaneRow: Equatable {
         isFocused: Bool,
         isWorking: Bool,
         taskProgress: PaneAgentTaskProgress? = nil,
-        serverPorts: [WorklaneSidebarServerPort] = []
+        serverPorts: [WorklaneSidebarServerPort] = [],
+        isRemotePane: Bool = false,
+        remotePaneLabel: String? = nil
     ) {
         self.paneID = paneID
         self.primaryText = primaryText
@@ -61,6 +65,8 @@ struct WorklaneSidebarPaneRow: Equatable {
         self.isWorking = isWorking
         self.taskProgress = taskProgress
         self.serverPorts = serverPorts
+        self.isRemotePane = isRemotePane
+        self.remotePaneLabel = remotePaneLabel
     }
 }
 

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
@@ -273,9 +273,17 @@ enum WorklaneSidebarSummaryBuilder {
                 isFocused: isFocused,
                 isWorking: statusPresentation.isWorking,
                 taskProgress: statusPresentation.taskProgress,
-                serverPorts: serverPorts(for: paneContext.paneID, serverContext: serverContext)
+                serverPorts: serverPorts(for: paneContext.paneID, serverContext: serverContext),
+                isRemotePane: paneContext.presentation.isRemotePane,
+                remotePaneLabel: remotePaneLabel(for: paneContext.presentation)
             )
         }
+    }
+
+    private static func remotePaneLabel(for presentation: PanePresentationState) -> String? {
+        WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel)
+            ?? WorklaneContextFormatter.trimmed(presentation.foregroundSSHDestination?.target)
+            ?? WorklaneContextFormatter.trimmed(presentation.remoteHostLabel)
     }
 
     private static func serverPorts(
@@ -422,7 +430,8 @@ enum WorklaneSidebarSummaryBuilder {
     private static func paneDetailCandidate(
         for paneContext: WorklanePaneContext
     ) -> PaneDetailCandidate? {
-        guard paneContext.presentation.hasInferredSSHConnection == false else {
+        guard paneContext.presentation.hasInferredSSHConnection == false,
+              paneContext.presentation.hasForegroundSSHProcess == false else {
             return nil
         }
 
@@ -487,7 +496,8 @@ enum WorklaneSidebarSummaryBuilder {
             )
         }
 
-        if let sshConnectionLabel = WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel) {
+        if let sshConnectionLabel = WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel)
+            ?? WorklaneContextFormatter.trimmed(presentation.foregroundSSHDestination?.target) {
             return PaneSidebarIdentity(
                 primaryText: sshConnectionLabel,
                 trailingText: nil,

--- a/Zentty/UI/Toast/PathCopiedToastView.swift
+++ b/Zentty/UI/Toast/PathCopiedToastView.swift
@@ -3,6 +3,27 @@ import QuartzCore
 
 @MainActor
 final class PathCopiedToastView: NSView {
+    @MainActor
+    final class ProgressHandle {
+        private weak var toast: PathCopiedToastView?
+
+        fileprivate init(toast: PathCopiedToastView) {
+            self.toast = toast
+        }
+
+        func updateProgress(fraction: Double, message: String) {
+            toast?.updateProgress(fraction: fraction, message: message)
+        }
+
+        func finish(message: String, icon: String) {
+            toast?.finish(message: message, icon: icon)
+        }
+
+        func fail(message: String) {
+            toast?.fail(message: message)
+        }
+    }
+
     private enum Layout {
         static let horizontalPadding: CGFloat = 14
         static let verticalPadding: CGFloat = 9
@@ -12,6 +33,7 @@ final class PathCopiedToastView: NSView {
         static let minimumHeight: CGFloat = 34
         static let cornerRadius: CGFloat = 17
         static let displayDuration: TimeInterval = 1.5
+        static let failureDisplayDuration: TimeInterval = 2.5
         static let fadeInDuration: TimeInterval = 0.22
         static let fadeOutDuration: TimeInterval = 0.18
         static let bottomOffset: CGFloat = 32
@@ -20,12 +42,33 @@ final class PathCopiedToastView: NSView {
         static let initialScale: CGFloat = 0.985
     }
 
+    private enum ToastMode: Equatable {
+        case idle
+        case transient
+        case progress
+        case finished
+        case failed
+    }
+
+    private struct ProgressMessageOverride {
+        var token: UUID
+        var restoreMessage: String
+    }
+
     private let surfaceView = GlassSurfaceView(style: .toast)
     private let contentStackView = NSStackView()
+    private let iconContainerView = NSView()
     private let iconView = NSImageView()
+    private let progressView = ToastCircularProgressView()
     private let messageLabel = NSTextField(labelWithString: "Path copied")
     private var dismissWorkItem: DispatchWorkItem?
+    private var progressMessageOverrideWorkItem: DispatchWorkItem?
+    private var progressMessageOverride: ProgressMessageOverride?
     private var restingFrame: CGRect = .zero
+    private var mode: ToastMode = .idle
+    private var currentTheme: ZenttyTheme?
+    private var currentLabelColor: NSColor = .labelColor
+    private var currentIconSymbolName: String?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -56,22 +99,119 @@ final class PathCopiedToastView: NSView {
     }
 
     func show(message: String, in parentView: NSView, theme: ZenttyTheme) {
+        guard mode != .progress else {
+            return
+        }
+
+        mode = .transient
+        clearProgressMessageOverride()
+        setSymbolIcon("checkmark.circle.fill", accessibilityDescription: message)
+        present(message: message, in: parentView, theme: theme, autoDismissAfter: Layout.displayDuration)
+    }
+
+    func beginProgress(
+        message: String,
+        in parentView: NSView,
+        theme: ZenttyTheme
+    ) -> ProgressHandle {
+        mode = .progress
+        clearProgressMessageOverride()
+        progressView.fraction = 0
+        showProgressIcon()
+        present(message: message, in: parentView, theme: theme, autoDismissAfter: nil)
+        return ProgressHandle(toast: self)
+    }
+
+    func updateProgress(fraction: Double, message: String) {
+        guard mode == .progress else {
+            return
+        }
+
+        progressView.fraction = max(0, min(1, fraction))
+        if var progressMessageOverride {
+            progressMessageOverride.restoreMessage = message
+            self.progressMessageOverride = progressMessageOverride
+        } else {
+            messageLabel.stringValue = message
+            updateFrameForCurrentContent()
+        }
+    }
+
+    func finish(message: String, icon: String) {
+        guard mode == .progress else {
+            return
+        }
+
+        mode = .finished
+        clearProgressMessageOverride()
+        setSymbolIcon(icon, accessibilityDescription: message)
+        messageLabel.stringValue = message
+        updateFrameForCurrentContent()
+        scheduleDismiss(after: Layout.displayDuration)
+    }
+
+    func fail(message: String) {
+        guard mode == .progress else {
+            return
+        }
+
+        mode = .failed
+        clearProgressMessageOverride()
+        setSymbolIcon("xmark.circle.fill", accessibilityDescription: message)
+        messageLabel.stringValue = message
+        updateFrameForCurrentContent()
+        scheduleDismiss(after: Layout.failureDisplayDuration)
+    }
+
+    func temporarilyShowProgressMessage(_ message: String, duration: TimeInterval) {
+        guard mode == .progress else {
+            return
+        }
+
+        let token = UUID()
+        progressMessageOverrideWorkItem?.cancel()
+        progressMessageOverride = ProgressMessageOverride(token: token, restoreMessage: messageLabel.stringValue)
+        messageLabel.stringValue = message
+        updateFrameForCurrentContent()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            MainActorShim.assumeIsolated {
+                guard
+                    let self,
+                    self.mode == .progress,
+                    let progressMessageOverride = self.progressMessageOverride,
+                    progressMessageOverride.token == token
+                else {
+                    return
+                }
+
+                self.progressMessageOverride = nil
+                self.messageLabel.stringValue = progressMessageOverride.restoreMessage
+                self.updateFrameForCurrentContent()
+            }
+        }
+        progressMessageOverrideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
+    }
+
+    var isProgressActive: Bool {
+        mode == .progress
+    }
+
+    private func present(
+        message: String,
+        in parentView: NSView,
+        theme: ZenttyTheme,
+        autoDismissAfter duration: TimeInterval?
+    ) {
         messageLabel.stringValue = message
         dismissWorkItem?.cancel()
         removeFromSuperview()
 
+        currentTheme = theme
         apply(theme: theme)
         layoutSubtreeIfNeeded()
-
-        let fittingSize = self.fittingSize
-        let width = max(Layout.minimumWidth, ceil(fittingSize.width))
-        let height = max(Layout.minimumHeight, ceil(fittingSize.height))
-        restingFrame = CGRect(
-            x: round(parentView.bounds.midX - width / 2),
-            y: Layout.bottomOffset,
-            width: width,
-            height: height
-        )
+        updateRestingFrame(in: parentView)
 
         frame = restingFrame.offsetBy(dx: 0, dy: Layout.entranceOffsetY)
         autoresizingMask = []
@@ -89,11 +229,46 @@ final class PathCopiedToastView: NSView {
         }
         animateScale(from: Layout.initialScale, to: 1, duration: Layout.fadeInDuration, timing: .easeOut)
 
+        if let duration {
+            scheduleDismiss(after: duration)
+        }
+    }
+
+    private func updateRestingFrame(in parentView: NSView) {
+        let fittingSize = self.fittingSize
+        let width = max(Layout.minimumWidth, ceil(fittingSize.width))
+        let height = max(Layout.minimumHeight, ceil(fittingSize.height))
+        restingFrame = CGRect(
+            x: round(parentView.bounds.midX - width / 2),
+            y: Layout.bottomOffset,
+            width: width,
+            height: height
+        )
+    }
+
+    private func updateFrameForCurrentContent() {
+        guard let parentView = superview else {
+            return
+        }
+
+        updateRestingFrame(in: parentView)
+        frame = restingFrame
+        layoutSubtreeIfNeeded()
+    }
+
+    private func scheduleDismiss(after duration: TimeInterval) {
+        dismissWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             self?.dismiss()
         }
         dismissWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + Layout.displayDuration, execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
+    }
+
+    private func clearProgressMessageOverride() {
+        progressMessageOverrideWorkItem?.cancel()
+        progressMessageOverrideWorkItem = nil
+        progressMessageOverride = nil
     }
 
     private func setup() {
@@ -110,11 +285,18 @@ final class PathCopiedToastView: NSView {
         contentStackView.spacing = Layout.interItemSpacing
         surfaceView.addSubview(contentStackView)
 
+        iconContainerView.translatesAutoresizingMaskIntoConstraints = false
+        iconContainerView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        iconContainerView.setContentHuggingPriority(.required, for: .horizontal)
+        contentStackView.addArrangedSubview(iconContainerView)
+
         iconView.translatesAutoresizingMaskIntoConstraints = false
         iconView.imageScaling = .scaleProportionallyDown
-        iconView.setContentCompressionResistancePriority(.required, for: .horizontal)
-        iconView.setContentHuggingPriority(.required, for: .horizontal)
-        contentStackView.addArrangedSubview(iconView)
+        iconContainerView.addSubview(iconView)
+
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.isHidden = true
+        iconContainerView.addSubview(progressView)
 
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
         messageLabel.lineBreakMode = .byClipping
@@ -145,8 +327,16 @@ final class PathCopiedToastView: NSView {
                 constant: -Layout.verticalPadding
             ),
 
-            iconView.widthAnchor.constraint(equalToConstant: Layout.iconPointSize + 4),
-            iconView.heightAnchor.constraint(equalToConstant: Layout.iconPointSize + 4),
+            iconContainerView.widthAnchor.constraint(equalToConstant: Layout.iconPointSize + 4),
+            iconContainerView.heightAnchor.constraint(equalToConstant: Layout.iconPointSize + 4),
+            iconView.leadingAnchor.constraint(equalTo: iconContainerView.leadingAnchor),
+            iconView.trailingAnchor.constraint(equalTo: iconContainerView.trailingAnchor),
+            iconView.topAnchor.constraint(equalTo: iconContainerView.topAnchor),
+            iconView.bottomAnchor.constraint(equalTo: iconContainerView.bottomAnchor),
+            progressView.leadingAnchor.constraint(equalTo: iconContainerView.leadingAnchor),
+            progressView.trailingAnchor.constraint(equalTo: iconContainerView.trailingAnchor),
+            progressView.topAnchor.constraint(equalTo: iconContainerView.topAnchor),
+            progressView.bottomAnchor.constraint(equalTo: iconContainerView.bottomAnchor),
             widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.minimumWidth),
             heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.minimumHeight),
         ])
@@ -158,20 +348,12 @@ final class PathCopiedToastView: NSView {
         surfaceView.apply(theme: theme, animated: false)
 
         let labelColor = theme.openWithPopoverText.withAlphaComponent(isDark ? 0.96 : 0.92)
+        currentLabelColor = labelColor
         messageLabel.textColor = labelColor
         messageLabel.font = .systemFont(ofSize: 13, weight: .semibold)
 
-        let symbolConfiguration = NSImage.SymbolConfiguration(
-            pointSize: Layout.iconPointSize,
-            weight: .semibold,
-            scale: .medium
-        )
-        let icon = NSImage(
-            systemSymbolName: "checkmark.circle.fill",
-            accessibilityDescription: "Path copied"
-        )?.withSymbolConfiguration(symbolConfiguration)
-        iconView.image = icon
         iconView.contentTintColor = labelColor.withAlphaComponent(isDark ? 0.96 : 0.88)
+        progressView.tintColor = iconView.contentTintColor ?? labelColor
         let shadowColor = theme.openWithPopoverShadow
             .mixed(towards: .black, amount: 0.52)
             .withAlphaComponent(isDark ? 0.42 : 0.18)
@@ -179,6 +361,28 @@ final class PathCopiedToastView: NSView {
         layer?.shadowColor = shadowColor.cgColor
         layer?.shadowRadius = isDark ? 16 : 14
         layer?.shadowOffset = CGSize(width: 0, height: 8)
+    }
+
+    private func setSymbolIcon(_ symbolName: String, accessibilityDescription: String) {
+        let symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: Layout.iconPointSize,
+            weight: .semibold,
+            scale: .medium
+        )
+        iconView.image = NSImage(
+            systemSymbolName: symbolName,
+            accessibilityDescription: accessibilityDescription
+        )?.withSymbolConfiguration(symbolConfiguration)
+        iconView.contentTintColor = currentLabelColor
+        iconView.isHidden = false
+        progressView.isHidden = true
+        currentIconSymbolName = symbolName
+    }
+
+    private func showProgressIcon() {
+        iconView.isHidden = true
+        progressView.isHidden = false
+        currentIconSymbolName = nil
     }
 
     private func dismiss() {
@@ -192,6 +396,7 @@ final class PathCopiedToastView: NSView {
             self.animator().frame = destinationFrame
         }, completionHandler: { [weak self] in
             MainActorShim.assumeIsolated {
+                self?.mode = .idle
                 self?.removeFromSuperview()
             }
         })
@@ -213,5 +418,80 @@ final class PathCopiedToastView: NSView {
         animation.timingFunction = CAMediaTimingFunction(name: timing)
         layer.transform = CATransform3DMakeScale(endScale, endScale, 1)
         layer.add(animation, forKey: "toastScale")
+    }
+
+    var isProgressActiveForTesting: Bool {
+        isProgressActive
+    }
+
+    var messageForTesting: String {
+        messageLabel.stringValue
+    }
+
+    var progressFractionForTesting: Double {
+        progressView.fraction
+    }
+
+    var iconSymbolNameForTesting: String? {
+        currentIconSymbolName
+    }
+}
+
+@MainActor
+private final class ToastCircularProgressView: NSView {
+    private var fractionStorage: Double = 0
+
+    var fraction: Double {
+        get {
+            fractionStorage
+        }
+        set {
+            fractionStorage = max(0, min(1, newValue))
+            needsDisplay = true
+        }
+    }
+
+    var tintColor: NSColor = .labelColor {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    override var isFlipped: Bool {
+        false
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard bounds.width > 0, bounds.height > 0 else {
+            return
+        }
+
+        let side = min(bounds.width, bounds.height) - 2
+        let rect = NSRect(
+            x: bounds.midX - side / 2,
+            y: bounds.midY - side / 2,
+            width: side,
+            height: side
+        )
+
+        let background = NSBezierPath(ovalIn: rect)
+        background.lineWidth = 1.6
+        tintColor.withAlphaComponent(0.24).setStroke()
+        background.stroke()
+
+        let progress = NSBezierPath()
+        progress.lineWidth = 1.8
+        progress.lineCapStyle = .round
+        let center = NSPoint(x: rect.midX, y: rect.midY)
+        progress.appendArc(
+            withCenter: center,
+            radius: side / 2,
+            startAngle: 90,
+            endAngle: 90 - (360 * CGFloat(fraction)),
+            clockwise: true
+        )
+        tintColor.setStroke()
+        progress.stroke()
     }
 }

--- a/ZenttyLogicTests/PaneSSHProcessProbeTests.swift
+++ b/ZenttyLogicTests/PaneSSHProcessProbeTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import Zentty
+
+final class PaneSSHProcessProbeTests: XCTestCase {
+    func test_destination_from_argv_parses_supported_ssh_forms() throws {
+        struct Case {
+            let argv: [String]
+            let target: String
+            let user: String?
+            let host: String
+            let port: Int?
+        }
+
+        let cases = [
+            Case(argv: ["ssh", "host"], target: "host", user: nil, host: "host", port: nil),
+            Case(argv: ["ssh", "user@host"], target: "user@host", user: "user", host: "host", port: nil),
+            Case(argv: ["ssh", "-p", "2222", "host"], target: "host", user: nil, host: "host", port: 2222),
+            Case(argv: ["ssh", "-l", "user", "host"], target: "user@host", user: "user", host: "host", port: nil),
+            Case(argv: ["ssh", "-i", "/k", "-o", "ProxyJump=b", "host"], target: "host", user: nil, host: "host", port: nil),
+            Case(argv: ["ssh", "user@2001:db8::1"], target: "user@2001:db8::1", user: "user", host: "2001:db8::1", port: nil),
+            Case(argv: ["ssh", "user@[2001:db8::1]"], target: "user@[2001:db8::1]", user: "user", host: "[2001:db8::1]", port: nil),
+            Case(argv: ["ssh", "-p", "2222", "2001:db8::1"], target: "2001:db8::1", user: nil, host: "2001:db8::1", port: 2222),
+        ]
+
+        for testCase in cases {
+            let destination = try XCTUnwrap(
+                PaneSSHProcessProbe.destination(fromArgv: testCase.argv),
+                "argv: \(testCase.argv)"
+            )
+            XCTAssertEqual(destination.target, testCase.target, "argv: \(testCase.argv)")
+            XCTAssertEqual(destination.user, testCase.user, "argv: \(testCase.argv)")
+            XCTAssertEqual(destination.host, testCase.host, "argv: \(testCase.argv)")
+            XCTAssertEqual(destination.port, testCase.port, "argv: \(testCase.argv)")
+        }
+    }
+
+    func test_scan_returns_destination_when_ssh_is_present() throws {
+        let treeProvider = FakePaneSSHProcessTreeProvider(
+            pids: [100: [100, 101]],
+            names: [100: "zsh", 101: "ssh"]
+        )
+        let argvProvider = FakePaneSSHArgvProvider(
+            argvByPID: [101: ["ssh", "-p", "2222", "peter@gilfoyle.example.test"]]
+        )
+        let probe = PaneSSHProcessProbe(
+            processTreeProvider: treeProvider,
+            argvProvider: argvProvider
+        )
+
+        let destination = try XCTUnwrap(probe.scan(rootPID: 100))
+
+        XCTAssertEqual(destination.target, "peter@gilfoyle.example.test")
+        XCTAssertEqual(destination.user, "peter")
+        XCTAssertEqual(destination.host, "gilfoyle.example.test")
+        XCTAssertEqual(destination.port, 2222)
+    }
+
+    func test_scan_returns_nil_when_ssh_is_absent() {
+        let probe = PaneSSHProcessProbe(
+            processTreeProvider: FakePaneSSHProcessTreeProvider(
+                pids: [100: [100, 101]],
+                names: [100: "zsh", 101: "vim"]
+            ),
+            argvProvider: FakePaneSSHArgvProvider(argvByPID: [:])
+        )
+
+        XCTAssertNil(probe.scan(rootPID: 100))
+        XCTAssertFalse(probe.hasSSH(rootPID: 100))
+    }
+
+    func test_scan_prefers_deepest_nested_ssh() throws {
+        let probe = PaneSSHProcessProbe(
+            processTreeProvider: FakePaneSSHProcessTreeProvider(
+                pids: [100: [100, 101, 102]],
+                names: [100: "zsh", 101: "ssh", 102: "ssh"]
+            ),
+            argvProvider: FakePaneSSHArgvProvider(
+                argvByPID: [
+                    101: ["ssh", "jump.example.test"],
+                    102: ["ssh", "-l", "deploy", "prod.example.test"],
+                ]
+            )
+        )
+
+        let destination = try XCTUnwrap(probe.scan(rootPID: 100))
+
+        XCTAssertEqual(destination.target, "deploy@prod.example.test")
+        XCTAssertEqual(destination.user, "deploy")
+        XCTAssertEqual(destination.host, "prod.example.test")
+    }
+
+    func test_darwin_process_tree_provider_reads_current_process_name() throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+
+        let processName = try XCTUnwrap(DarwinPaneSSHProcessTreeProvider().processName(pid: pid))
+
+        XCTAssertFalse(processName.isEmpty)
+    }
+
+    func test_darwin_argv_provider_reads_current_process_arguments() throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+
+        let argv = try XCTUnwrap(DarwinPaneSSHProcessArgvProvider().argv(pid: pid))
+
+        XCTAssertFalse(argv.isEmpty)
+    }
+}
+
+private struct FakePaneSSHProcessTreeProvider: PaneSSHProcessTreeProviding {
+    var pids: [Int32: [Int32]]
+    var names: [Int32: String]
+
+    func treePIDs(rootPID: Int32) -> [Int32] {
+        pids[rootPID] ?? []
+    }
+
+    func processName(pid: Int32) -> String? {
+        names[pid]
+    }
+}
+
+private struct FakePaneSSHArgvProvider: PaneSSHProcessArgvProviding {
+    var argvByPID: [Int32: [String]]
+
+    func argv(pid: Int32) -> [String]? {
+        argvByPID[pid]
+    }
+}

--- a/ZenttyLogicTests/PathCopiedToastViewProgressTests.swift
+++ b/ZenttyLogicTests/PathCopiedToastViewProgressTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class PathCopiedToastViewProgressTests: AppKitTestCase {
+    func test_progress_mode_updates_message_and_fraction() {
+        let parentView = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        let toast = PathCopiedToastView()
+
+        let handle = toast.beginProgress(
+            message: "Uploading pasted image (0%)",
+            in: parentView,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        handle.updateProgress(fraction: 0.42, message: "Uploading pasted image (42%)")
+
+        XCTAssertTrue(toast.isProgressActiveForTesting)
+        XCTAssertEqual(toast.messageForTesting, "Uploading pasted image (42%)")
+        XCTAssertEqual(toast.progressFractionForTesting, 0.42, accuracy: 0.001)
+    }
+
+    func test_progress_finish_switches_to_success_message() {
+        let parentView = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        let toast = PathCopiedToastView()
+
+        let handle = toast.beginProgress(
+            message: "Uploading pasted image (0%)",
+            in: parentView,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        handle.finish(message: "Pasted remote path", icon: "checkmark.circle.fill")
+
+        XCTAssertFalse(toast.isProgressActiveForTesting)
+        XCTAssertEqual(toast.messageForTesting, "Pasted remote path")
+        XCTAssertEqual(toast.iconSymbolNameForTesting, "checkmark.circle.fill")
+    }
+
+    func test_progress_failure_switches_to_error_message() {
+        let parentView = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        let toast = PathCopiedToastView()
+
+        let handle = toast.beginProgress(
+            message: "Uploading pasted image (0%)",
+            in: parentView,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        handle.fail(message: "Couldn't upload image — ssh key auth required")
+
+        XCTAssertFalse(toast.isProgressActiveForTesting)
+        XCTAssertEqual(toast.messageForTesting, "Couldn't upload image — ssh key auth required")
+        XCTAssertEqual(toast.iconSymbolNameForTesting, "xmark.circle.fill")
+    }
+
+    func test_progress_temporary_message_restores_latest_progress_message() async throws {
+        let parentView = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        let toast = PathCopiedToastView()
+
+        let handle = toast.beginProgress(
+            message: "Uploading pasted image (0%)",
+            in: parentView,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        toast.temporarilyShowProgressMessage("Upload already in progress", duration: 0.01)
+        handle.updateProgress(fraction: 0.42, message: "Uploading pasted image (42%)")
+
+        XCTAssertEqual(toast.messageForTesting, "Upload already in progress")
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(toast.messageForTesting, "Uploading pasted image (42%)")
+        XCTAssertEqual(toast.progressFractionForTesting, 0.42, accuracy: 0.001)
+    }
+}

--- a/ZenttyLogicTests/RemoteFileUploadRequestResolverTests.swift
+++ b/ZenttyLogicTests/RemoteFileUploadRequestResolverTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+@testable import Zentty
+
+final class RemoteFileUploadRequestResolverTests: XCTestCase {
+    func test_resolve_skips_directories_in_mixed_drop() {
+        let directoryURL = URL(fileURLWithPath: "/tmp/folder", isDirectory: true)
+        let pdfURL = URL(fileURLWithPath: "/tmp/Quarterly Report.pdf")
+        let archiveURL = URL(fileURLWithPath: "/tmp/archive.zip")
+        let resourceResolver = FakeRemoteFileResourceResolver(valuesByURL: [
+            directoryURL: RemoteFileResourceValues(isDirectory: true, fileSize: nil),
+            pdfURL: RemoteFileResourceValues(isDirectory: false, fileSize: 123),
+            archiveURL: RemoteFileResourceValues(isDirectory: false, fileSize: 456),
+        ])
+
+        let result = RemoteFileUploadRequestResolver.resolve(
+            fileURLs: [directoryURL, pdfURL, archiveURL],
+            resourceResolver: resourceResolver
+        )
+
+        XCTAssertEqual(
+            result,
+            .files([
+                RemoteFileUploadRequest(localURL: pdfURL, originalFilename: "Quarterly Report.pdf", byteCount: 123),
+                RemoteFileUploadRequest(localURL: archiveURL, originalFilename: "archive.zip", byteCount: 456),
+            ])
+        )
+    }
+
+    func test_resolve_reports_folders_only_when_all_entries_are_directories() {
+        let firstDirectoryURL = URL(fileURLWithPath: "/tmp/folder-a", isDirectory: true)
+        let secondDirectoryURL = URL(fileURLWithPath: "/tmp/folder-b", isDirectory: true)
+        let resourceResolver = FakeRemoteFileResourceResolver(valuesByURL: [
+            firstDirectoryURL: RemoteFileResourceValues(isDirectory: true, fileSize: nil),
+            secondDirectoryURL: RemoteFileResourceValues(isDirectory: true, fileSize: nil),
+        ])
+
+        let result = RemoteFileUploadRequestResolver.resolve(
+            fileURLs: [firstDirectoryURL, secondDirectoryURL],
+            resourceResolver: resourceResolver
+        )
+
+        XCTAssertEqual(result, .foldersOnly)
+    }
+
+    func test_resolve_rejects_over_limit_file_before_upload_request() {
+        let largeFileURL = URL(fileURLWithPath: "/tmp/movie.mov")
+        let resourceResolver = FakeRemoteFileResourceResolver(valuesByURL: [
+            largeFileURL: RemoteFileResourceValues(
+                isDirectory: false,
+                fileSize: RemoteFileUploadRequestResolver.maxFileByteCount + 1
+            ),
+        ])
+
+        let result = RemoteFileUploadRequestResolver.resolve(
+            fileURLs: [largeFileURL],
+            resourceResolver: resourceResolver
+        )
+
+        XCTAssertEqual(result, .fileTooLarge)
+        XCTAssertEqual(resourceResolver.requestedURLs, [largeFileURL])
+    }
+}
+
+private final class FakeRemoteFileResourceResolver: RemoteFileResourceResolving, @unchecked Sendable {
+    private let valuesByURL: [URL: RemoteFileResourceValues]
+    private(set) var requestedURLs: [URL] = []
+
+    init(valuesByURL: [URL: RemoteFileResourceValues]) {
+        self.valuesByURL = valuesByURL
+    }
+
+    func values(for fileURL: URL) throws -> RemoteFileResourceValues {
+        requestedURLs.append(fileURL)
+        return valuesByURL[fileURL] ?? RemoteFileResourceValues(isDirectory: false, fileSize: 0)
+    }
+}

--- a/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
+++ b/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import Zentty
+
+final class RemoteImagePasteDecisionTests: XCTestCase {
+    func test_destination_uses_remote_shell_context_when_title_and_ssh_label_are_missing() throws {
+        let shellContext = PaneShellContext(
+            scope: .remote,
+            path: "/srv/app",
+            home: "/home/peter",
+            user: "peter",
+            host: "prod-box"
+        )
+        let auxiliaryState = PaneAuxiliaryState(
+            raw: PaneRawState(shellContext: shellContext),
+            presentation: PanePresentationNormalizer.normalize(
+                paneTitle: "zsh",
+                raw: PaneRawState(shellContext: shellContext),
+                previous: nil
+            )
+        )
+
+        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+        XCTAssertEqual(destination.target, "peter@prod-box")
+        XCTAssertEqual(destination.user, "peter")
+        XCTAssertEqual(destination.host, "prod-box")
+        XCTAssertNil(destination.port)
+    }
+
+    func test_destination_prefers_process_probe_over_title_derived_destination() throws {
+        let raw = PaneRawState(
+            metadata: TerminalMetadata(title: "ssh stale@example.test", processName: "ssh"),
+            foregroundSSHDestination: SSHDestination(
+                target: "peter@live.example.test",
+                user: "peter",
+                host: "live.example.test",
+                port: 2222
+            )
+        )
+        let auxiliaryState = PaneAuxiliaryState(
+            raw: raw,
+            presentation: PanePresentationNormalizer.normalize(
+                paneTitle: "ssh stale@example.test",
+                raw: raw,
+                previous: nil
+            )
+        )
+
+        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+
+        XCTAssertEqual(destination.target, "peter@live.example.test")
+        XCTAssertEqual(destination.user, "peter")
+        XCTAssertEqual(destination.host, "live.example.test")
+        XCTAssertEqual(destination.port, 2222)
+    }
+
+    func test_destination_falls_back_to_title_when_probe_is_nil() throws {
+        let raw = PaneRawState(
+            metadata: TerminalMetadata(title: "ssh -p 2200 stale@example.test", processName: "ssh"),
+            foregroundSSHDestination: nil
+        )
+        let auxiliaryState = PaneAuxiliaryState(
+            raw: raw,
+            presentation: PanePresentationNormalizer.normalize(
+                paneTitle: "ssh -p 2200 stale@example.test",
+                raw: raw,
+                previous: nil
+            )
+        )
+
+        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+
+        XCTAssertEqual(destination.target, "stale@example.test")
+        XCTAssertEqual(destination.user, "stale")
+        XCTAssertEqual(destination.host, "example.test")
+        XCTAssertEqual(destination.port, 2200)
+    }
+
+    func test_remote_image_data_uploads() {
+        XCTAssertTrue(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
+                pasteboardContents: .imageData
+            )
+        )
+    }
+
+    func test_remote_text_does_not_upload() {
+        XCTAssertFalse(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
+                pasteboardContents: .text
+            )
+        )
+    }
+
+    func test_local_image_data_does_not_upload() {
+        XCTAssertFalse(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: RemoteImagePastePaneState(isRemotePane: false, destination: nil),
+                pasteboardContents: .imageData
+            )
+        )
+    }
+
+    func test_local_pane_without_probe_destination_stays_local() {
+        let raw = PaneRawState(
+            metadata: TerminalMetadata(title: "~/app", processName: "zsh"),
+            foregroundSSHDestination: nil
+        )
+        let presentation = PanePresentationNormalizer.normalize(
+            paneTitle: "shell",
+            raw: raw,
+            previous: nil
+        )
+        let paneState = RemoteImagePastePaneState(
+            isRemotePane: presentation.isRemotePane,
+            destination: RemoteImagePasteDestination.destination(
+                from: PaneAuxiliaryState(raw: raw, presentation: presentation)
+            )
+        )
+
+        XCTAssertFalse(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: paneState,
+                pasteboardContents: .imageData
+            )
+        )
+        XCTAssertNil(paneState.destination)
+    }
+
+    func test_remote_image_file_url_uploads() {
+        XCTAssertTrue(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
+                pasteboardContents: .imageFileURL
+            )
+        )
+    }
+
+    func test_remote_non_image_file_url_does_not_upload() {
+        XCTAssertFalse(
+            RemoteImagePasteDecision.shouldUploadRemotely(
+                paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
+                pasteboardContents: .nonImageFileURL
+            )
+        )
+    }
+}

--- a/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
+++ b/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
@@ -128,20 +128,20 @@ final class RemoteImagePasteDecisionTests: XCTestCase {
         XCTAssertNil(paneState.destination)
     }
 
-    func test_remote_image_file_url_uploads() {
+    func test_remote_file_urls_upload_regardless_of_type() {
         XCTAssertTrue(
             RemoteImagePasteDecision.shouldUploadRemotely(
                 paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
-                pasteboardContents: .imageFileURL
+                pasteboardContents: .fileURL
             )
         )
     }
 
-    func test_remote_non_image_file_url_does_not_upload() {
+    func test_local_file_urls_do_not_upload() {
         XCTAssertFalse(
             RemoteImagePasteDecision.shouldUploadRemotely(
-                paneState: RemoteImagePastePaneState(isRemotePane: true, destination: SSHDestination(target: "host")),
-                pasteboardContents: .nonImageFileURL
+                paneState: RemoteImagePastePaneState(isRemotePane: false, destination: nil),
+                pasteboardContents: .fileURL
             )
         )
     }

--- a/ZenttyLogicTests/RemoteImageUploaderTests.swift
+++ b/ZenttyLogicTests/RemoteImageUploaderTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class RemoteImageUploaderTests: XCTestCase {
+    func test_upload_streams_chunks_reports_progress_and_returns_remote_path() async throws {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(exitStatus: 0, stderr: "", timedOut: false)
+        )
+        let factory = FakeRemoteImageUploadProcessFactory(process: process)
+        let uploader = RemoteImageUploader(
+            processFactory: factory,
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 2,
+            timeout: 60
+        )
+        var progressFractions: [Double] = []
+
+        let path = try await uploader.upload(
+            imageData: Data([1, 2, 3, 4, 5]),
+            fileExtension: "png",
+            destination: SSHDestination(target: "peter@example.test", port: 2222),
+            progress: { progressFractions.append($0) }
+        )
+
+        XCTAssertEqual(path, "/tmp/zentty-paste-1700000000-12345678.png")
+        XCTAssertEqual(process.executableURL?.path, "/usr/bin/ssh")
+        XCTAssertEqual(process.arguments, [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=10",
+            "-p", "2222",
+            "--",
+            "peter@example.test",
+            "sh",
+            "-c",
+            "umask 077; cat > /tmp/zentty-paste-1700000000-12345678.png",
+        ])
+        let destinationIndex = try XCTUnwrap(process.arguments.firstIndex(of: "peter@example.test"))
+        XCTAssertFalse(process.arguments[(destinationIndex + 1)...].contains { $0.hasPrefix("--") })
+        XCTAssertEqual(process.writtenChunks, [Data([1, 2]), Data([3, 4]), Data([5])])
+        XCTAssertTrue(process.didCloseStandardInput)
+        XCTAssertEqual(progressFractions, [0.4, 0.8, 1.0])
+    }
+
+    func test_upload_maps_permission_denied_to_auth_required() async {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(
+                exitStatus: 255,
+                stderr: "Permission denied (publickey).",
+                timedOut: false
+            )
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 64,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.authRequired) {
+            _ = try await uploader.upload(
+                imageData: Data([1, 2, 3]),
+                fileExtension: "png",
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+    }
+
+    func test_upload_maps_unreachable_stderr_to_host_unreachable() async {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(
+                exitStatus: 255,
+                stderr: "ssh: connect to host example.test port 22: Operation timed out",
+                timedOut: false
+            )
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 64,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.hostUnreachable) {
+            _ = try await uploader.upload(
+                imageData: Data([1, 2, 3]),
+                fileExtension: "png",
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+    }
+
+    func test_upload_maps_permission_denied_to_auth_required_after_write_failure() async {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(
+                exitStatus: 255,
+                stderr: "Permission denied (publickey).",
+                timedOut: false
+            ),
+            throwOnWriteNumber: 2
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 2,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.authRequired) {
+            _ = try await uploader.upload(
+                imageData: Data([1, 2, 3, 4, 5]),
+                fileExtension: "png",
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+
+        XCTAssertEqual(process.waitUntilExitCallCount, 1)
+    }
+
+    func test_upload_maps_connection_timeout_to_host_unreachable_after_write_failure() async {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(
+                exitStatus: 255,
+                stderr: "ssh: connect to host example.test port 22: Connection timed out",
+                timedOut: false
+            ),
+            throwOnWriteNumber: 2
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 2,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.hostUnreachable) {
+            _ = try await uploader.upload(
+                imageData: Data([1, 2, 3, 4, 5]),
+                fileExtension: "png",
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+
+        XCTAssertEqual(process.waitUntilExitCallCount, 1)
+    }
+
+    func test_upload_maps_overall_timeout_to_timeout_error() async {
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(exitStatus: -1, stderr: "", timedOut: true)
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            remotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678.png" },
+            chunkSize: 64,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.timeout) {
+            _ = try await uploader.upload(
+                imageData: Data([1, 2, 3]),
+                fileExtension: "png",
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+    }
+
+    func test_remote_path_generation_uses_safe_filename_and_normalized_extension() throws {
+        let path = RemoteImageUploadPath.generate(
+            fileExtension: "jpeg",
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            uuid: UUID(uuidString: "12345678-9ABC-DEF0-1234-56789ABCDEF0")!
+        )
+
+        XCTAssertEqual(path, "/tmp/zentty-paste-1700000000-12345678.jpeg")
+        XCTAssertTrue(RemoteImageUploadPath.isSafeRemotePath(path))
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "public.png"), "png")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "public.jpeg"), "jpeg")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "public.tiff"), "tiff")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "com.compuserve.gif"), "gif")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "org.webmproject.webp"), "webp")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "public.heic"), "heic")
+        XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "com.example.unknown"), "png")
+    }
+}
+
+private func XCTAssertThrowsRemoteImageUploadError(
+    _ expected: RemoteImageUploadError,
+    operation: @escaping @Sendable () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await operation()
+        XCTFail("Expected \(expected)", file: file, line: line)
+    } catch let error as RemoteImageUploadError {
+        XCTAssertEqual(error, expected, file: file, line: line)
+    } catch {
+        XCTFail("Unexpected error: \(error)", file: file, line: line)
+    }
+}
+
+private final class FakeRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory, @unchecked Sendable {
+    private let process: FakeRemoteImageUploadProcess
+
+    init(process: FakeRemoteImageUploadProcess) {
+        self.process = process
+    }
+
+    func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess {
+        process.executableURL = executableURL
+        process.arguments = arguments
+        return process
+    }
+}
+
+private final class FakeRemoteImageUploadProcess: RemoteImageUploadProcess, @unchecked Sendable {
+    private enum FakeWriteError: Error {
+        case brokenPipe
+    }
+
+    var executableURL: URL?
+    var arguments: [String] = []
+    var writtenChunks: [Data] = []
+    var didCloseStandardInput = false
+    var waitUntilExitCallCount = 0
+
+    private let result: RemoteImageUploadProcessResult
+    private let throwOnWriteNumber: Int?
+
+    init(
+        result: RemoteImageUploadProcessResult,
+        throwOnWriteNumber: Int? = nil
+    ) {
+        self.result = result
+        self.throwOnWriteNumber = throwOnWriteNumber
+    }
+
+    func run() throws {}
+
+    func write(_ data: Data) throws {
+        if writtenChunks.count + 1 == throwOnWriteNumber {
+            throw FakeWriteError.brokenPipe
+        }
+
+        writtenChunks.append(data)
+    }
+
+    func closeStandardInput() {
+        didCloseStandardInput = true
+    }
+
+    func waitUntilExit(timeout: TimeInterval) -> RemoteImageUploadProcessResult {
+        waitUntilExitCallCount += 1
+        return result
+    }
+
+    func terminate() {}
+}

--- a/ZenttyLogicTests/RemoteImageUploaderTests.swift
+++ b/ZenttyLogicTests/RemoteImageUploaderTests.swift
@@ -170,6 +170,153 @@ final class RemoteImageUploaderTests: XCTestCase {
         }
     }
 
+    func test_upload_file_url_streams_chunks_reports_progress_and_returns_remote_path() async throws {
+        let fileURL = try makeTemporaryFile(contents: Data([1, 2, 3, 4, 5]), filename: "Quarterly Report.pdf")
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(exitStatus: 0, stderr: "", timedOut: false)
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            fileRemotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678-Quarterly-Report.pdf" },
+            chunkSize: 2,
+            timeout: 60
+        )
+        var progressFractions: [Double] = []
+
+        let path = try await uploader.upload(
+            fileURL: fileURL,
+            originalFilename: "Quarterly Report.pdf",
+            byteCount: 5,
+            destination: SSHDestination(target: "peter@example.test"),
+            progress: { progressFractions.append($0) }
+        )
+
+        XCTAssertEqual(path, "/tmp/zentty-paste-1700000000-12345678-Quarterly-Report.pdf")
+        XCTAssertEqual(process.writtenChunks, [Data([1, 2]), Data([3, 4]), Data([5])])
+        XCTAssertTrue(process.didCloseStandardInput)
+        XCTAssertEqual(progressFractions, [0.4, 0.8, 1.0])
+    }
+
+    func test_upload_file_url_maps_permission_denied_to_auth_required() async throws {
+        let fileURL = try makeTemporaryFile(contents: Data([1, 2, 3]), filename: "private.pdf")
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(
+                exitStatus: 255,
+                stderr: "Permission denied (publickey).",
+                timedOut: false
+            )
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            fileRemotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678-private.pdf" },
+            chunkSize: 64,
+            timeout: 60
+        )
+
+        await XCTAssertThrowsRemoteImageUploadError(.authRequired) {
+            _ = try await uploader.upload(
+                fileURL: fileURL,
+                originalFilename: "private.pdf",
+                byteCount: 3,
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+    }
+
+    func test_upload_file_url_cancellation_mid_file_terminates_process() async throws {
+        let fileURL = try makeTemporaryFile(contents: Data([1, 2, 3, 4, 5]), filename: "cancel.bin")
+        let process = FakeRemoteImageUploadProcess(
+            result: RemoteImageUploadProcessResult(exitStatus: 0, stderr: "", timedOut: false),
+            blockOnWriteNumber: 2
+        )
+        let uploader = RemoteImageUploader(
+            processFactory: FakeRemoteImageUploadProcessFactory(process: process),
+            fileRemotePathProvider: { _ in "/tmp/zentty-paste-1700000000-12345678-cancel.bin" },
+            chunkSize: 1,
+            timeout: 60
+        )
+
+        let task = Task {
+            try await uploader.upload(
+                fileURL: fileURL,
+                originalFilename: "cancel.bin",
+                byteCount: 5,
+                destination: SSHDestination(target: "example.test"),
+                progress: { _ in }
+            )
+        }
+
+        let didBlockOnWrite = await Task.detached {
+            process.waitForBlockedWrite(timeout: 2)
+        }.value
+        XCTAssertTrue(didBlockOnWrite)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(process.didTerminate)
+        XCTAssertTrue(process.didCloseStandardInput)
+        XCTAssertLessThan(process.writtenChunks.count, 5)
+    }
+
+    func test_batch_upload_preserves_drop_order_and_omits_failed_files_from_paste_text() async throws {
+        let firstURL = try makeTemporaryFile(contents: Data([1]), filename: "first.pdf")
+        let secondURL = try makeTemporaryFile(contents: Data([2]), filename: "second.mov")
+        let thirdURL = try makeTemporaryFile(contents: Data([3]), filename: "third.zip")
+        let factory = SequencedFakeRemoteImageUploadProcessFactory(processes: [
+            FakeRemoteImageUploadProcess(
+                result: RemoteImageUploadProcessResult(exitStatus: 0, stderr: "", timedOut: false)
+            ),
+            FakeRemoteImageUploadProcess(
+                result: RemoteImageUploadProcessResult(exitStatus: 1, stderr: "disk full", timedOut: false)
+            ),
+            FakeRemoteImageUploadProcess(
+                result: RemoteImageUploadProcessResult(exitStatus: 0, stderr: "", timedOut: false)
+            ),
+        ])
+        let uploader = RemoteImageUploader(
+            processFactory: factory,
+            fileRemotePathProvider: {
+                RemoteImageUploadPath.path(
+                    forOriginalFilename: $0,
+                    date: Date(timeIntervalSince1970: 1_700_000_000),
+                    uuid: UUID(uuidString: "12345678-9ABC-DEF0-1234-56789ABCDEF0")!
+                )
+            },
+            chunkSize: 64,
+            timeout: 60
+        )
+        let batch = RemoteFileUploadBatch(uploader: uploader)
+
+        let result = try await batch.uploadFiles(
+            [
+                RemoteFileUploadRequest(localURL: firstURL, originalFilename: "first.pdf", byteCount: 1),
+                RemoteFileUploadRequest(localURL: secondURL, originalFilename: "second.mov", byteCount: 1),
+                RemoteFileUploadRequest(localURL: thirdURL, originalFilename: "third.zip", byteCount: 1),
+            ],
+            destination: SSHDestination(target: "example.test"),
+            progress: { _ in }
+        )
+
+        XCTAssertEqual(result.successfulRemotePaths, [
+            "/tmp/zentty-paste-1700000000-12345678-first.pdf",
+            "/tmp/zentty-paste-1700000000-12345678-third.zip",
+        ])
+        XCTAssertEqual(result.failedCount, 1)
+        XCTAssertEqual(result.totalCount, 3)
+        XCTAssertEqual(
+            result.pasteText,
+            "/tmp/zentty-paste-1700000000-12345678-first.pdf /tmp/zentty-paste-1700000000-12345678-third.zip"
+        )
+    }
+
     func test_remote_path_generation_uses_safe_filename_and_normalized_extension() throws {
         let path = RemoteImageUploadPath.generate(
             fileExtension: "jpeg",
@@ -186,6 +333,40 @@ final class RemoteImageUploaderTests: XCTestCase {
         XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "org.webmproject.webp"), "webp")
         XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "public.heic"), "heic")
         XCTAssertEqual(TerminalClipboardImagePolicy.fileExtension(forUTIIdentifier: "com.example.unknown"), "png")
+    }
+
+    func test_remote_path_generation_from_original_filename_sanitizes_names_and_preserves_extension() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let uuid = UUID(uuidString: "12345678-9ABC-DEF0-1234-56789ABCDEF0")!
+
+        XCTAssertEqual(
+            uploadedName(for: "Quarterly Report.pdf", date: date, uuid: uuid),
+            "Quarterly-Report.pdf"
+        )
+        XCTAssertEqual(
+            uploadedName(for: "résumé 🚀.png", date: date, uuid: uuid),
+            "r-sum.png"
+        )
+        XCTAssertEqual(
+            uploadedName(for: "???bad***name.zip", date: date, uuid: uuid),
+            "bad-name.zip"
+        )
+        XCTAssertEqual(
+            uploadedName(for: ".env", date: date, uuid: uuid),
+            "env"
+        )
+        XCTAssertEqual(
+            uploadedName(for: "README", date: date, uuid: uuid),
+            "README"
+        )
+
+        let longName = uploadedName(
+            for: "\(String(repeating: "a", count: 160)).tar.gz",
+            date: date,
+            uuid: uuid
+        )
+        XCTAssertLessThanOrEqual(longName.count, 128)
+        XCTAssertTrue(longName.hasSuffix(".gz"))
     }
 }
 
@@ -219,6 +400,25 @@ private final class FakeRemoteImageUploadProcessFactory: RemoteImageUploadProces
     }
 }
 
+private final class SequencedFakeRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory, @unchecked Sendable {
+    private let lock = NSLock()
+    private var processes: [FakeRemoteImageUploadProcess]
+
+    init(processes: [FakeRemoteImageUploadProcess]) {
+        self.processes = processes
+    }
+
+    func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess {
+        lock.lock()
+        let process = processes.removeFirst()
+        lock.unlock()
+
+        process.executableURL = executableURL
+        process.arguments = arguments
+        return process
+    }
+}
+
 private final class FakeRemoteImageUploadProcess: RemoteImageUploadProcess, @unchecked Sendable {
     private enum FakeWriteError: Error {
         case brokenPipe
@@ -228,17 +428,23 @@ private final class FakeRemoteImageUploadProcess: RemoteImageUploadProcess, @unc
     var arguments: [String] = []
     var writtenChunks: [Data] = []
     var didCloseStandardInput = false
+    var didTerminate = false
     var waitUntilExitCallCount = 0
 
     private let result: RemoteImageUploadProcessResult
     private let throwOnWriteNumber: Int?
+    private let blockOnWriteNumber: Int?
+    private let blockedWriteSemaphore = DispatchSemaphore(value: 0)
+    private let unblockWriteSemaphore = DispatchSemaphore(value: 0)
 
     init(
         result: RemoteImageUploadProcessResult,
-        throwOnWriteNumber: Int? = nil
+        throwOnWriteNumber: Int? = nil,
+        blockOnWriteNumber: Int? = nil
     ) {
         self.result = result
         self.throwOnWriteNumber = throwOnWriteNumber
+        self.blockOnWriteNumber = blockOnWriteNumber
     }
 
     func run() throws {}
@@ -246,6 +452,11 @@ private final class FakeRemoteImageUploadProcess: RemoteImageUploadProcess, @unc
     func write(_ data: Data) throws {
         if writtenChunks.count + 1 == throwOnWriteNumber {
             throw FakeWriteError.brokenPipe
+        }
+
+        if writtenChunks.count + 1 == blockOnWriteNumber {
+            blockedWriteSemaphore.signal()
+            _ = unblockWriteSemaphore.wait(timeout: .now() + 2)
         }
 
         writtenChunks.append(data)
@@ -260,5 +471,33 @@ private final class FakeRemoteImageUploadProcess: RemoteImageUploadProcess, @unc
         return result
     }
 
-    func terminate() {}
+    func terminate() {
+        didTerminate = true
+        unblockWriteSemaphore.signal()
+    }
+
+    func waitForBlockedWrite(timeout: TimeInterval) -> Bool {
+        blockedWriteSemaphore.wait(timeout: .now() + timeout) == .success
+    }
+}
+
+private func makeTemporaryFile(contents: Data, filename: String) throws -> URL {
+    let directoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("Zentty.RemoteImageUploaderTests.\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    let fileURL = directoryURL.appendingPathComponent(filename)
+    try contents.write(to: fileURL)
+    return fileURL
+}
+
+private func uploadedName(for originalFilename: String, date: Date, uuid: UUID) -> String {
+    let path = RemoteImageUploadPath.path(
+        forOriginalFilename: originalFilename,
+        date: date,
+        uuid: uuid
+    )
+    XCTAssertTrue(RemoteImageUploadPath.isSafeRemotePath(path))
+    let prefix = "/tmp/zentty-paste-1700000000-12345678-"
+    XCTAssertTrue(path.hasPrefix(prefix))
+    return String(path.dropFirst(prefix.count))
 }

--- a/ZenttyLogicTests/RootViewControllerUpdateIntegrationTests.swift
+++ b/ZenttyLogicTests/RootViewControllerUpdateIntegrationTests.swift
@@ -6,14 +6,16 @@ import XCTest
 final class RootViewControllerUpdateIntegrationTests: AppKitTestCase {
     private func makeController(
         appUpdateStateStore: AppUpdateStateStore = AppUpdateStateStore(),
-        runtimeRegistry: PaneRuntimeRegistry = PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() })
+        runtimeRegistry: PaneRuntimeRegistry = PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() }),
+        remoteImageUploader: RemoteImageUploader = RemoteImageUploader()
     ) -> RootViewController {
         let controller = RootViewController(
             configStore: AppConfigStore(
                 fileURL: AppConfigStore.temporaryFileURL(prefix: "Zentty.RootViewController.UpdateRow")
             ),
             appUpdateStateStore: appUpdateStateStore,
-            runtimeRegistry: runtimeRegistry
+            runtimeRegistry: runtimeRegistry,
+            remoteImageUploader: remoteImageUploader
         )
         addTeardownBlock {
             MainActor.assumeIsolated {
@@ -21,6 +23,53 @@ final class RootViewControllerUpdateIntegrationTests: AppKitTestCase {
             }
         }
         return controller
+    }
+
+    func test_remoteFileURLPasteInRemotePaneStartsUploadTask() async throws {
+        let paneID = PaneID("pane-remote-file-upload")
+        let runtimeRegistry = PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() })
+        let uploadProcess = BlockingRemoteImageUploadProcess()
+        let remoteImageUploader = RemoteImageUploader(
+            processFactory: SingleRemoteImageUploadProcessFactory(process: uploadProcess),
+            fileRemotePathProvider: { _ in "/tmp/zentty-paste-file-upload-test.pdf" }
+        )
+        let controller = makeController(
+            runtimeRegistry: runtimeRegistry,
+            remoteImageUploader: remoteImageUploader
+        )
+        controller.loadViewIfNeeded()
+        controller.replaceWorklanes(
+            [makeFileUploadWorklane(paneID: paneID, isRemote: true)],
+            activeWorklaneID: WorklaneID("worklane-file-upload")
+        )
+        let runtime = try XCTUnwrap(runtimeRegistry.runtime(for: paneID))
+        let pasteHandler = try XCTUnwrap(runtime.hostView.remoteImagePasteHandler)
+        let pasteboard = try makeFileURLPasteboard()
+
+        XCTAssertTrue(pasteHandler(pasteboard, .drag))
+        XCTAssertTrue(controller.hasRemoteImageUploadTaskForTesting(for: paneID))
+        let uploadStarted = await uploadProcess.waitForWaitUntilExit(timeout: 1)
+        XCTAssertTrue(uploadStarted)
+        XCTAssertEqual(uploadProcess.writtenData, Data("report".utf8))
+
+        controller.cancelAllRemoteImageUploads()
+    }
+
+    func test_remoteFileURLPasteInLocalPaneReturnsFalse() throws {
+        let paneID = PaneID("pane-local-file-paste")
+        let runtimeRegistry = PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() })
+        let controller = makeController(runtimeRegistry: runtimeRegistry)
+        controller.loadViewIfNeeded()
+        controller.replaceWorklanes(
+            [makeFileUploadWorklane(paneID: paneID, isRemote: false)],
+            activeWorklaneID: WorklaneID("worklane-file-upload")
+        )
+        let runtime = try XCTUnwrap(runtimeRegistry.runtime(for: paneID))
+        let pasteHandler = try XCTUnwrap(runtime.hostView.remoteImagePasteHandler)
+        let pasteboard = try makeFileURLPasteboard()
+
+        XCTAssertFalse(pasteHandler(pasteboard, .drag))
+        XCTAssertFalse(controller.hasRemoteImageUploadTaskForTesting(for: paneID))
     }
 
     func test_root_controller_hides_update_row_when_no_update_is_available() throws {
@@ -464,6 +513,56 @@ private func makeTaskRunnerAction(
     )
 }
 
+private func makeFileUploadWorklane(paneID: PaneID, isRemote: Bool) -> WorklaneState {
+    let auxiliaryState: PaneAuxiliaryState
+    if isRemote {
+        auxiliaryState = PaneAuxiliaryState(
+            raw: PaneRawState(
+                shellContext: PaneShellContext(
+                    scope: .remote,
+                    path: "/home/deploy",
+                    home: "/home/deploy",
+                    user: "deploy",
+                    host: "example.com"
+                )
+            )
+        )
+    } else {
+        auxiliaryState = PaneAuxiliaryState()
+    }
+
+    return WorklaneState(
+        id: WorklaneID("worklane-file-upload"),
+        title: nil,
+        paneStripState: PaneStripState(
+            panes: [PaneState(id: paneID, title: "shell")],
+            focusedPaneID: paneID
+        ),
+        auxiliaryStateByPaneID: [
+            paneID: auxiliaryState
+        ]
+    )
+}
+
+private extension RootViewControllerUpdateIntegrationTests {
+    func makeFileURLPasteboard() throws -> NSPasteboard {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Zentty.RootViewController.FilePaste.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+
+        let fileURL = directoryURL.appendingPathComponent("Quarterly Report.pdf")
+        try Data("report".utf8).write(to: fileURL)
+
+        let pasteboard = NSPasteboard(name: .init("test-\(UUID().uuidString)"))
+        pasteboard.declareTypes([.fileURL], owner: nil)
+        XCTAssertTrue(pasteboard.writeObjects([fileURL as NSURL]))
+        return pasteboard
+    }
+}
+
 private final class RecordingRootTerminalAdapter: TerminalAdapter {
     var metadataDidChange: ((TerminalMetadata) -> Void)?
     var eventDidOccur: ((TerminalEvent) -> Void)?
@@ -496,4 +595,79 @@ private final class RecordingRootTerminalAdapter: TerminalAdapter {
     }
 
     func close() {}
+}
+
+private final class SingleRemoteImageUploadProcessFactory: RemoteImageUploadProcessFactory, @unchecked Sendable {
+    private let process: BlockingRemoteImageUploadProcess
+
+    init(process: BlockingRemoteImageUploadProcess) {
+        self.process = process
+    }
+
+    func makeProcess(executableURL: URL, arguments: [String]) -> any RemoteImageUploadProcess {
+        process.executableURL = executableURL
+        process.arguments = arguments
+        return process
+    }
+}
+
+private final class BlockingRemoteImageUploadProcess: RemoteImageUploadProcess, @unchecked Sendable {
+    var executableURL: URL?
+    var arguments: [String] = []
+
+    private let lock = NSLock()
+    private var writtenChunks: [Data] = []
+    private var didWaitUntilExit = false
+    private let terminateSemaphore = DispatchSemaphore(value: 0)
+
+    var writtenData: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return writtenChunks.reduce(into: Data()) { result, chunk in
+            result.append(chunk)
+        }
+    }
+
+    func run() throws {}
+
+    func write(_ data: Data) throws {
+        lock.lock()
+        writtenChunks.append(data)
+        lock.unlock()
+    }
+
+    func closeStandardInput() {}
+
+    func waitUntilExit(timeout: TimeInterval) -> RemoteImageUploadProcessResult {
+        lock.lock()
+        didWaitUntilExit = true
+        lock.unlock()
+        _ = terminateSemaphore.wait(timeout: .now() + 5)
+        return RemoteImageUploadProcessResult(
+            exitStatus: 1,
+            stderr: "cancelled",
+            timedOut: false
+        )
+    }
+
+    func terminate() {
+        terminateSemaphore.signal()
+    }
+
+    func waitForWaitUntilExit(timeout: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if hasReachedWaitUntilExit {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return hasReachedWaitUntilExit
+    }
+
+    private var hasReachedWaitUntilExit: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didWaitUntilExit
+    }
 }

--- a/ZenttyLogicTests/RootViewControllerUpdateIntegrationTests.swift
+++ b/ZenttyLogicTests/RootViewControllerUpdateIntegrationTests.swift
@@ -217,6 +217,56 @@ final class RootViewControllerUpdateIntegrationTests: AppKitTestCase {
         XCTAssertEqual(panes.last?.sessionRequest.environmentVariables["NODE_ENV"], "production")
     }
 
+    func test_remoteImageUploadTaskIsCancelledWhenPaneIsClosed() {
+        let controller = makeController()
+        controller.loadViewIfNeeded()
+        let paneID = PaneID("pane-upload")
+        let siblingPaneID = PaneID("pane-sibling")
+        let worklane = WorklaneState(
+            id: WorklaneID("worklane-main"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [
+                    PaneState(id: paneID, title: "upload"),
+                    PaneState(id: siblingPaneID, title: "sibling"),
+                ],
+                focusedPaneID: paneID
+            )
+        )
+        controller.replaceWorklanes([worklane], activeWorklaneID: worklane.id)
+        let task = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 60_000_000_000)
+        }
+        controller.insertRemoteImageUploadTaskForTesting(task, for: paneID)
+
+        controller.closePaneByID(paneID)
+
+        XCTAssertTrue(task.isCancelled)
+        XCTAssertFalse(controller.hasRemoteImageUploadTaskForTesting(for: paneID))
+    }
+
+    func test_remoteImageUploadTasksAreCancelledOnControllerTeardown() {
+        let controller = makeController()
+        controller.loadViewIfNeeded()
+        let firstPaneID = PaneID("pane-upload-1")
+        let secondPaneID = PaneID("pane-upload-2")
+        let firstTask = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 60_000_000_000)
+        }
+        let secondTask = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 60_000_000_000)
+        }
+        controller.insertRemoteImageUploadTaskForTesting(firstTask, for: firstPaneID)
+        controller.insertRemoteImageUploadTaskForTesting(secondTask, for: secondPaneID)
+
+        controller.cancelAllRemoteImageUploads()
+
+        XCTAssertTrue(firstTask.isCancelled)
+        XCTAssertTrue(secondTask.isCancelled)
+        XCTAssertFalse(controller.hasRemoteImageUploadTaskForTesting(for: firstPaneID))
+        XCTAssertFalse(controller.hasRemoteImageUploadTaskForTesting(for: secondPaneID))
+    }
+
     func test_root_controller_global_search_aggregates_results_across_worklanes() {
         let controller = makeController()
         controller.loadViewIfNeeded()

--- a/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
+++ b/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class SidebarPanePrimaryRowViewTests: AppKitTestCase {
+    func test_remote_indicator_hides_when_not_remote() {
+        let view = SidebarPanePrimaryRowView()
+
+        view.configureRemoteIndicator(isRemote: false, label: nil)
+
+        XCTAssertFalse(view.remoteIconIsVisibleForTesting)
+        XCTAssertNil(view.remoteIconToolTipForTesting)
+        XCTAssertEqual(view.remoteIconAccessibilityLabelForTesting, "")
+    }
+
+    func test_remote_indicator_shows_cloud_icon_without_label() {
+        let view = SidebarPanePrimaryRowView()
+
+        view.configureRemoteIndicator(isRemote: true, label: nil)
+
+        XCTAssertTrue(view.remoteIconIsVisibleForTesting)
+        XCTAssertEqual(view.remoteIconSymbolNameForTesting, "cloud.fill")
+        XCTAssertEqual(view.remoteIconToolTipForTesting, "Remote session")
+        XCTAssertEqual(view.remoteIconAccessibilityLabelForTesting, "Remote session")
+    }
+
+    func test_remote_indicator_shows_trimmed_label_in_tooltip_and_accessibility_label() {
+        let view = SidebarPanePrimaryRowView()
+
+        view.configureRemoteIndicator(isRemote: true, label: "  prod.example.test  ")
+
+        XCTAssertTrue(view.remoteIconIsVisibleForTesting)
+        XCTAssertEqual(view.remoteIconToolTipForTesting, "Remote session: prod.example.test")
+        XCTAssertEqual(view.remoteIconAccessibilityLabelForTesting, "Remote session: prod.example.test")
+    }
+
+    func test_remote_indicator_remains_visible_after_primary_text_update() {
+        let view = SidebarPanePrimaryRowView()
+        view.configure(
+            primaryText: "ssh",
+            trailingText: nil,
+            presentationMode: .inline,
+            lineCount: 1
+        )
+        view.configureRemoteIndicator(isRemote: true, label: "prod.example.test")
+
+        view.setPrimaryText("deploy")
+
+        XCTAssertTrue(view.remoteIconIsVisibleForTesting)
+        XCTAssertEqual(view.primaryText, "deploy")
+    }
+
+    func test_remote_indicator_uses_trailing_color() {
+        let view = SidebarPanePrimaryRowView()
+        let trailingColor = NSColor.systemTeal
+
+        view.configureRemoteIndicator(isRemote: true, label: nil)
+        view.applyColors(
+            primaryColor: .systemPink,
+            trailingColor: trailingColor,
+            isShimmering: true,
+            shimmerColor: .systemPurple,
+            reducedMotion: false
+        )
+
+        XCTAssertEqual(view.remoteIconTintColorForTesting, trailingColor)
+    }
+}

--- a/ZenttyLogicTests/TerminalClipboardTests.swift
+++ b/ZenttyLogicTests/TerminalClipboardTests.swift
@@ -4,25 +4,10 @@ import XCTest
 
 @MainActor
 final class TerminalClipboardTests: XCTestCase {
-    func test_image_upload_content_rejects_oversized_image_file_before_reading() throws {
-        let directoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("Zentty.TerminalClipboardTests.\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-
-        let imageURL = directoryURL.appendingPathComponent("oversized.png")
-        XCTAssertTrue(FileManager.default.createFile(atPath: imageURL.path, contents: Data([0x89, 0x50, 0x4E, 0x47])))
-        let fileHandle = try FileHandle(forWritingTo: imageURL)
-        try fileHandle.truncate(atOffset: UInt64(TerminalClipboardImagePolicy.maxImageByteCount + 1))
-        try fileHandle.close()
-        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: imageURL.path)
-        addTeardownBlock {
-            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: imageURL.path)
-            try? FileManager.default.removeItem(at: directoryURL)
-        }
-
+    func test_image_upload_content_rejects_oversized_raw_image_data() {
         let pasteboard = makeTestPasteboard()
-        pasteboard.declareTypes([.fileURL], owner: nil)
-        pasteboard.writeObjects([imageURL as NSURL])
+        pasteboard.declareTypes([.png], owner: nil)
+        pasteboard.setData(Data(count: TerminalClipboardImagePolicy.maxImageByteCount + 1), forType: .png)
 
         switch TerminalClipboard.imageUploadContent(from: pasteboard) {
         case .imageTooLarge:
@@ -30,6 +15,16 @@ final class TerminalClipboardTests: XCTestCase {
         case let content:
             XCTFail("Expected imageTooLarge, got \(content)")
         }
+    }
+
+    func test_file_urls_returns_file_urls_for_any_file_type_in_drop_order() {
+        let pasteboard = makeTestPasteboard()
+        let pdfURL = URL(fileURLWithPath: "/tmp/Quarterly Report.pdf")
+        let movieURL = URL(fileURLWithPath: "/tmp/demo.mov")
+        pasteboard.declareTypes([.fileURL], owner: nil)
+        pasteboard.writeObjects([pdfURL as NSURL, movieURL as NSURL])
+
+        XCTAssertEqual(TerminalClipboard.fileURLs(from: pasteboard), [pdfURL, movieURL])
     }
 
     func test_pasted_string_returns_plain_text() {

--- a/ZenttyLogicTests/TerminalClipboardTests.swift
+++ b/ZenttyLogicTests/TerminalClipboardTests.swift
@@ -4,6 +4,34 @@ import XCTest
 
 @MainActor
 final class TerminalClipboardTests: XCTestCase {
+    func test_image_upload_content_rejects_oversized_image_file_before_reading() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Zentty.TerminalClipboardTests.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let imageURL = directoryURL.appendingPathComponent("oversized.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: imageURL.path, contents: Data([0x89, 0x50, 0x4E, 0x47])))
+        let fileHandle = try FileHandle(forWritingTo: imageURL)
+        try fileHandle.truncate(atOffset: UInt64(TerminalClipboardImagePolicy.maxImageByteCount + 1))
+        try fileHandle.close()
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: imageURL.path)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: imageURL.path)
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+
+        let pasteboard = makeTestPasteboard()
+        pasteboard.declareTypes([.fileURL], owner: nil)
+        pasteboard.writeObjects([imageURL as NSURL])
+
+        switch TerminalClipboard.imageUploadContent(from: pasteboard) {
+        case .imageTooLarge:
+            break
+        case let content:
+            XCTFail("Expected imageTooLarge, got \(content)")
+        }
+    }
+
     func test_pasted_string_returns_plain_text() {
         let pasteboard = makeTestPasteboard()
         pasteboard.declareTypes([.string], owner: nil)

--- a/ZenttyLogicTests/WorklaneContextFormatterTests.swift
+++ b/ZenttyLogicTests/WorklaneContextFormatterTests.swift
@@ -217,6 +217,34 @@ final class WorklaneContextFormatterTests: XCTestCase {
         XCTAssertEqual(label, "peter@203.0.113.10")
     }
 
+    func test_ssh_destination_parses_common_command_titles() {
+        struct Case {
+            let title: String
+            let target: String
+            let user: String?
+            let host: String
+            let port: Int?
+        }
+
+        let cases: [Case] = [
+            Case(title: "ssh host.example.test", target: "host.example.test", user: nil, host: "host.example.test", port: nil),
+            Case(title: "ssh peter@host.example.test", target: "peter@host.example.test", user: "peter", host: "host.example.test", port: nil),
+            Case(title: "ssh -p 2222 host.example.test", target: "host.example.test", user: nil, host: "host.example.test", port: 2222),
+            Case(title: "ssh -p2222 host.example.test", target: "host.example.test", user: nil, host: "host.example.test", port: 2222),
+            Case(title: "ssh -l peter host.example.test", target: "peter@host.example.test", user: "peter", host: "host.example.test", port: nil),
+            Case(title: "ssh -i /tmp/key -o ProxyJump=bastion prod", target: "prod", user: nil, host: "prod", port: nil),
+            Case(title: "ssh -- host-alias", target: "host-alias", user: nil, host: "host-alias", port: nil),
+        ]
+
+        for entry in cases {
+            let destination = WorklaneContextFormatter.sshDestination(fromCommandTitle: entry.title)
+            XCTAssertEqual(destination?.target, entry.target, entry.title)
+            XCTAssertEqual(destination?.user, entry.user, entry.title)
+            XCTAssertEqual(destination?.host, entry.host, entry.title)
+            XCTAssertEqual(destination?.port, entry.port, entry.title)
+        }
+    }
+
     private func makeTemporaryRepository(named repositoryName: String) throws -> String {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/ZenttyLogicTests/WorklaneSidebarSummaryTests.swift
+++ b/ZenttyLogicTests/WorklaneSidebarSummaryTests.swift
@@ -295,6 +295,118 @@ final class WorklaneSidebarSummaryTests: XCTestCase {
         XCTAssertEqual(summary.paneRows.first?.detailText, "~/project")
     }
 
+    func test_builder_marks_remote_pane_from_shell_context() throws {
+        let paneID = PaneID("worklane-main-shell")
+        var auxiliaryState = PaneAuxiliaryState()
+        auxiliaryState.raw = PaneRawState(
+            metadata: TerminalMetadata(title: "zsh", processName: "zsh"),
+            shellContext: PaneShellContext(
+                scope: .remote,
+                path: "/home/peter/project",
+                home: "/home/peter",
+                user: "peter",
+                host: "gilfoyle"
+            )
+        )
+        auxiliaryState.presentation = PanePresentationNormalizer.normalize(
+            paneTitle: "shell",
+            raw: auxiliaryState.raw,
+            previous: nil
+        )
+        let worklane = WorklaneState(
+            id: WorklaneID("worklane-main"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: paneID, title: "shell")],
+                focusedPaneID: paneID
+            ),
+            auxiliaryStateByPaneID: [paneID: auxiliaryState]
+        )
+
+        let paneRow = try XCTUnwrap(
+            WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true).paneRows.first
+        )
+
+        XCTAssertTrue(paneRow.isRemotePane)
+        XCTAssertEqual(paneRow.remotePaneLabel, "gilfoyle")
+    }
+
+    func test_builder_marks_remote_pane_from_inferred_ssh_connection() throws {
+        let paneID = PaneID("worklane-main-shell")
+        let worklane = WorklaneState(
+            id: WorklaneID("worklane-main"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: paneID, title: "shell")],
+                focusedPaneID: paneID
+            ),
+            metadataByPaneID: [
+                paneID: TerminalMetadata(
+                    title: "ssh peter@gilfoyle.example.test",
+                    currentWorkingDirectory: "/Users/peter/Development/Personal/zentty",
+                    processName: "ssh"
+                )
+            ]
+        )
+
+        let paneRow = try XCTUnwrap(
+            WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true).paneRows.first
+        )
+
+        XCTAssertTrue(paneRow.isRemotePane)
+        XCTAssertEqual(paneRow.remotePaneLabel, "peter@gilfoyle.example.test")
+    }
+
+    func test_builder_marks_remote_pane_from_foreground_ssh_process_when_title_resets() throws {
+        let paneID = PaneID("worklane-main-shell")
+        var raw = PaneRawState(
+            metadata: TerminalMetadata(
+                title: "peter@gilfoyle: ~/app",
+                currentWorkingDirectory: "/Users/peter/Development/Personal/zentty",
+                processName: "zsh"
+            ),
+            foregroundSSHDestination: SSHDestination(
+                target: "peter@gilfoyle.example.test",
+                user: "peter",
+                host: "gilfoyle.example.test"
+            )
+        )
+        let presentation = PanePresentationNormalizer.normalize(
+            paneTitle: "shell",
+            raw: raw,
+            previous: nil
+        )
+        raw.metadata = TerminalMetadata(
+            title: "~/app",
+            currentWorkingDirectory: "/Users/peter/Development/Personal/zentty",
+            processName: "zsh"
+        )
+        let auxiliaryState = PaneAuxiliaryState(
+            raw: raw,
+            presentation: PanePresentationNormalizer.normalize(
+                paneTitle: "shell",
+                raw: raw,
+                previous: presentation
+            )
+        )
+        let worklane = WorklaneState(
+            id: WorklaneID("worklane-main"),
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: paneID, title: "shell")],
+                focusedPaneID: paneID
+            ),
+            auxiliaryStateByPaneID: [paneID: auxiliaryState]
+        )
+
+        let paneRow = try XCTUnwrap(
+            WorklaneSidebarSummaryBuilder.summary(for: worklane, isActive: true).paneRows.first
+        )
+
+        XCTAssertTrue(paneRow.isRemotePane)
+        XCTAssertEqual(paneRow.remotePaneLabel, "peter@gilfoyle.example.test")
+    }
+
     func test_builder_shows_codex_action_required_title_and_needs_input_badge() {
         let paneID = PaneID("worklane-main-shell")
         let worklane = WorklaneState(


### PR DESCRIPTION
Pasting a screenshot into a pane that's ssh'ed into a server used to be useless: the terminal got a local file path that doesn't exist on the remote. Now Zentty detects the ssh session, uploads the file, and pastes the remote path instead.

## What's in here

**Remote pane detection.** A probe walks the pane's process tree looking for a live ssh process and reads its argv for the exact destination (user, host, port). The old title heuristic broke the moment the remote prompt renamed the terminal title; the process tree doesn't lie. Title and shell-integration signals stay as fallbacks. Remote panes get a cloud icon next to their title in the sidebar.

**File upload on paste/drop.** Any file — image, pdf, screen recording — pasted or dropped on a remote pane streams over `ssh dest 'umask 077; cat > /tmp/zentty-paste-...'` with a progress HUD. On completion the remote path is pasted, shell-escaped. Original filenames survive (sanitized): `/tmp/zentty-paste-1751728000-a3f81b22-report.pdf`.

- 500 MB cap per file, checked before reading; big files stream from disk in chunks
- multi-file drops upload sequentially, one HUD counting `(2/5, 41%)`, paths pasted in drop order; partial failures paste what succeeded
- folders rejected with a toast
- raw screenshot pastes keep the existing 10 MB image path
- failure toasts distinguish key-auth-required, host unreachable, timeout, transfer failure
- uploads cancel on pane close / window teardown

**A latent bug fix that fell out of this.** `proc_name()` needs a buffer of at least `2*MAXCOMLEN` or it fails with ENOMEM. Both the new probe and the existing Task Manager sampler used `MAXCOMLEN` — so the Task Manager has been showing "pid 12345" fallback labels instead of process names. Fixed in both places, with real-syscall regression tests.

## Testing

- ~90 new logic tests: argv parsing, path sanitization, upload streaming/cancellation/error classification, multi-file batching, decision wiring, sidebar rendering
- wiring-level regression tests after a review pass caught the decision guard evaluating the wrong variable (unit tests alone missed it)
- manually verified against a real remote box: badge stability across the session, screenshot paste, pdf/video drops, multi-drop, folder rejection, mode-600 files on the remote