### PR TITLE
feat(omp): add Oh My Pi agent status integration

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		DA4EBB588176E3DEB4B96C6E /* ErrorReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0057216F25AA9654E5BDB87 /* ErrorReporting.swift */; };
 		DB21A0CF0DDA1220BC123F3B /* SidebarWorklaneDragGestureTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750C0A516E7016E42B94EC2 /* SidebarWorklaneDragGestureTracker.swift */; };
 		DB99D15DBBA9E04854EE979F /* DroidHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E98A96BAD466E5847C42948 /* DroidHooksInstaller.swift */; };
+		DBCAAF164769A450761B89C8 /* PiFamilyLaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA24EE3B2294AADC4A0C3E82 /* PiFamilyLaunchPolicy.swift */; };
 		DC139F18052FBD8126678D7F /* TerminalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7FF718B0E0C3314C57BFC5 /* TerminalAdapter.swift */; };
 		DC6594609ADC8C26340A0B8A /* SidebarWorklaneRowButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4225E34022CEC2DFB9C70338 /* SidebarWorklaneRowButtonTests.swift */; };
 		DD1FBB3CA62ACE6EFBA1E7AD /* FuzzyMatch in Frameworks */ = {isa = PBXBuildFile; productRef = 1783CDCC7848CB005D3A519C /* FuzzyMatch */; };
@@ -481,6 +482,7 @@
 		E94E1DACAFBCE24E8AA485C5 /* SidebarShimmerColorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7F2B3A458136A7651CA4BA /* SidebarShimmerColorResolver.swift */; };
 		E95C4FC6740D1885397423A2 /* ServerIPCCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0633B563FD38C6FAF61062 /* ServerIPCCommands.swift */; };
 		E9BF42DC69D4CF63845BCBE2 /* SidebarWorklaneRowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BC50CDB5D0B82695D9A2D4 /* SidebarWorklaneRowLayoutTests.swift */; };
+		EA10CB44073C9B4AA793AB67 /* PiFamilyLaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA24EE3B2294AADC4A0C3E82 /* PiFamilyLaunchPolicy.swift */; };
 		EA6847AAD0A938767899B578 /* VendoredGhosttyResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E1E9FF5B98D7124B6E65AC /* VendoredGhosttyResourcesTests.swift */; };
 		EAC39845FAE3EF9784F2F17C /* DroidTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCA77C435DCC7E4F338789C /* DroidTaskStore.swift */; };
 		EBA82B93B865F768A59C3FB5 /* CommandPaletteItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1927429EEB90A74961D30D /* CommandPaletteItemBuilderTests.swift */; };
@@ -1041,6 +1043,7 @@
 		E84313842197C75BCA9CE6E8 /* HermesTitleOverrideReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesTitleOverrideReducer.swift; sourceTree = "<group>"; };
 		E89BAAA51D175EA4CC9174AA /* RecentCommandsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentCommandsTracker.swift; sourceTree = "<group>"; };
 		E8E6AFBC242DD01217E89E74 /* MenuBarStatusKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusKind.swift; sourceTree = "<group>"; };
+		EA24EE3B2294AADC4A0C3E82 /* PiFamilyLaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFamilyLaunchPolicy.swift; sourceTree = "<group>"; };
 		EA5DD7A1968777DF9C77029D /* LibghosttySelectionAutoscrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttySelectionAutoscrollControllerTests.swift; sourceTree = "<group>"; };
 		EB2414DEC30C1A200BC42DD4 /* AgentIntegrationGrandfather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIntegrationGrandfather.swift; sourceTree = "<group>"; };
 		EB3CF0787F91406CE385FEB3 /* PaneDragCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragCoordinator.swift; sourceTree = "<group>"; };
@@ -1481,6 +1484,7 @@
 				D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */,
 				EB869749410CBF86B97FA142 /* PaneAgentReducer.swift */,
 				C5A65B5FE282DD307A732E81 /* PaneIPCHandler.swift */,
+				EA24EE3B2294AADC4A0C3E82 /* PiFamilyLaunchPolicy.swift */,
 				B3D36140C30599601062D9BF /* ProcessCWDResolver.swift */,
 				58F3670F6A327C1BE9F37B1B /* ServerIPCHandler.swift */,
 				8EF1C35E3E3441C4C57051CA /* TmuxCompatArguments.swift */,
@@ -2190,7 +2194,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/amp/plugins\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/amp/amp\" -o -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/droid/droid\" -o -path \"*/gemini/gemini\" -o -path \"*/grok/grok\" -o -path \"*/hermes/hermes\" -o -path \"*/kimi/kimi\" -o -path \"*/kimi/kimi-cli\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/agy/agy\" -o -path \"*/vibe/vibe\" -o -path \"*/vibe/mistral-vibe\" -o -path \"*/small-harness/small-harness\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" -o -path \"*/tmux-shim/tmux\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/amp/\" \"${RESOURCES_DST}/amp/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
+			shellScript = "set -euo pipefail\n\nRESOURCES_SRC=\"${PROJECT_DIR}/ZenttyResources\"\nRESOURCES_DST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n\nmkdir -p \"${RESOURCES_DST}/bin\" \"${RESOURCES_DST}/shell-integration\" \"${RESOURCES_DST}/amp/plugins\" \"${RESOURCES_DST}/opencode/plugins\" \"${RESOURCES_DST}/pi/extensions\" \"${RESOURCES_DST}/omp/extensions\" \"${RESOURCES_DST}/shared/pi-family\" \"${RESOURCES_DST}/ghostty\" \"${RESOURCES_DST}/terminfo\"\nrsync -a --delete \"${RESOURCES_SRC}/bin/\" \"${RESOURCES_DST}/bin/\"\ninstall -m 755 \"${BUILT_PRODUCTS_DIR}/zentty\" \"${RESOURCES_DST}/bin/shared/zentty\"\nfind \"${RESOURCES_DST}/bin\" -type f \\( -path \"*/amp/amp\" -o -path \"*/claude/claude\" -o -path \"*/codex/codex\" -o -path \"*/copilot/copilot\" -o -path \"*/cursor/cursor-agent\" -o -path \"*/droid/droid\" -o -path \"*/gemini/gemini\" -o -path \"*/grok/grok\" -o -path \"*/hermes/hermes\" -o -path \"*/kimi/kimi\" -o -path \"*/kimi/kimi-cli\" -o -path \"*/opencode/opencode\" -o -path \"*/pi/pi\" -o -path \"*/omp/omp\" -o -path \"*/agy/agy\" -o -path \"*/vibe/vibe\" -o -path \"*/vibe/mistral-vibe\" -o -path \"*/small-harness/small-harness\" -o -path \"*/shared/zentty\" -o -path \"*/shared/zentty-agent-wrapper\" -o -path \"*/tmux-shim/tmux\" \\) -exec chmod 755 {} +\nrsync -a --delete \"${RESOURCES_SRC}/shell-integration/\" \"${RESOURCES_DST}/shell-integration/\"\nrsync -a --delete \"${RESOURCES_SRC}/amp/\" \"${RESOURCES_DST}/amp/\"\nrsync -a --delete \"${RESOURCES_SRC}/opencode/\" \"${RESOURCES_DST}/opencode/\"\nrsync -a --delete \"${RESOURCES_SRC}/pi/\" \"${RESOURCES_DST}/pi/\"\nrsync -a --delete \"${RESOURCES_SRC}/omp/\" \"${RESOURCES_DST}/omp/\"\nrsync -a --delete \"${RESOURCES_SRC}/shared/pi-family/\" \"${RESOURCES_DST}/shared/pi-family/\"\nrsync -a --delete \"${RESOURCES_SRC}/ghostty/\" \"${RESOURCES_DST}/ghostty/\"\nrsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\"\n";
 		};
 		C7055FCE2E5119172F74E931 /* Verify GhosttyKit */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2555,6 +2559,7 @@
 				961ADDCEBB2BBB78B2820F67 /* PaneStripView.swift in Sources */,
 				C989D4E5646E700C8802CBD9 /* PassiveServerDetection.swift in Sources */,
 				AD9CD66217E3E181B808CDB1 /* PathCopiedToastView.swift in Sources */,
+				DBCAAF164769A450761B89C8 /* PiFamilyLaunchPolicy.swift in Sources */,
 				6219CFABA673D1F436C3EBB2 /* PresentationDraft.swift in Sources */,
 				F79914E37499F5FE7297C009 /* PresentationPipeline.swift in Sources */,
 				39721130F49DA6F5A8ACE5DB /* PresentationReducer.swift in Sources */,
@@ -2755,6 +2760,7 @@
 				99451BC2B09FAA072A3B3A88 /* JSONCRelaxedParse.swift in Sources */,
 				6763F2DC7655B039F55D08F4 /* JSONKeyAccess.swift in Sources */,
 				B32F85F567CD87464A187C57 /* KimiHooksInstaller.swift in Sources */,
+				EA10CB44073C9B4AA793AB67 /* PiFamilyLaunchPolicy.swift in Sources */,
 				E95C4FC6740D1885397423A2 /* ServerIPCCommands.swift in Sources */,
 				860CBB896950670C3BD5842A /* ServerOutputURLDetector.swift in Sources */,
 				03B68115EC5C72019F10D82A /* ServerURLNormalizer.swift in Sources */,

--- a/Zentty/AppState/Agent/AgentIPCProtocol.swift
+++ b/Zentty/AppState/Agent/AgentIPCProtocol.swift
@@ -39,6 +39,7 @@ enum AgentBootstrapTool: String, Codable, Equatable, CaseIterable {
     case kimi
     case opencode
     case pi
+    case omp
     case grok
     case agy
     case hermes
@@ -52,7 +53,7 @@ enum AgentBootstrapTool: String, Codable, Equatable, CaseIterable {
         switch self {
         case .cursor:
             return ["cursor-agent"]
-        case .amp, .claude, .codex, .copilot, .droid, .gemini, .opencode, .pi, .grok, .agy, .hermes, .smallHarness:
+        case .amp, .claude, .codex, .copilot, .droid, .gemini, .opencode, .pi, .omp, .grok, .agy, .hermes, .smallHarness:
             return [rawValue]
         case .kimi:
             return [rawValue, "kimi-cli"]

--- a/Zentty/AppState/Agent/AgentIntegrationConsent.swift
+++ b/Zentty/AppState/Agent/AgentIntegrationConsent.swift
@@ -78,7 +78,7 @@ extension AgentBootstrapTool {
         switch self {
         case .amp, .cursor, .droid, .grok, .agy, .hermes, .vibe:
             return .persistent
-        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .smallHarness:
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .omp, .smallHarness:
             return .ephemeral
         }
     }
@@ -103,6 +103,7 @@ extension AgentBootstrapTool {
         case .kimi: return .kimi
         case .opencode: return .openCode
         case .pi: return .pi
+        case .omp: return .omp
         case .grok: return .grok
         case .agy: return .agy
         case .hermes: return .hermes
@@ -129,7 +130,7 @@ extension AgentBootstrapTool {
         case .agy: return AgyHooksInstaller.defaultUserHooksFileURL()
         case .hermes: return HermesHooksInstaller.defaultConfigURL()
         case .vibe: return VibeHooksInstaller.defaultUserHooksFileURL()
-        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .smallHarness:
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .omp, .smallHarness:
             return nil
         }
     }
@@ -147,7 +148,7 @@ enum AgentIntegrationConsent {
     /// Persistent (config-modifying) agents, in Settings display order.
     static let persistentTools: [AgentBootstrapTool] = [.amp, .cursor, .droid, .grok, .agy, .hermes, .vibe]
     /// Ephemeral (built-in) agents, in Settings display order.
-    static let ephemeralTools: [AgentBootstrapTool] = [.claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .smallHarness]
+    static let ephemeralTools: [AgentBootstrapTool] = [.claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .omp, .smallHarness]
     /// All known agents, persistent group first.
     static let allTools: [AgentBootstrapTool] = persistentTools + ephemeralTools
 
@@ -239,7 +240,7 @@ enum AgentIntegrationHooks {
                 isInstalled: { VibeHooksInstaller.isInstalled() },
                 uninstall: { try VibeHooksInstaller.uninstall() }
             )
-        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .smallHarness:
+        case .claude, .codex, .copilot, .gemini, .kimi, .opencode, .pi, .omp, .smallHarness:
             return nil
         }
     }

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -141,6 +141,15 @@ enum AgentLaunchBootstrap {
             return piPlan(
                 executablePath: executablePath,
                 arguments: request.arguments,
+                environment: environment,
+                bundle: bundle,
+                fileManager: fileManager
+            )
+        case .omp:
+            return ompPlan(
+                executablePath: executablePath,
+                arguments: request.arguments,
+                environment: environment,
                 bundle: bundle,
                 fileManager: fileManager
             )
@@ -306,35 +315,81 @@ enum AgentLaunchBootstrap {
     private static func piPlan(
         executablePath: String,
         arguments: [String],
+        environment: [String: String],
         bundle: Bundle,
         fileManager: FileManager
     ) -> AgentLaunchPlan {
-        // Pi itself sets PI_CODING_AGENT=true at startup (src/cli.ts),
-        // so we only need ZENTTY_AGENT_TOOL for Zentty's own recognition.
-        let setEnvironment = ["ZENTTY_AGENT_TOOL": "pi"]
+        piFamilyLaunchPlan(
+            executablePath: executablePath,
+            arguments: arguments,
+            environment: environment,
+            bundle: bundle,
+            fileManager: fileManager,
+            bootstrapToolValue: "pi",
+            bundleFolder: "pi",
+            extensionEntryFilename: "zentty-pi-zentty.js",
+            canonicalAgentName: "Pi",
+            hooksDisabledEnvironmentKey: "ZENTTY_PI_HOOKS_DISABLED"
+        )
+    }
+
+    private static func ompPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        bundle: Bundle,
+        fileManager: FileManager
+    ) -> AgentLaunchPlan {
+        piFamilyLaunchPlan(
+            executablePath: executablePath,
+            arguments: arguments,
+            environment: environment,
+            bundle: bundle,
+            fileManager: fileManager,
+            bootstrapToolValue: "omp",
+            bundleFolder: "omp",
+            extensionEntryFilename: "zentty-omp-zentty.js",
+            canonicalAgentName: "OMP",
+            hooksDisabledEnvironmentKey: "ZENTTY_OMP_HOOKS_DISABLED"
+        )
+    }
+
+    private static func piFamilyLaunchPlan(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        bundle: Bundle,
+        fileManager: FileManager,
+        bootstrapToolValue: String,
+        bundleFolder: String,
+        extensionEntryFilename: String,
+        canonicalAgentName: String,
+        hooksDisabledEnvironmentKey: String
+    ) -> AgentLaunchPlan {
+        if environment[hooksDisabledEnvironmentKey] == "1" {
+            return directPlan(executablePath: executablePath, arguments: arguments)
+        }
+
+        var setEnvironment = [
+            "ZENTTY_AGENT_TOOL": bootstrapToolValue,
+            "ZENTTY_AGENT_CANONICAL_NAME": canonicalAgentName,
+        ]
 
         var plannedArguments = arguments
         let extensionURL = bundle.resourceURL?
-            .appendingPathComponent("pi", isDirectory: true)
+            .appendingPathComponent(bundleFolder, isDirectory: true)
             .appendingPathComponent("extensions", isDirectory: true)
-            .appendingPathComponent("zentty-pi-zentty.js", isDirectory: false)
+            .appendingPathComponent(extensionEntryFilename, isDirectory: false)
         if let extensionURL, fileManager.isReadableFile(atPath: extensionURL.path) {
-            // Stack the bridge on top of the user's own pi extensions:
-            // with `-e <path>` alone (no `--no-extensions`), pi merges CLI
-            // extensions with globals — see pi-mono
-            // packages/coding-agent/src/core/resource-loader.ts.
             plannedArguments.insert(contentsOf: ["-e", extensionURL.path], at: 0)
         } else {
-            // Silent miss here leaves the sidebar stuck on "Starting" with
-            // no breadcrumb. Warn so bundle misconfigurations are traceable
-            // via `log stream --predicate 'category == "AgentLaunchBootstrap"'`.
             agentLaunchLogger.warning(
-                "Pi bridge extension missing from bundle (path=\(extensionURL?.path ?? "<nil>", privacy: .public)); agent status will not be tracked"
+                "\(canonicalAgentName, privacy: .public) bridge extension missing from bundle (path=\(extensionURL?.path ?? "<nil>", privacy: .public)); agent status will not be tracked"
             )
         }
 
         let sessionStartJSON = """
-        {"version":1,"event":"session.start","agent":{"name":"Pi","pid":\(AgentIPCProtocol.selfPIDPlaceholder)}}
+        {"version":1,"event":"session.start","agent":{"name":"\(canonicalAgentName)","pid":\(AgentIPCProtocol.selfPIDPlaceholder)}}
         """
         return AgentLaunchPlan(
             executablePath: executablePath,
@@ -350,6 +405,7 @@ enum AgentLaunchBootstrap {
             ]
         )
     }
+
 
     private static func grokPlan(
         executablePath: String,
@@ -1571,7 +1627,7 @@ enum AgentLaunchBootstrap {
             return ["CLAUDECODE"]
         case .smallHarness:
             return smallHarnessManagedHookEnvironmentKeys
-        case .amp, .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi, .grok, .agy, .hermes, .vibe:
+        case .amp, .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi, .omp, .grok, .agy, .hermes, .vibe:
             return []
         }
     }

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -12,6 +12,7 @@ enum AgentTool: Equatable, Sendable {
     case kimi
     case openCode
     case pi
+    case omp
     case grok
     case agy
     case hermes
@@ -43,6 +44,8 @@ enum AgentTool: Equatable, Sendable {
             return "OpenCode"
         case .pi:
             return "Pi"
+        case .omp:
+            return "OMP"
         case .grok:
             return "Grok"
         case .agy:
@@ -131,6 +134,7 @@ enum AgentTool: Equatable, Sendable {
         ToolNameMatcher(tool: .kimi, isHookDrivenOnly: false, match: .contains("kimi")),
         ToolNameMatcher(tool: .openCode, isHookDrivenOnly: false, match: .containsAny(["opencode", "open code"])),
         ToolNameMatcher(tool: .pi, isHookDrivenOnly: false, match: .pi),
+        ToolNameMatcher(tool: .omp, isHookDrivenOnly: false, match: .leadingToken(["omp"])),
         ToolNameMatcher(tool: .grok, isHookDrivenOnly: false, match: .leadingToken(["grok", "grok-build"])),
         ToolNameMatcher(tool: .agy, isHookDrivenOnly: false, match: .leadingToken(["agy", "antigravity"])),
         ToolNameMatcher(tool: .hermes, isHookDrivenOnly: false, match: .leadingToken(["hermes"])),

--- a/Zentty/AppState/Agent/AgentStatusHelper.swift
+++ b/Zentty/AppState/Agent/AgentStatusHelper.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 enum AgentStatusHelper {
-    private static let wrappedToolNames = ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "kimi", "opencode", "pi", "agy", "vibe", "small-harness"]
+    private static let wrappedToolNames = ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "kimi", "opencode", "pi", "omp", "agy", "vibe", "small-harness"]
     private static let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
     static func runIfNeeded(arguments: [String], environment: [String: String]) -> Int32? {
@@ -63,6 +63,7 @@ enum AgentStatusHelper {
                     "kimi/kimi-cli",
                     "opencode/opencode",
                     "pi/pi",
+                    "omp/omp",
                     "agy/agy",
                     "vibe/vibe",
                     "vibe/mistral-vibe",
@@ -82,6 +83,7 @@ enum AgentStatusHelper {
                     "kimi/kimi-cli",
                     "opencode/opencode",
                     "pi/pi",
+                    "omp/omp",
                     "agy/agy",
                     "vibe/vibe",
                     "vibe/mistral-vibe",

--- a/Zentty/AppState/Agent/PiFamilyLaunchPolicy.swift
+++ b/Zentty/AppState/Agent/PiFamilyLaunchPolicy.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Passthrough rules for Pi-lineage CLIs (`pi`, `omp`) that inject Zentty status via `-e`.
+enum PiFamilyLaunchPolicy {
+    static let piPassthroughSubcommands: Set<String> = [
+        "install", "remove", "uninstall", "update", "list", "config",
+    ]
+
+    static let piEarlyExitFlags: Set<String> = [
+        "--help", "-h", "--version", "-v", "--list-models", "--export",
+    ]
+
+    /// Snapshot from `omp --help`, v16.3.6, 2026-07-05.
+    static let ompPassthroughSubcommands: Set<String> = [
+        "acp", "agents", "auth-broker", "auth-gateway", "bench", "commit", "completions",
+        "config", "dry-balance", "gallery", "gc", "grep", "grievances", "install", "join",
+        "models", "plugin", "read", "say", "search", "setup", "shell", "ssh", "stats",
+        "tiny-models", "token", "ttsr", "update", "usage", "worktree",
+    ]
+
+    static let ompEarlyExitFlags: Set<String> = piEarlyExitFlags.union(["--alias"])
+
+    // These are the global scope flags a user plausibly puts before a management
+    // subcommand (`omp --profile work plugin list`); boolean/session flags
+    // intentionally stop the scan because after them arguments are messages.
+    private static let passthroughScopeFlags: Set<String> = ["--profile", "--cwd", "--config"]
+
+    static func passthroughSubcommands(for tool: AgentBootstrapTool) -> Set<String>? {
+        switch tool {
+        case .pi: return piPassthroughSubcommands
+        case .omp: return ompPassthroughSubcommands
+        default: return nil
+        }
+    }
+
+    static func passthroughSubcommand(in arguments: [String], for tool: AgentBootstrapTool) -> String? {
+        guard let subcommands = passthroughSubcommands(for: tool),
+              !subcommands.isEmpty else {
+            return nil
+        }
+
+        var index = arguments.startIndex
+        while index < arguments.endIndex {
+            let argument = arguments[index]
+
+            if passthroughScopeFlags.contains(argument) {
+                index = arguments.index(after: index)
+                guard index < arguments.endIndex else { return nil }
+                index = arguments.index(after: index)
+                continue
+            }
+
+            if passthroughScopeFlags.contains(where: { argument.hasPrefix($0 + "=") }) {
+                index = arguments.index(after: index)
+                continue
+            }
+
+            return subcommands.contains(argument) ? argument : nil
+        }
+
+        return nil
+    }
+
+    static func earlyExitFlags(for tool: AgentBootstrapTool) -> Set<String>? {
+        switch tool {
+        case .pi: return piEarlyExitFlags
+        case .omp: return ompEarlyExitFlags
+        default: return nil
+        }
+    }
+}

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -898,6 +898,8 @@ enum PanePresentationNormalizer {
             return ["opencode", "open code"].contains(normalized)
         case .pi:
             return ["pi", "π"].contains(normalized)
+        case .omp:
+            return normalized == "omp"
         case .grok:
             return ["grok", "grok build", "grok-build"].contains(normalized)
         case .agy:

--- a/Zentty/AppState/WorklaneStore+DragDrop.swift
+++ b/Zentty/AppState/WorklaneStore+DragDrop.swift
@@ -1001,6 +1001,7 @@ extension WorklaneStore {
             case .kimi: return "kimi"
             case .openCode: return "opencode"
             case .pi: return "pi"
+            case .omp: return "omp"
             case .grok: return "grok"
             case .agy: return "agy"
             case .hermes: return "hermes"

--- a/Zentty/Restore/SessionRestoreStore.swift
+++ b/Zentty/Restore/SessionRestoreStore.swift
@@ -569,7 +569,7 @@ enum SessionRestoreDraftExporter {
         switch tool {
         case .amp, .claudeCode, .codex, .copilot, .cursor, .droid, .kimi, .openCode, .hermes, .vibe:
             return .sessionID
-        case .gemini, .pi, .grok, .agy, .smallHarness:
+        case .gemini, .pi, .omp, .grok, .agy, .smallHarness:
             return .workingDirectory
         case .zentty, .custom:
             return .unsupported
@@ -755,6 +755,12 @@ enum AgentResumeCommandBuilder {
                 return nil
             }
             return "pi -c"
+        case .omp:
+            guard hasWorkingDirectory(draft) else {
+                logRejectedWorkingDirectory(for: draft)
+                return nil
+            }
+            return "omp -c"
         case .smallHarness:
             guard hasWorkingDirectory(draft) else {
                 logRejectedWorkingDirectory(for: draft)

--- a/Zentty/Terminal/TerminalMetadata.swift
+++ b/Zentty/Terminal/TerminalMetadata.swift
@@ -1630,6 +1630,8 @@ final class TerminalDiagnostics: @unchecked Sendable {
             return "opencode"
         case .pi:
             return "pi"
+        case .omp:
+            return "omp"
         case .grok:
             return "grok"
         case .agy:

--- a/Zentty/UI/MenuBar/MenuBarAgentIconInspector.swift
+++ b/Zentty/UI/MenuBar/MenuBarAgentIconInspector.swift
@@ -22,6 +22,7 @@ enum MenuBarAgentIconInspector {
         .kimi,
         .openCode,
         .pi,
+        .omp,
         .grok,
         .agy,
         .hermes,

--- a/Zentty/UI/MenuBar/MenuBarStatusIconRenderer.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusIconRenderer.swift
@@ -430,6 +430,8 @@ enum MenuBarStatusIconRenderer {
             return "AgentIconOpenCode"
         case .pi:
             return "AgentIconPi"
+        case .omp:
+            return nil
         case .grok:
             return "AgentIconGrok"
         case .agy:

--- a/ZenttyCLI/AgentToolLauncher.swift
+++ b/ZenttyCLI/AgentToolLauncher.swift
@@ -160,25 +160,15 @@ struct AgentToolLauncher {
             }
             return nil
         case .pi:
-            // Pi has management subcommands (install/remove/update/list/…)
-            // and early-exit flags (--help, --version, --list-models, …).
-            // Injecting our bridge extension via -e at position 0 turns the
-            // subcommand into a chat message, so pass these through without
-            // any Zentty rewriting.
-            //
-            // Source of truth: `pi --help`, i.e. pi-mono's
-            // packages/coding-agent/src/cli.ts. Bump the sets below if pi
-            // core adds a new subcommand or early-exit flag. Pi extensions
-            // cannot add shell subcommands, only slash commands / CLI flags
-            // parsed after the extension loads, so only pi-core drift can
-            // invalidate this list.
-            if let subcommand = arguments.first, Self.piPassthroughSubcommands.contains(subcommand) {
-                return "pi passthrough subcommand: \(subcommand)"
+            if environment["ZENTTY_PI_HOOKS_DISABLED"] == "1" {
+                return "ZENTTY_PI_HOOKS_DISABLED=1"
             }
-            if let flag = arguments.first(where: { Self.piEarlyExitFlags.contains($0) }) {
-                return "pi early-exit flag: \(flag)"
+            return Self.piFamilyBootstrapSkipReason(tool: .pi, arguments: arguments, label: "pi")
+        case .omp:
+            if environment["ZENTTY_OMP_HOOKS_DISABLED"] == "1" {
+                return "ZENTTY_OMP_HOOKS_DISABLED=1"
             }
-            return nil
+            return Self.piFamilyBootstrapSkipReason(tool: .omp, arguments: arguments, label: "omp")
         case .grok:
             if environment["ZENTTY_GROK_HOOKS_DISABLED"] == "1" {
                 return "ZENTTY_GROK_HOOKS_DISABLED=1"
@@ -238,13 +228,23 @@ struct AgentToolLauncher {
         }
     }
 
-    static let piPassthroughSubcommands: Set<String> = [
-        "install", "remove", "uninstall", "update", "list", "config",
-    ]
+    private static func piFamilyBootstrapSkipReason(
+        tool: AgentBootstrapTool,
+        arguments: [String],
+        label: String
+    ) -> String? {
+        if let subcommand = PiFamilyLaunchPolicy.passthroughSubcommand(in: arguments, for: tool) {
+            return "\(label) passthrough subcommand: \(subcommand)"
+        }
+        if let flags = PiFamilyLaunchPolicy.earlyExitFlags(for: tool),
+           let flag = arguments.first(where: { argument in
+               flags.contains { argument == $0 || argument.hasPrefix($0 + "=") }
+           }) {
+            return "\(label) early-exit flag: \(flag)"
+        }
+        return nil
+    }
 
-    static let piEarlyExitFlags: Set<String> = [
-        "--help", "-h", "--version", "-v", "--list-models", "--export",
-    ]
 
     static let ampPassthroughSubcommands: Set<String> = [
         "login", "logout", "mcp", "permission", "permissions", "review",
@@ -517,6 +517,8 @@ struct AgentToolLauncher {
             return "OpenCode"
         case .pi:
             return "Pi"
+        case .omp:
+            return "OMP"
         case .grok:
             return "Grok"
         case .agy:
@@ -550,8 +552,10 @@ struct AgentToolLauncher {
             "ZENTTY_CURSOR_VERBOSE_HOOKS",
             "ZENTTY_DROID_HOOKS_DISABLED",
             "ZENTTY_KIMI_HOOKS_DISABLED",
-            "ZENTTY_KIMI_VARIANT",
+            "ZENTTY_PI_HOOKS_DISABLED",
+            "ZENTTY_OMP_HOOKS_DISABLED",
             "ZENTTY_GROK_HOOKS_DISABLED",
+            "ZENTTY_KIMI_VARIANT",
             "ZENTTY_AGY_HOOKS_DISABLED",
             "ZENTTY_HERMES_HOOKS_DISABLED",
             "ZENTTY_VIBE_HOOKS_DISABLED",
@@ -617,7 +621,7 @@ struct AgentToolLauncher {
             return EnvironmentPatch(set: [:], unset: ["CLAUDECODE"])
         case .smallHarness:
             return EnvironmentPatch(set: [:], unset: ["SMALL_HARNESS_MANAGED_HOOKS_FILE", "SMALL_HARNESS_MANAGED_HOOKS_JSON"])
-        case .amp, .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi, .grok, .agy, .hermes, .vibe:
+        case .amp, .codex, .copilot, .cursor, .droid, .gemini, .kimi, .opencode, .pi, .omp, .grok, .agy, .hermes, .vibe:
             return EnvironmentPatch()
         }
     }
@@ -660,7 +664,7 @@ struct AgentToolLauncher {
             environmentPatch.set["VIBE_ENABLE_EXPERIMENTAL_HOOKS"] = "true"
         case .smallHarness:
             environmentPatch.set["ZENTTY_SMALL_HARNESS_PID"] = "\(getpid())"
-        case .opencode, .pi:
+        case .opencode, .pi, .omp:
             break
         }
 

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -851,6 +851,40 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertEqual(AgentTool.resolve(named: idle.first?.toolName), .pi)
     }
 
+    func test_omp_running_idle_lifecycle() throws {
+        let running = try AgentEventBridge.makePayloads(
+            from: AgentEventBridge.parseInput(
+                #"{"version":1,"event":"agent.running","agent":{"name":"OMP"}}"#.data(using: .utf8)!
+            ),
+            environment: defaultEnvironment
+        )
+        let idle = try AgentEventBridge.makePayloads(
+            from: AgentEventBridge.parseInput(
+                #"{"version":1,"event":"agent.idle","agent":{"name":"OMP"}}"#.data(using: .utf8)!
+            ),
+            environment: defaultEnvironment
+        )
+
+        XCTAssertEqual(running.first?.state, .running)
+        XCTAssertEqual(idle.first?.state, .idle)
+        XCTAssertEqual(AgentTool.resolve(named: running.first?.toolName), .omp)
+        XCTAssertEqual(AgentTool.resolve(named: idle.first?.toolName), .omp)
+    }
+
+    func test_omp_wrapper_delegates_via_zentty_launch() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let wrapperPath = repoRoot
+            .appendingPathComponent("ZenttyResources/bin/omp/omp")
+            .path
+        let script = try String(contentsOfFile: wrapperPath, encoding: .utf8)
+
+        XCTAssertTrue(script.contains("launch omp"))
+        XCTAssertTrue(script.contains("find_real_omp"))
+    }
+
+
     func test_pi_wrapper_delegates_via_zentty_launch() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -1010,6 +1010,15 @@ final class AgentStatusSupportTests: XCTestCase {
     }
 
     func test_repository_shell_integrations_tag_codex_shell_activity() throws {
+        let fakeBinDirectory = try makeTemporaryDirectory(named: "shell-integration-fake-codex-bin")
+        let fakeCodexURL = fakeBinDirectory.appendingPathComponent("codex", isDirectory: false)
+        try "#!/bin/sh\nexit 0\n".write(to: fakeCodexURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeCodexURL.path)
+        let path = [
+            fakeBinDirectory.path,
+            ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin",
+        ].joined(separator: ":")
+
         for shell in [ShellIntegrationTestShell.zsh, .bash, .fish] {
             guard shell.isAvailable else { continue }
             let signals = try runShellIntegration(
@@ -1018,7 +1027,8 @@ final class AgentStatusSupportTests: XCTestCase {
                     ? #"_zentty_preexec "codex""#
                     : shell == .fish
                         ? #"_zentty_fish_preexec_hook codex"#
-                        : #"codex 2>/dev/null || true"#
+                        : #"codex 2>/dev/null || true"#,
+                extraEnvironment: ["PATH": path]
             )
 
             XCTAssertTrue(

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -155,6 +155,16 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(AgentTool.resolveKnown(named: "⠋ π - myproject"), .pi)
     }
 
+    func test_agent_tool_recognizes_omp_as_leading_token_only() {
+        XCTAssertEqual(AgentTool.resolve(named: "omp"), .omp)
+        XCTAssertEqual(AgentTool.resolve(named: "OMP"), .omp)
+        XCTAssertEqual(AgentTool.resolve(named: "omp - myproject"), .omp)
+        XCTAssertEqual(AgentTool.resolveKnown(named: "OMP"), .omp)
+        XCTAssertEqual(AgentTool.resolve(named: "opencode"), .openCode)
+        XCTAssertEqual(AgentTool.resolve(named: "pi"), .pi)
+    }
+
+
     func test_agent_tool_does_not_confuse_pi_with_unrelated_words() {
         // Must not swallow strings that merely start with the letters "pi".
         XCTAssertEqual(AgentTool.resolve(named: "pip"), .custom("pip"))
@@ -180,36 +190,56 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(AgentTool.resolve(named: "opencode"), .openCode)
     }
 
-    func test_pi_passthrough_list_matches_pi_mono_subcommands_snapshot() throws {
-        // Snapshot of `pi --help` verified 2026-04-19 against pi-mono's
-        // packages/coding-agent/src/cli.ts. Purpose: make intentional drift
-        // deliberate — if a maintainer adds/removes an item on one side,
-        // this test nudges them to update the other.
-        //
-        // AgentToolLauncher lives in the ZenttyCLI target which tests don't
-        // import, so we read the source file directly (same pattern as
-        // test_pi_wrapper_delegates_via_zentty_launch).
-        let repoRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let launcherPath = repoRoot
-            .appendingPathComponent("ZenttyCLI/AgentToolLauncher.swift")
-            .path
-        let source = try String(contentsOfFile: launcherPath, encoding: .utf8)
-
-        for subcommand in ["install", "remove", "uninstall", "update", "list", "config"] {
-            XCTAssertTrue(
-                source.contains("\"\(subcommand)\""),
-                "piPassthroughSubcommands should contain \(subcommand)"
-            )
+    func test_pi_passthrough_list_matches_pi_mono_subcommands_snapshot() {
+        for subcommand in PiFamilyLaunchPolicy.piPassthroughSubcommands {
+            XCTAssertFalse(subcommand.isEmpty)
         }
-        for flag in ["--help", "-h", "--version", "-v", "--list-models", "--export"] {
-            XCTAssertTrue(
-                source.contains("\"\(flag)\""),
-                "piEarlyExitFlags should contain \(flag)"
-            )
-        }
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.piPassthroughSubcommands,
+            ["install", "remove", "uninstall", "update", "list", "config"]
+        )
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.piEarlyExitFlags,
+            ["--help", "-h", "--version", "-v", "--list-models", "--export"]
+        )
     }
+
+    func test_omp_passthrough_policy_includes_management_commands_snapshot() {
+        XCTAssertTrue(PiFamilyLaunchPolicy.ompPassthroughSubcommands.contains("install"))
+        XCTAssertTrue(PiFamilyLaunchPolicy.ompPassthroughSubcommands.contains("plugin"))
+        XCTAssertFalse(PiFamilyLaunchPolicy.ompPassthroughSubcommands.contains("remove"))
+        XCTAssertFalse(PiFamilyLaunchPolicy.ompPassthroughSubcommands.contains("uninstall"))
+        XCTAssertFalse(PiFamilyLaunchPolicy.ompPassthroughSubcommands.contains("list"))
+        XCTAssertEqual(PiFamilyLaunchPolicy.ompEarlyExitFlags, PiFamilyLaunchPolicy.piEarlyExitFlags.union(["--alias"]))
+    }
+
+    func test_pi_family_passthrough_subcommand_skips_leading_scope_flags() {
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.passthroughSubcommand(in: ["plugin", "list"], for: .omp),
+            "plugin"
+        )
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.passthroughSubcommand(in: ["--profile", "work", "plugin", "list"], for: .omp),
+            "plugin"
+        )
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.passthroughSubcommand(in: ["--profile=work", "install", "x"], for: .omp),
+            "install"
+        )
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.passthroughSubcommand(in: ["--cwd", "/tmp", "config"], for: .omp),
+            "config"
+        )
+        XCTAssertNil(PiFamilyLaunchPolicy.passthroughSubcommand(in: ["-p", "plugin", "list"], for: .omp))
+        XCTAssertNil(PiFamilyLaunchPolicy.passthroughSubcommand(in: ["--no-session", "install"], for: .omp))
+        XCTAssertNil(PiFamilyLaunchPolicy.passthroughSubcommand(in: ["explain", "the", "plugin"], for: .omp))
+        XCTAssertNil(PiFamilyLaunchPolicy.passthroughSubcommand(in: ["--profile", "work"], for: .omp))
+        XCTAssertEqual(
+            PiFamilyLaunchPolicy.passthroughSubcommand(in: ["install"], for: .pi),
+            "install"
+        )
+    }
+
 
     func test_kimi_passthrough_list_matches_kimi_cli_help_snapshot() throws {
         // Snapshot of `kimi --help` verified 2026-04-20 against the locally
@@ -415,7 +445,7 @@ final class AgentStatusSupportTests: XCTestCase {
         let bundle = try XCTUnwrap(Bundle(url: bundleRoot))
         XCTAssertEqual(
             AgentStatusHelper.wrapperDirectoryPaths(in: bundle),
-            ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "kimi", "opencode", "pi", "agy", "vibe", "small-harness"].map {
+            ["amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "kimi", "opencode", "pi", "omp", "agy", "vibe", "small-harness"].map {
                 binURL.appendingPathComponent($0, isDirectory: true).path
             }
         )
@@ -522,7 +552,7 @@ final class AgentStatusSupportTests: XCTestCase {
         try FileManager.default.createDirectory(at: realBinURL, withIntermediateDirectories: true)
         // Real binaries Zentty's wrappers expect on PATH. Note cursor resolves to `cursor-agent`,
         // not `cursor` (which is the Cursor IDE launcher).
-        for name in ["amp", "claude", "cursor-agent", "gemini", "kimi", "opencode", "agy"] {
+        for name in ["amp", "claude", "cursor-agent", "gemini", "kimi", "opencode", "omp", "agy"] {
             let fileURL = realBinURL.appendingPathComponent(name, isDirectory: false)
             try "#!/bin/sh\n".write(to: fileURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
@@ -539,6 +569,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 binURL.appendingPathComponent("kimi", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
                 binURL.appendingPathComponent("pi", isDirectory: true).path,
+                binURL.appendingPathComponent("omp", isDirectory: true).path,
                 binURL.appendingPathComponent("agy", isDirectory: true).path,
                 sharedURL.path,
                 realBinURL.path,
@@ -556,6 +587,7 @@ final class AgentStatusSupportTests: XCTestCase {
                 binURL.appendingPathComponent("gemini", isDirectory: true).path,
                 binURL.appendingPathComponent("kimi", isDirectory: true).path,
                 binURL.appendingPathComponent("opencode", isDirectory: true).path,
+                binURL.appendingPathComponent("omp", isDirectory: true).path,
                 binURL.appendingPathComponent("agy", isDirectory: true).path,
             ]
         )
@@ -10307,6 +10339,7 @@ final class AgentStatusSupportTests: XCTestCase {
             ("opencode", "opencode"),
             ("amp", "amp"),
             ("pi", "pi"),
+            ("omp", "omp"),
             ("agy", "agy"),
             ("hermes", "hermes"),
             ("vibe", "vibe"),

--- a/ZenttyResources/bin/omp/omp
+++ b/ZenttyResources/bin/omp/omp
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -u
+
+find_real_omp() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local path_entry
+    local IFS=:
+    for path_entry in $PATH; do
+        [[ -n "$path_entry" ]] || continue
+        [[ "$path_entry" == "$self_dir" ]] && continue
+        [[ -x "$path_entry/omp" ]] || continue
+        printf '%s\n' "$path_entry/omp"
+        return 0
+    done
+    return 1
+}
+
+zentty_cli_bin() {
+    if [[ -n "${ZENTTY_CLI_BIN:-}" && -x "${ZENTTY_CLI_BIN}" ]]; then
+        printf '%s\n' "$ZENTTY_CLI_BIN"
+        return 0
+    fi
+
+    command -v zentty >/dev/null 2>&1 || return 1
+    command -v zentty
+}
+
+if cli_bin="$(zentty_cli_bin 2>/dev/null)"; then
+    exec "$cli_bin" launch omp "$@"
+fi
+
+real_omp="$(find_real_omp)" || {
+    echo "Error: omp not found in PATH" >&2
+    exit 127
+}
+
+exec "$real_omp" "$@"

--- a/ZenttyResources/omp/extensions/zentty-omp-zentty.js
+++ b/ZenttyResources/omp/extensions/zentty-omp-zentty.js
@@ -2,7 +2,7 @@ import register from "../../shared/pi-family/zentty-pi-family-zentty.js"
 
 if (!process.env.ZENTTY_AGENT_CANONICAL_NAME) {
   // The shared module reads this lazily because ESM imports run before this body.
-  process.env.ZENTTY_AGENT_CANONICAL_NAME = "Pi"
+  process.env.ZENTTY_AGENT_CANONICAL_NAME = "OMP"
 }
 
 export default register

--- a/ZenttyResources/shared/pi-family/zentty-pi-family-zentty.js
+++ b/ZenttyResources/shared/pi-family/zentty-pi-family-zentty.js
@@ -1,0 +1,111 @@
+import { spawn } from "node:child_process"
+
+const worklaneID = process.env.ZENTTY_WORKLANE_ID
+const paneID = process.env.ZENTTY_PANE_ID
+const socketPath = process.env.ZENTTY_INSTANCE_SOCKET
+const paneToken = process.env.ZENTTY_PANE_TOKEN
+const resolvedCliBin = process.env.ZENTTY_CLI_BIN || ""
+
+const hasZenttyIntegration = Boolean(resolvedCliBin && socketPath && paneToken && worklaneID && paneID)
+
+function canonicalAgentName() {
+  return process.env.ZENTTY_AGENT_CANONICAL_NAME || "Pi"
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim()
+      if (trimmed) return trimmed
+    }
+  }
+  return undefined
+}
+
+function describeSession(event) {
+  if (!event || typeof event !== "object") return { sessionID: undefined, cwd: undefined }
+  return {
+    sessionID: firstString(event.sessionId, event.sessionID, event.session?.id, event.id),
+    cwd: firstString(event.cwd, event.workingDirectory, event.session?.cwd, event.session?.workingDirectory),
+  }
+}
+
+// Each forward() spawns an independent `zentty ipc agent-event` child.
+// On pi's /reload, session_shutdown + session_start fire back-to-back, so
+// without ordering we can't guarantee session.end arrives before the
+// following session.start - Zentty would clear state AFTER the restart.
+// Chain spawns on a single promise tail so each child's exit is awaited
+// before the next one starts. Handlers are still fire-and-forget from
+// pi's perspective; we never block pi's event loop on Zentty I/O.
+let pendingTail = Promise.resolve()
+
+function forward(canonical) {
+  if (!hasZenttyIntegration || !canonical) return
+  const payload = `${JSON.stringify(canonical)}\n`
+  pendingTail = pendingTail
+    .then(() => new Promise((resolve) => {
+      try {
+        const child = spawn(resolvedCliBin, ["ipc", "agent-event"], {
+          stdio: ["pipe", "ignore", "ignore"],
+          env: process.env,
+        })
+        let done = false
+        const finish = () => {
+          if (done) return
+          done = true
+          resolve()
+        }
+        child.on("error", finish)
+        child.on("exit", finish)
+        // Swallow EPIPE etc. if the CLI exits before we finish writing -
+        // pi must keep running even when the Zentty IPC path is broken.
+        child.stdin.on("error", () => {})
+        child.stdin.end(payload)
+      } catch {
+        // Never crash pi because of Zentty integration.
+        resolve()
+      }
+    }))
+    .catch(() => {}) // Never let the chain reject and leak.
+}
+
+function baseEnvelope(event, fallbackCwd) {
+  const { sessionID, cwd } = describeSession(event)
+  const envelope = { version: 1, agent: { name: canonicalAgentName() } }
+  if (sessionID) envelope.session = { id: sessionID }
+  if (cwd || fallbackCwd) envelope.context = { workingDirectory: cwd || fallbackCwd }
+  return envelope
+}
+
+export default function registerPiFamilyExtension(ctx) {
+  if (!hasZenttyIntegration) return
+
+  const fallbackCwd = typeof ctx?.cwd === "string" && ctx.cwd.length > 0 ? ctx.cwd : undefined
+
+  // Pi fires session_start for startup, reload, resume, new, and fork -
+  // piPlan's pre-launch action only covers the first case, so we re-emit
+  // session.start here to reset Zentty state on every session boundary.
+  ctx.on("session_start", async (event) => {
+    forward({ ...baseEnvelope(event, fallbackCwd), event: "session.start" })
+  })
+  // Pi fires both agent_start/end and turn_start/end around every turn -
+  // hook only agent_* to avoid duplicate events (matches notify.ts and
+  // titlebar-spinner.ts in pi-mono's own examples/).
+  ctx.on("agent_start", async (event) => {
+    forward({ ...baseEnvelope(event, fallbackCwd), event: "agent.running" })
+  })
+  ctx.on("agent_end", async (event) => {
+    forward({ ...baseEnvelope(event, fallbackCwd), event: "agent.idle" })
+  })
+  // session_shutdown fires on graceful exit (double Ctrl+C / Ctrl+D via
+  // dispose() -> process.exit(0)) and also on reload/resume/fork. Emit
+  // session.end - a lifecycle payload with state=nil that clears Zentty's
+  // agent status (including the "Agent ready" ready-label). On reload etc.
+  // the subsequent session_start restores it.
+  ctx.on("session_shutdown", async (event) => {
+    forward({ ...baseEnvelope(event, fallbackCwd), event: "session.end" })
+    // The host waits shutdown handlers with a bounded timeout; await the
+    // reassigned tail so print-mode/graceful-exit events flush before exit.
+    await pendingTail
+  })
+}

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -330,6 +330,28 @@ Each hook calls:
 - `PreToolUse(AskUserQuestion)` -> `needs-input` with `question`
 - `PostToolUse(AskUserQuestion)` -> `running`
 
+
+## Pi
+
+Wrapped `pi` launches inject an ephemeral coding-agent extension with `-e <bundle>/pi/extensions/zentty-pi-zentty.js`. The extension shares implementation with OMP via `shared/pi-family/zentty-pi-family-zentty.js` and emits canonical JSON through `zentty ipc agent-event`.
+
+Pi management subcommands (`install`, `remove`, `update`, `list`, `config`, …) and early-exit flags (`--help`, `--version`, `--list-models`, …) bypass Zentty bootstrap so the real `pi` binary handles them unchanged. Set `ZENTTY_PI_HOOKS_DISABLED=1` to launch without the bridge.
+
+### Current mapping
+
+- `session_start` -> `session.start`
+- `agent_start` -> `agent.running`
+- `agent_end` -> `agent.idle`
+- `session_shutdown` -> `session.end`
+
+## Oh My Pi (OMP)
+
+OMP uses the same Pi-lineage extension host and ephemeral `-e` injection pattern as Pi. Zentty prepends `-e <bundle>/omp/extensions/zentty-omp-zentty.js`, sets `ZENTTY_AGENT_CANONICAL_NAME=OMP`, and does not modify the user's OMP config. Management commands from `omp --help` (including `plugin`, `install`, `config`, …) passthrough without bootstrap; set `ZENTTY_OMP_HOOKS_DISABLED=1` to skip the bridge.
+
+### Current mapping
+
+Same lifecycle events as Pi (`session.start`, `agent.running`, `agent.idle`, `session.end`). OMP is a distinct tool in the sidebar (`agent.name` **OMP**, title match leading token `omp` only—not Pi's `π` rules).
+
 ## OpenCode
 
 Zentty injects a local OpenCode plugin overlay via the shared agent wrapper. The plugin forwards `session.status`, `session.idle`, permission/question events, and `todo.updated`.

--- a/project.yml
+++ b/project.yml
@@ -61,13 +61,14 @@ targets:
       - path: Zentty/AppState/Agent/GrokHooksInstaller.swift
       - path: Zentty/AppState/Agent/GrokCanonicalReEmitter.swift
       - path: Zentty/AppState/Agent/HookCanonicalReEmitter.swift
+      - path: Zentty/AppState/Agent/JSONCRelaxedParse.swift
       - path: Zentty/AppState/Agent/JSONKeyAccess.swift
       - path: Zentty/AppState/Agent/KimiHooksInstaller.swift
       - path: Zentty/AppState/Agent/AgyHooksInstaller.swift
       - path: Zentty/AppState/Agent/AgyCanonicalReEmitter.swift
       - path: Zentty/AppState/Agent/HermesHooksInstaller.swift
       - path: Zentty/AppState/Agent/VibeHooksInstaller.swift
-      - path: Zentty/AppState/Agent/JSONCRelaxedParse.swift
+      - path: Zentty/AppState/Agent/PiFamilyLaunchPolicy.swift
       - path: Zentty/Servers/ServerIPCCommands.swift
       - path: Zentty/Servers/ServerOutputURLDetector.swift
       - path: Zentty/Servers/ServerURLNormalizer.swift
@@ -143,14 +144,16 @@ targets:
           RESOURCES_SRC="${PROJECT_DIR}/ZenttyResources"
           RESOURCES_DST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
-          mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/amp/plugins" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
+          mkdir -p "${RESOURCES_DST}/bin" "${RESOURCES_DST}/shell-integration" "${RESOURCES_DST}/amp/plugins" "${RESOURCES_DST}/opencode/plugins" "${RESOURCES_DST}/pi/extensions" "${RESOURCES_DST}/omp/extensions" "${RESOURCES_DST}/shared/pi-family" "${RESOURCES_DST}/ghostty" "${RESOURCES_DST}/terminfo"
           rsync -a --delete "${RESOURCES_SRC}/bin/" "${RESOURCES_DST}/bin/"
           install -m 755 "${BUILT_PRODUCTS_DIR}/zentty" "${RESOURCES_DST}/bin/shared/zentty"
-          find "${RESOURCES_DST}/bin" -type f \( -path "*/amp/amp" -o -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/droid/droid" -o -path "*/gemini/gemini" -o -path "*/grok/grok" -o -path "*/hermes/hermes" -o -path "*/kimi/kimi" -o -path "*/kimi/kimi-cli" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/agy/agy" -o -path "*/vibe/vibe" -o -path "*/vibe/mistral-vibe" -o -path "*/small-harness/small-harness" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" -o -path "*/tmux-shim/tmux" \) -exec chmod 755 {} +
+          find "${RESOURCES_DST}/bin" -type f \( -path "*/amp/amp" -o -path "*/claude/claude" -o -path "*/codex/codex" -o -path "*/copilot/copilot" -o -path "*/cursor/cursor-agent" -o -path "*/droid/droid" -o -path "*/gemini/gemini" -o -path "*/grok/grok" -o -path "*/hermes/hermes" -o -path "*/kimi/kimi" -o -path "*/kimi/kimi-cli" -o -path "*/opencode/opencode" -o -path "*/pi/pi" -o -path "*/omp/omp" -o -path "*/agy/agy" -o -path "*/vibe/vibe" -o -path "*/vibe/mistral-vibe" -o -path "*/small-harness/small-harness" -o -path "*/shared/zentty" -o -path "*/shared/zentty-agent-wrapper" -o -path "*/tmux-shim/tmux" \) -exec chmod 755 {} +
           rsync -a --delete "${RESOURCES_SRC}/shell-integration/" "${RESOURCES_DST}/shell-integration/"
           rsync -a --delete "${RESOURCES_SRC}/amp/" "${RESOURCES_DST}/amp/"
           rsync -a --delete "${RESOURCES_SRC}/opencode/" "${RESOURCES_DST}/opencode/"
           rsync -a --delete "${RESOURCES_SRC}/pi/" "${RESOURCES_DST}/pi/"
+          rsync -a --delete "${RESOURCES_SRC}/omp/" "${RESOURCES_DST}/omp/"
+          rsync -a --delete "${RESOURCES_SRC}/shared/pi-family/" "${RESOURCES_DST}/shared/pi-family/"
           rsync -a --delete "${RESOURCES_SRC}/ghostty/" "${RESOURCES_DST}/ghostty/"
           rsync -a --delete "${RESOURCES_SRC}/terminfo/" "${RESOURCES_DST}/terminfo/"
         basedOnDependencyAnalysis: false

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -27,7 +27,7 @@ from collections import Counter
 from typing import Any
 
 
-SUPPORTED_AGENTS = ("agy", "amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "hermes", "kimi", "kimi-code", "opencode", "pi", "small-harness", "vibe")
+SUPPORTED_AGENTS = ("agy", "amp", "claude", "codex", "copilot", "cursor", "droid", "gemini", "grok", "hermes", "kimi", "kimi-code", "omp", "opencode", "pi", "small-harness", "vibe")
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BENCH_ROOT = pathlib.Path(__file__).resolve().parent
 DEFAULT_RUNS_DIR = REPO_ROOT / ".agent-bench-runs"
@@ -1757,7 +1757,20 @@ class LaunchPlanner:
         return self._launch_plan(
             executable,
             planned,
-            {"ZENTTY_AGENT_TOOL": "pi"},
+            {"ZENTTY_AGENT_TOOL": "pi", "ZENTTY_AGENT_CANONICAL_NAME": "Pi"},
+            prelaunch=[{"subcommand": "agent-event", "arguments": [], "standardInput": prelaunch}],
+        )
+
+    def _plan_omp(self, executable: str, arguments: list[str], environment: dict[str, Any], cli_path: str) -> dict[str, Any]:
+        planned = list(arguments)
+        extension = self.resources_dir / "omp" / "extensions" / "zentty-omp-zentty.js" if self.resources_dir else None
+        if extension and extension.exists():
+            planned = ["-e", str(extension)] + planned
+        prelaunch = '{"version":1,"event":"session.start","agent":{"name":"OMP","pid":"__ZENTTY_SELF_PID__"}}'
+        return self._launch_plan(
+            executable,
+            planned,
+            {"ZENTTY_AGENT_TOOL": "omp", "ZENTTY_AGENT_CANONICAL_NAME": "OMP"},
             prelaunch=[{"subcommand": "agent-event", "arguments": [], "standardInput": prelaunch}],
         )
 

--- a/scripts/agent-bench/profiles/omp.json
+++ b/scripts/agent-bench/profiles/omp.json
@@ -1,0 +1,36 @@
+{
+  "name": "omp",
+  "command": "omp",
+  "real_binary_names": ["omp"],
+  "version_args": ["--version"],
+  "launch_args_by_scenario": {
+    "smoke": [
+      "--print",
+      "--no-session",
+      "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
+    ],
+    "session_capture": [
+      "--print",
+      "Run this exact shell command: printf ZENTTY_AGENT_BENCH_OK"
+    ],
+    "restore_launch": [
+      "-c"
+    ]
+  },
+  "expectations": {
+    "smoke": {
+      "required_events": ["session.start", "agent.running", "agent.idle", "session.end"]
+    },
+    "session_capture": {
+      "required_events": ["session.start", "agent.running", "agent.idle", "session.end"],
+      "session_identity": {
+        "tracked_pid": true
+      }
+    },
+    "restore_launch": {
+      "required_events": [],
+      "required_bootstrap_arguments": [["-c"]]
+    }
+  },
+  "skip_patterns": ["login", "auth", "not authenticated", "api key", "sign in"]
+}

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -1817,6 +1817,7 @@ class ProfileTests(unittest.TestCase):
                 "hermes",
                 "kimi",
                 "kimi-code",
+                "omp",
                 "opencode",
                 "pi",
                 "small-harness",


### PR DESCRIPTION
Adds sidebar status tracking for Oh My Pi (`omp`), reusing the pi extension bridge instead of forking it.

Why the first cut didn't work: omp's extension loader only loads ESM. A CommonJS extension is ignored silently, no error, no log, the file just never runs. The bridge was CJS, so Zentty never received a single event. The bridge and both entry shims are now ESM, verified live against omp 16.3.6 and pi 0.80.3.

omp differs from pi in a few more ways, all handled here:

- Events carry only `{type}`, no session id or cwd. The bridge falls back to the extension context's `cwd`, and the bench profile doesn't expect a session id (omp never exposes one).
- In print mode omp exits before the async IPC chain drains, losing `agent.idle` and `session.end`. The `session_shutdown` handler now awaits the chain; omp holds shutdown for async handlers with a bounded timeout, so this is safe.
- Global scope flags can precede subcommands (`omp --profile work plugin list`). Passthrough detection skips `--profile`/`--cwd`/`--config` so these still bypass bootstrap instead of getting a broken `-e` injected.
- omp has no `remove`/`uninstall`/`list` subcommands, so its passthrough list is a standalone snapshot of `omp --help` rather than a superset of pi's. Otherwise `omp list` would silently start an untracked chat session.

Pi moves onto the shared path in the same change: `piFamilyLaunchPlan` in the bootstrap, `PiFamilyLaunchPolicy` for passthrough rules, one shared JS module with thin per-tool shims. Pi behavior is unchanged; existing pi tests pass and a live `pi -e` smoke produces the same four lifecycle events.

Also fixes a pre-existing hang unrelated to omp: `test_repository_shell_integrations_tag_codex_shell_activity` executed the real codex CLI, which nowadays opens its TUI even without a TTY and sits for ~23 minutes until SIGTERM. It now uses a fake shim on PATH, same pattern as the amp test. Full local suite time drops from ~25 minutes back to ~2.

Verification: live smokes of both CLIs with a stub `zentty` capturing IPC (all four events, correct agent names and cwd), ZenttyLogicTests green (3402 tests), agent-bench profile tests 125/125.
