### PR TITLE
fix(agent-bench): surface login keychain so agy bench reuses global auth

### DIFF
--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -2010,13 +2010,32 @@ class LaunchPlanner:
         # from the top-level symlink set so we can place a hooks.json we own
         # under `.gemini/config/` without mutating the real user file.
         home = self._overlay_home("agy", environment, {".gemini": {"antigravity-cli", "config"}})
+        source_home = pathlib.Path(str(environment.get("HOME") or pathlib.Path.home()))
+
+        # agy keeps its OAuth login in the macOS login keychain
+        # (~/Library/Keychains), NOT under ~/.gemini. Because the overlay
+        # redirects HOME, agy resolves the keychain at
+        # <overlay>/Library/Keychains, finds nothing, and starts logged out —
+        # forcing an interactive browser login and breaking the `tools` /
+        # `session_capture` scenarios (auth-skip, no real conversation id).
+        # Symlink the real login keychain into the overlay so agy reuses the
+        # user's existing global Antigravity login. Only auth material is
+        # shared; the agent's conversations / history / state stay isolated in
+        # the fresh overlay `antigravity-cli`, preserving restore_launch
+        # fixture hermeticity. If the keychain is absent (not logged in, or a
+        # non-macOS host) we do nothing and behave exactly as before.
+        real_keychains = source_home / "Library" / "Keychains"
+        if real_keychains.exists():
+            overlay_keychains = home / "Library" / "Keychains"
+            overlay_keychains.parent.mkdir(parents=True, exist_ok=True)
+            if not overlay_keychains.exists() and not overlay_keychains.is_symlink():
+                overlay_keychains.symlink_to(real_keychains)
 
         # Rebuild `.gemini/config` in the overlay: symlink the real config's
         # contents (so agy still sees the user's settings) except hooks.json,
         # which we own and write fresh pointing at the bench CLI. This makes
         # the `tools` scenario hermetic — it no longer depends on the host
         # user having run `zentty install agy-hooks` first.
-        source_home = pathlib.Path(str(environment.get("HOME") or pathlib.Path.home()))
         overlay_config = home / ".gemini" / "config"
         symlink_directory_contents_skipping(
             source_home / ".gemini" / "config", overlay_config, {"hooks.json"}

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -2094,6 +2094,12 @@ class ProfileTests(unittest.TestCase):
             (real_home / ".gemini" / "antigravity-cli" / "settings.json").write_text("{}")
             (real_home / ".gemini" / "config").mkdir(parents=True)
             (real_home / ".gemini" / "config" / "config.json").write_text('{"theme":"dark"}')
+            # agy reads its OAuth login from the macOS login keychain under
+            # ~/Library/Keychains; the overlay must surface it so agy reuses
+            # the user's global Antigravity login instead of starting logged
+            # out.
+            (real_home / "Library" / "Keychains").mkdir(parents=True)
+            (real_home / "Library" / "Keychains" / "login.keychain-db").write_text("x")
 
             plan = agent_bench.LaunchPlanner(
                 profile=profile,
@@ -2118,6 +2124,16 @@ class ProfileTests(unittest.TestCase):
             self.assertTrue((overlay_home / ".gemini" / "config" / "config.json").exists())
             # …the antigravity-cli subtree is skipped…
             self.assertFalse((overlay_home / ".gemini" / "antigravity-cli" / "settings.json").exists())
+            # …the login keychain is surfaced as a symlink to the real one so
+            # agy reuses the global Antigravity login (auth material only; the
+            # agent's conversations/state stay isolated in the fresh
+            # overlay antigravity-cli).
+            overlay_keychains = overlay_home / "Library" / "Keychains"
+            self.assertTrue(overlay_keychains.is_symlink())
+            self.assertEqual(
+                os.path.realpath(overlay_keychains),
+                os.path.realpath(real_home / "Library" / "Keychains"),
+            )
             # …and we write a real hooks.json (not a symlink) so the tools
             # scenario fires real hooks against the bench CLI.
             overlay_hooks = overlay_home / ".gemini" / "config" / "hooks.json"
@@ -2153,6 +2169,36 @@ class ProfileTests(unittest.TestCase):
             self.assertIn('"id":"' + placeholder + '"', plan["preLaunchActions"][0]["standardInput"])
             self.assertIn('"id":"' + placeholder + '"', plan["preLaunchActions"][1]["standardInput"])
             self.assertNotIn("pane-antigravity", plan["preLaunchActions"][0]["standardInput"])
+
+    def test_agy_plan_without_login_keychain_omits_symlink(self):
+        # When the host has no ~/Library/Keychains (not logged in, or a
+        # non-macOS runner) the plan must degrade gracefully — no keychain
+        # symlink, and no crash — behaving exactly as before the seed.
+        profile = agent_bench.load_profiles(ROOT / "profiles")["agy"]
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = pathlib.Path(tmp)
+            real_home = run_dir / "real-home"
+            (real_home / ".gemini" / "config").mkdir(parents=True)
+
+            plan = agent_bench.LaunchPlanner(
+                profile=profile,
+                scenario="tools",
+                run_dir=run_dir,
+                resources_dir=None,
+            ).plan(
+                {
+                    "arguments": ["--print", "--prompt", "hello"],
+                    "environment": {
+                        "ZENTTY_REAL_BINARY": "/usr/local/bin/agy",
+                        "ZENTTY_CLI_BIN": "/tmp/zentty-bench",
+                        "HOME": str(real_home),
+                    },
+                }
+            )
+
+            overlay_home = pathlib.Path(plan["setEnvironment"]["HOME"])
+            self.assertFalse((overlay_home / "Library" / "Keychains").exists())
+            self.assertFalse((overlay_home / "Library" / "Keychains").is_symlink())
 
     def test_hermes_plan_installs_overlay_hooks_and_preserves_launch_context(self):
         profile = agent_bench.load_profiles(ROOT / "profiles")["hermes"]


### PR DESCRIPTION
The agy bench always launched a logged-out Antigravity, so the `tools` scenario auth-skipped and `session_capture` never saw a real conversation id, even with the user signed in. Root cause, proven empirically: agy keeps its OAuth login in the macOS login Keychain, not under `~/.gemini`, and the bench's overlay HOME had no `Library/Keychains`.

The fix symlinks `~/Library/Keychains` into the overlay home in `_plan_agy`. Conversations, history, and CLI state stay hermetic (nothing from `antigravity-cli/` is seeded), and when the keychain dir is absent the symlink is omitted, preserving today's logged-out behavior and strict auth-skip classification.

With this change the full strict sweep passes 6/6 (previously 4/6): `tools` observes pre-tool-use / post-tool-use / stop, and `session_capture` captures a real uuid. Profile tests extended to pin the symlink and its absence case (126/126 green). Note the `tools` scenario now runs real authed turns against the signed-in account.
