### PR TITLE
fix(agent): canonicalize Kimi session_index.jsonl paths to source home

### DIFF
--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -10,6 +10,11 @@ private let agentLaunchLogger = Logger(
 )
 
 enum AgentLaunchBootstrap {
+    /// Kimi shares `session_index.jsonl` across all panes via the persistent
+    /// `~/.kimi-code` home, but its per-launch overlay home paths can end up
+    /// recorded in that index. Serialization protects the read-modify-write.
+    private static let kimiSessionIndexCanonicalizationLock = NSLock()
+
     static func makePlan(
         request: AgentIPCRequest,
         target: AgentIPCTarget,
@@ -1109,6 +1114,80 @@ enum AgentLaunchBootstrap {
         return overlayHomeURL.path
     }
 
+    /// Rewrite stale per-launch overlay paths in Kimi's shared session index
+    /// back to the persistent `~/.kimi-code/sessions/` location.
+    ///
+    /// Kimi records `sessionDir` as an absolute path under `KIMI_CODE_HOME`.
+    /// Because Zentty launches modern Kimi with an ephemeral overlay home,
+    /// the shared `session_index.jsonl` can accumulate entries whose
+    /// `sessionDir` points to a now-deleted overlay directory. On the next
+    /// launch, `kimi -S <id>` fails with "Session not found" because the
+    /// directory no longer exists. This pass canonicalizes those entries
+    /// before Kimi starts.
+    internal static func canonicalizeKimiSessionIndexIfNeeded(
+        sourceHomeURL: URL,
+        fileManager: FileManager
+    ) {
+        kimiSessionIndexCanonicalizationLock.lock()
+        defer { kimiSessionIndexCanonicalizationLock.unlock() }
+
+        let indexURL = sourceHomeURL.appendingPathComponent("session_index.jsonl", isDirectory: false)
+        guard fileManager.isReadableFile(atPath: indexURL.path) else { return }
+
+        let sourceHomePath = sourceHomeURL.path
+        let sourceHomePathWithSlash = sourceHomePath.hasSuffix("/") ? sourceHomePath : sourceHomePath + "/"
+        let sourceSessionsURL = sourceHomeURL.appendingPathComponent("sessions", isDirectory: true)
+
+        guard let rawData = try? Data(contentsOf: indexURL),
+              let rawText = String(data: rawData, encoding: .utf8) else {
+            return
+        }
+
+        var changed = false
+        var newLines: [String] = []
+        let lines = rawText.components(separatedBy: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  var json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                newLines.append(line)
+                continue
+            }
+            guard let sessionID = json["id"] as? String,
+                  let sessionDir = json["sessionDir"] as? String else {
+                newLines.append(line)
+                continue
+            }
+
+            let sessionDirPath = URL(fileURLWithPath: sessionDir, isDirectory: true).path
+            let isCanonical = sessionDirPath == sourceHomePath
+                || sessionDirPath.hasPrefix(sourceHomePathWithSlash)
+            guard !isCanonical else {
+                newLines.append(line)
+                continue
+            }
+
+            let canonicalPath = sourceSessionsURL.appendingPathComponent(sessionID, isDirectory: true).path
+            json["sessionDir"] = canonicalPath
+            guard let newData = try? JSONSerialization.data(withJSONObject: json, options: .sortedKeys),
+                  var newLine = String(data: newData, encoding: .utf8) else {
+                newLines.append(line)
+                continue
+            }
+            newLine = newLine.replacingOccurrences(of: "\\/", with: "/")
+            newLines.append(newLine)
+            changed = true
+        }
+
+        guard changed else { return }
+
+        let newText = newLines.joined(separator: "\n")
+        guard let outputData = newText.data(using: .utf8) else { return }
+
+        try? outputData.write(to: indexURL, options: .atomic)
+    }
+
     private static func prepareKimiCodeOverlay(
         sourceHomeURL: URL,
         overlayDirectoryURL: URL,
@@ -1126,6 +1205,7 @@ enum AgentLaunchBootstrap {
 
         let overlayConfigURL = overlayHomeURL.appendingPathComponent("config.toml", isDirectory: false)
         try mergedConfig.write(to: overlayConfigURL, atomically: true, encoding: .utf8)
+        canonicalizeKimiSessionIndexIfNeeded(sourceHomeURL: sourceHomeURL, fileManager: fileManager)
         let migrationSkipURL = overlayHomeURL.appendingPathComponent(".skip-migration-from-kimi-cli", isDirectory: false)
         let migrationSkipPath = migrationSkipURL.path
         let migrationSkipExists = fileManager.fileExists(atPath: migrationSkipPath)

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -1114,80 +1114,6 @@ enum AgentLaunchBootstrap {
         return overlayHomeURL.path
     }
 
-    /// Rewrite stale per-launch overlay paths in Kimi's shared session index
-    /// back to the persistent `~/.kimi-code/sessions/` location.
-    ///
-    /// Kimi records `sessionDir` as an absolute path under `KIMI_CODE_HOME`.
-    /// Because Zentty launches modern Kimi with an ephemeral overlay home,
-    /// the shared `session_index.jsonl` can accumulate entries whose
-    /// `sessionDir` points to a now-deleted overlay directory. On the next
-    /// launch, `kimi -S <id>` fails with "Session not found" because the
-    /// directory no longer exists. This pass canonicalizes those entries
-    /// before Kimi starts.
-    internal static func canonicalizeKimiSessionIndexIfNeeded(
-        sourceHomeURL: URL,
-        fileManager: FileManager
-    ) {
-        kimiSessionIndexCanonicalizationLock.lock()
-        defer { kimiSessionIndexCanonicalizationLock.unlock() }
-
-        let indexURL = sourceHomeURL.appendingPathComponent("session_index.jsonl", isDirectory: false)
-        guard fileManager.isReadableFile(atPath: indexURL.path) else { return }
-
-        let sourceHomePath = sourceHomeURL.path
-        let sourceHomePathWithSlash = sourceHomePath.hasSuffix("/") ? sourceHomePath : sourceHomePath + "/"
-        let sourceSessionsURL = sourceHomeURL.appendingPathComponent("sessions", isDirectory: true)
-
-        guard let rawData = try? Data(contentsOf: indexURL),
-              let rawText = String(data: rawData, encoding: .utf8) else {
-            return
-        }
-
-        var changed = false
-        var newLines: [String] = []
-        let lines = rawText.components(separatedBy: "\n")
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty,
-                  let lineData = trimmed.data(using: .utf8),
-                  var json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
-                newLines.append(line)
-                continue
-            }
-            guard let sessionID = json["id"] as? String,
-                  let sessionDir = json["sessionDir"] as? String else {
-                newLines.append(line)
-                continue
-            }
-
-            let sessionDirPath = URL(fileURLWithPath: sessionDir, isDirectory: true).path
-            let isCanonical = sessionDirPath == sourceHomePath
-                || sessionDirPath.hasPrefix(sourceHomePathWithSlash)
-            guard !isCanonical else {
-                newLines.append(line)
-                continue
-            }
-
-            let canonicalPath = sourceSessionsURL.appendingPathComponent(sessionID, isDirectory: true).path
-            json["sessionDir"] = canonicalPath
-            guard let newData = try? JSONSerialization.data(withJSONObject: json, options: .sortedKeys),
-                  var newLine = String(data: newData, encoding: .utf8) else {
-                newLines.append(line)
-                continue
-            }
-            newLine = newLine.replacingOccurrences(of: "\\/", with: "/")
-            newLines.append(newLine)
-            changed = true
-        }
-
-        guard changed else { return }
-
-        let newText = newLines.joined(separator: "\n")
-        guard let outputData = newText.data(using: .utf8) else { return }
-
-        try? outputData.write(to: indexURL, options: .atomic)
-    }
-
     private static func prepareKimiCodeOverlay(
         sourceHomeURL: URL,
         overlayDirectoryURL: URL,
@@ -1214,6 +1140,106 @@ enum AgentLaunchBootstrap {
             try "".write(to: migrationSkipURL, atomically: true, encoding: .utf8)
         }
         return overlayHomeURL
+    }
+
+    /// Rewrite stale per-launch overlay paths in Kimi's shared session index
+    /// back to the persistent `~/.kimi-code/sessions/` location.
+    ///
+    /// Kimi records `sessionDir` as an absolute path under `KIMI_CODE_HOME`.
+    /// Because Zentty launches modern Kimi with an ephemeral overlay home,
+    /// the shared `session_index.jsonl` can accumulate entries whose
+    /// `sessionDir` points to a now-deleted overlay directory. On the next
+    /// launch, `kimi -S <id>` fails with "Session not found" because the
+    /// directory no longer exists. This pass remaps those entries by
+    /// preserving the `/sessions/...` suffix onto the durable source home,
+    /// but only when that remapped directory already exists on disk.
+    internal static func canonicalizeKimiSessionIndexIfNeeded(
+        sourceHomeURL: URL,
+        fileManager: FileManager
+    ) {
+        kimiSessionIndexCanonicalizationLock.lock()
+        defer { kimiSessionIndexCanonicalizationLock.unlock() }
+
+        let indexURL = sourceHomeURL.appendingPathComponent("session_index.jsonl", isDirectory: false)
+        guard fileManager.isReadableFile(atPath: indexURL.path),
+              let rawData = try? Data(contentsOf: indexURL),
+              let rawText = String(data: rawData, encoding: .utf8) else {
+            return
+        }
+
+        let sourceHomePath = sourceHomeURL.path
+        let sourceHomePathWithSlash = sourceHomePath.hasSuffix("/") ? sourceHomePath : sourceHomePath + "/"
+
+        var changed = false
+        let newLines = rawText.components(separatedBy: "\n").map { line -> String in
+            let result = canonicalizedKimiSessionIndexLine(
+                line,
+                sourceHomePath: sourceHomePath,
+                sourceHomePathWithSlash: sourceHomePathWithSlash,
+                fileManager: fileManager
+            )
+            if result.changed {
+                changed = true
+            }
+            return result.output
+        }
+
+        guard changed,
+              let outputData = newLines.joined(separator: "\n").data(using: .utf8) else {
+            return
+        }
+
+        do {
+            try outputData.write(to: indexURL, options: .atomic)
+        } catch {
+            agentLaunchLogger.error(
+                "Failed to canonicalize Kimi session_index.jsonl at \(indexURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private static func canonicalizedKimiSessionIndexLine(
+        _ line: String,
+        sourceHomePath: String,
+        sourceHomePathWithSlash: String,
+        fileManager: FileManager
+    ) -> (output: String, changed: Bool) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty,
+              let lineData = trimmed.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+            return (line, false)
+        }
+
+        let hasSessionID = (json["sessionId"] as? String) != nil || (json["id"] as? String) != nil
+        guard hasSessionID,
+              let sessionDir = json["sessionDir"] as? String else {
+            return (line, false)
+        }
+
+        let sessionDirPath = URL(fileURLWithPath: sessionDir, isDirectory: true).path
+        let isCanonical = sessionDirPath == sourceHomePath
+            || sessionDirPath.hasPrefix(sourceHomePathWithSlash)
+        guard !isCanonical,
+              let sessionsRange = sessionDirPath.range(of: "/sessions/") else {
+            return (line, false)
+        }
+
+        let relativeFromSessions = String(sessionDirPath[sessionsRange.lowerBound...])
+        let canonicalPath = sourceHomePath + relativeFromSessions
+        guard fileManager.fileExists(atPath: canonicalPath) else {
+            return (line, false)
+        }
+
+        json["sessionDir"] = canonicalPath
+        guard let newData = try? JSONSerialization.data(
+            withJSONObject: json,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ),
+              let newLine = String(data: newData, encoding: .utf8) else {
+            return (line, false)
+        }
+        return (newLine, true)
     }
 
     private static func kimiCodeHomeURL(environment: [String: String]) -> URL {

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -4737,6 +4737,144 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertEqual(sourceConfig, original)
     }
 
+    func test_canonicalize_kimi_session_index_rewrites_stale_overlay_session_dir() throws {
+        let sourceHome = try makeTemporaryDirectory(named: "kimi-session-index-source")
+        let sessionID = "session_a4d78f91-ea80-41e7-91d3-c699197ff442"
+        let workDirHash = "wd_fix-kimi-code-cli_57590bf29904"
+        let durableSessionURL = try makeDurableKimiSessionDirectory(
+            in: sourceHome,
+            workDirHash: workDirHash,
+            sessionID: sessionID
+        )
+
+        let overlaySessionDir = "/Users/peter/Library/Caches/Zentty/ipc-11370-9183AB50/launch/wl_x/pn_y/kimi/home/sessions/\(workDirHash)/\(sessionID)"
+        let workDir = "/Users/peter/Development/Personal/worktrees/fix-kimi-code-cli"
+        let indexURL = try writeKimiSessionIndex(
+            at: sourceHome,
+            sessionID: sessionID,
+            sessionDir: overlaySessionDir,
+            workDir: workDir
+        )
+
+        AgentLaunchBootstrap.canonicalizeKimiSessionIndexIfNeeded(
+            sourceHomeURL: sourceHome,
+            fileManager: .default
+        )
+
+        let json = try firstJSONObject(from: indexURL)
+        XCTAssertEqual(json["sessionId"] as? String, sessionID)
+        XCTAssertEqual(json["sessionDir"] as? String, durableSessionURL.path)
+        XCTAssertEqual(json["workDir"] as? String, workDir)
+    }
+
+    func test_canonicalize_kimi_session_index_preserves_canonical_and_unknown_lines() throws {
+        let sourceHome = try makeTemporaryDirectory(named: "kimi-session-index-preserve")
+        let sessionID = "ses_686b194c-ea5f-45d8-bb4b-d5242a12b009"
+        let workDirHash = "wd_kimi-approval_c6bdd38935ad"
+        let durableSessionURL = try makeDurableKimiSessionDirectory(
+            in: sourceHome,
+            workDirHash: workDirHash,
+            sessionID: sessionID
+        )
+
+        let canonicalLine = #"{"sessionId":"\#(sessionID)","sessionDir":"\#(durableSessionURL.path)","workDir":"/tmp/project"}"#
+        let unknownLine = #"{"note":"not-a-session"}"#
+        let garbageLine = "not-json"
+        let original = [canonicalLine, unknownLine, garbageLine, ""].joined(separator: "\n")
+        let indexURL = sourceHome.appendingPathComponent("session_index.jsonl", isDirectory: false)
+        try original.write(to: indexURL, atomically: true, encoding: .utf8)
+
+        AgentLaunchBootstrap.canonicalizeKimiSessionIndexIfNeeded(
+            sourceHomeURL: sourceHome,
+            fileManager: .default
+        )
+
+        let after = try String(contentsOf: indexURL, encoding: .utf8)
+        XCTAssertEqual(after, original)
+    }
+
+    func test_canonicalize_kimi_session_index_skips_missing_target_directory() throws {
+        let sourceHome = try makeTemporaryDirectory(named: "kimi-session-index-missing-target")
+        try FileManager.default.createDirectory(
+            at: sourceHome.appendingPathComponent("sessions", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let sessionID = "session_missing-on-disk"
+        let workDirHash = "wd_missing_abcdef123456"
+        let overlaySessionDir = "/tmp/overlay/kimi/home/sessions/\(workDirHash)/\(sessionID)"
+        let indexURL = try writeKimiSessionIndex(
+            at: sourceHome,
+            sessionID: sessionID,
+            sessionDir: overlaySessionDir
+        )
+        let poisoned = try String(contentsOf: indexURL, encoding: .utf8)
+
+        AgentLaunchBootstrap.canonicalizeKimiSessionIndexIfNeeded(
+            sourceHomeURL: sourceHome,
+            fileManager: .default
+        )
+
+        let after = try String(contentsOf: indexURL, encoding: .utf8)
+        XCTAssertEqual(after, poisoned)
+    }
+
+    func test_agent_launch_bootstrap_canonicalizes_kimi_session_index_during_modern_overlay() throws {
+        let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-canonicalize-runtime")
+        let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-kimi-canonicalize-home")
+        let kimiCodeHome = homeDirectory.appendingPathComponent(".kimi-code", isDirectory: true)
+        try FileManager.default.createDirectory(at: kimiCodeHome, withIntermediateDirectories: true)
+        try #"default_model = "kimi-code/kimi-for-coding""#.write(
+            to: kimiCodeHome.appendingPathComponent("config.toml", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let sessionID = "session_ae5ef9dc-a4fe-4cc1-9b18-27823ca399cc"
+        let workDirHash = "wd_fix-kimi-code-cli_57590bf29904"
+        let durableSessionURL = try makeDurableKimiSessionDirectory(
+            in: kimiCodeHome,
+            workDirHash: workDirHash,
+            sessionID: sessionID
+        )
+
+        let overlaySessionDir = "\(runtimeDirectory.path)/launch/wl_old/pn_old/kimi/home/sessions/\(workDirHash)/\(sessionID)"
+        let indexURL = try writeKimiSessionIndex(
+            at: kimiCodeHome,
+            sessionID: sessionID,
+            sessionDir: overlaySessionDir
+        )
+
+        let fakeKimiURL = try makeFakeKimiBinary(modern: true)
+        let request = AgentIPCRequest(
+            kind: .bootstrap,
+            arguments: ["chat"],
+            standardInput: nil,
+            environment: [
+                "HOME": homeDirectory.path,
+                "KIMI_CODE_HOME": kimiCodeHome.path,
+                "ZENTTY_REAL_BINARY": fakeKimiURL.path,
+                "ZENTTY_CLI_BIN": "/tmp/zentty",
+                "ZENTTY_KIMI_VARIANT": "modern",
+            ],
+            expectsResponse: true,
+            tool: .kimi
+        )
+
+        _ = try AgentLaunchBootstrap.makePlan(
+            request: request,
+            target: AgentIPCTarget(
+                windowID: WindowID("window-main"),
+                worklaneID: WorklaneID("worklane-main"),
+                paneID: PaneID("pane-main")
+            ),
+            runtimeDirectoryURL: runtimeDirectory
+        )
+
+        let json = try firstJSONObject(from: indexURL)
+        XCTAssertEqual(json["sessionDir"] as? String, durableSessionURL.path)
+    }
+
     func test_agent_launch_bootstrap_builds_modern_kimi_overlay_from_default_home_config() throws {
         let runtimeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-default-runtime")
         let homeDirectory = try makeTemporaryDirectory(named: "agent-launch-modern-kimi-default-home")
@@ -10394,6 +10532,38 @@ final class AgentStatusSupportTests: XCTestCase {
             try? FileManager.default.removeItem(at: url)
         }
         return url
+    }
+
+    private func makeDurableKimiSessionDirectory(
+        in sourceHome: URL,
+        workDirHash: String,
+        sessionID: String
+    ) throws -> URL {
+        let sessionURL = sourceHome
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(workDirHash, isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionURL, withIntermediateDirectories: true)
+        return sessionURL
+    }
+
+    @discardableResult
+    private func writeKimiSessionIndex(
+        at sourceHome: URL,
+        sessionID: String,
+        sessionDir: String,
+        workDir: String = "/tmp/project"
+    ) throws -> URL {
+        let indexURL = sourceHome.appendingPathComponent("session_index.jsonl", isDirectory: false)
+        let line = #"{"sessionId":"\#(sessionID)","sessionDir":"\#(sessionDir)","workDir":"\#(workDir)"}"# + "\n"
+        try line.write(to: indexURL, atomically: true, encoding: .utf8)
+        return indexURL
+    }
+
+    private func firstJSONObject(from indexURL: URL) throws -> [String: Any] {
+        let text = try String(contentsOf: indexURL, encoding: .utf8)
+        let line = try XCTUnwrap(text.split(separator: "\n", omittingEmptySubsequences: false).first.map(String.init))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
     }
 
     private func makeFakeKimiBinary(modern: Bool) throws -> URL {

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -1701,6 +1701,7 @@ class LaunchPlanner:
             overlay_home = overlay_dir / "home"
             symlink_directory_contents_skipping(source_dir, overlay_home, {"config.toml"})
             (overlay_home / "config.toml").write_text(merged, encoding="utf-8")
+            canonicalize_kimi_session_index_if_needed(source_dir)
             migration_skip = overlay_home / ".skip-migration-from-kimi-cli"
             if not os.path.lexists(migration_skip):
                 migration_skip.touch()
@@ -3016,6 +3017,88 @@ def kimi_config_source_dir(environment: dict[str, Any], variant: str) -> pathlib
     if str(environment.get("KIMI_SHARE_DIR") or "").strip():
         return config_source_dir(environment, "KIMI_SHARE_DIR", ".kimi")
     return config_source_dir(environment, "KIMI_HOME", ".kimi")
+
+
+_KIMI_SESSION_INDEX_LOCK = threading.Lock()
+_KIMI_SESSIONS_MARKER = "/sessions/"
+
+
+def _rewrite_kimi_session_index_line(
+    line: str,
+    *,
+    source_home_path: str,
+    source_home_prefix: str,
+) -> tuple[str, bool]:
+    trimmed = line.strip()
+    if not trimmed:
+        return line, False
+    try:
+        json_obj = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return line, False
+    if not isinstance(json_obj, dict):
+        return line, False
+
+    session_id = json_obj.get("sessionId") or json_obj.get("id")
+    session_dir = json_obj.get("sessionDir")
+    if not isinstance(session_id, str) or not isinstance(session_dir, str):
+        return line, False
+
+    session_dir_path = str(pathlib.Path(session_dir).expanduser())
+    if session_dir_path == source_home_path or session_dir_path.startswith(source_home_prefix):
+        return line, False
+
+    marker_index = session_dir_path.find(_KIMI_SESSIONS_MARKER)
+    if marker_index < 0:
+        return line, False
+
+    canonical_path = source_home_path + session_dir_path[marker_index:]
+    if not pathlib.Path(canonical_path).exists():
+        return line, False
+
+    json_obj["sessionDir"] = canonical_path
+    return json.dumps(json_obj, sort_keys=True, separators=(",", ":")), True
+
+
+def canonicalize_kimi_session_index_if_needed(source_home: pathlib.Path) -> None:
+    """Rewrite stale overlay sessionDir paths in Kimi's shared session index.
+
+    Mirrors AgentLaunchBootstrap.canonicalizeKimiSessionIndexIfNeeded: remap
+    absolute overlay paths that contain `/sessions/...` onto the durable source
+    home, but only when the remapped directory already exists on disk.
+    """
+    index_path = source_home / "session_index.jsonl"
+    if not index_path.is_file():
+        return
+
+    source_home_path = str(source_home.resolve())
+    source_home_prefix = source_home_path if source_home_path.endswith("/") else source_home_path + "/"
+
+    with _KIMI_SESSION_INDEX_LOCK:
+        try:
+            raw_text = index_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        changed = False
+        new_lines: list[str] = []
+        for line in raw_text.split("\n"):
+            rewritten, line_changed = _rewrite_kimi_session_index_line(
+                line,
+                source_home_path=source_home_path,
+                source_home_prefix=source_home_prefix,
+            )
+            new_lines.append(rewritten)
+            if line_changed:
+                changed = True
+
+        if not changed:
+            return
+
+        try:
+            index_path.write_text("\n".join(new_lines), encoding="utf-8")
+        except OSError:
+            return
 
 
 def is_zentty_launch_cache_path(entry: str) -> bool:

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -16,6 +16,46 @@ sys.modules["agent_bench"] = agent_bench
 SPEC.loader.exec_module(agent_bench)
 
 
+def _write_kimi_session_index(
+    source_home: pathlib.Path,
+    *,
+    session_id: str,
+    session_dir: str,
+    work_dir: str = "/tmp/project",
+) -> pathlib.Path:
+    index_path = source_home / "session_index.jsonl"
+    index_path.write_text(
+        json.dumps(
+            {
+                "sessionId": session_id,
+                "sessionDir": session_dir,
+                "workDir": work_dir,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return index_path
+
+
+def _modern_kimi_launch_planner(run_dir: pathlib.Path) -> agent_bench.LaunchPlanner:
+    return agent_bench.LaunchPlanner(
+        profile=agent_bench.AgentProfile(
+            name="kimi-code",
+            tool="kimi",
+            command="kimi",
+            real_binary_names=["kimi"],
+            version_args=["--version"],
+            launch_args_by_scenario={},
+            expectations={},
+            kimi_variant="modern",
+        ),
+        scenario="smoke",
+        run_dir=run_dir,
+        resources_dir=None,
+    )
+
+
 class RedactionTests(unittest.TestCase):
     def test_redacts_secret_values_and_keeps_routing_context(self):
         env = {
@@ -310,6 +350,84 @@ class ExpectationTests(unittest.TestCase):
             self.assertIn('model = "kimi"', merged)
             self.assertIn("[[hooks]]", merged)
             self.assertTrue((overlay_home / ".skip-migration-from-kimi-cli").is_file())
+
+    def test_canonicalize_kimi_session_index_rewrites_stale_overlay_session_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_home = pathlib.Path(tmp) / "source-home"
+            session_id = "session_a4d78f91-ea80-41e7-91d3-c699197ff442"
+            work_dir_hash = "wd_fix-kimi-code-cli_57590bf29904"
+            durable = source_home / "sessions" / work_dir_hash / session_id
+            durable.mkdir(parents=True)
+            overlay_session_dir = (
+                f"/Users/peter/Library/Caches/Zentty/ipc-11370/launch/wl_x/pn_y/kimi/home/"
+                f"sessions/{work_dir_hash}/{session_id}"
+            )
+            work_dir = "/Users/peter/Development/Personal/worktrees/fix-kimi-code-cli"
+            index_path = _write_kimi_session_index(
+                source_home,
+                session_id=session_id,
+                session_dir=overlay_session_dir,
+                work_dir=work_dir,
+            )
+
+            agent_bench.canonicalize_kimi_session_index_if_needed(source_home)
+
+            rewritten = json.loads(index_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rewritten["sessionId"], session_id)
+            self.assertEqual(rewritten["sessionDir"], str(durable.resolve()))
+            self.assertEqual(rewritten["workDir"], work_dir)
+
+    def test_canonicalize_kimi_session_index_skips_missing_target_and_preserves_other_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_home = pathlib.Path(tmp) / "source-home"
+            (source_home / "sessions").mkdir(parents=True)
+            session_id = "session_missing-on-disk"
+            work_dir_hash = "wd_missing_abcdef123456"
+            overlay_session_dir = f"/tmp/overlay/kimi/home/sessions/{work_dir_hash}/{session_id}"
+            poisoned = json.dumps(
+                {
+                    "sessionId": session_id,
+                    "sessionDir": overlay_session_dir,
+                    "workDir": "/tmp/project",
+                }
+            )
+            original = "\n".join([poisoned, '{"note":"not-a-session"}', "not-json", ""])
+            index_path = source_home / "session_index.jsonl"
+            index_path.write_text(original, encoding="utf-8")
+
+            agent_bench.canonicalize_kimi_session_index_if_needed(source_home)
+
+            self.assertEqual(index_path.read_text(encoding="utf-8"), original)
+
+    def test_kimi_modern_plan_canonicalizes_poisoned_session_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            source_home = root / "source-home"
+            source_home.mkdir()
+            (source_home / "config.toml").write_text('model = "kimi"\n', encoding="utf-8")
+            session_id = "session_ae5ef9dc-a4fe-4cc1-9b18-27823ca399cc"
+            work_dir_hash = "wd_fix-kimi-code-cli_57590bf29904"
+            durable = source_home / "sessions" / work_dir_hash / session_id
+            durable.mkdir(parents=True)
+            overlay_session_dir = (
+                f"{root}/overlays/old/kimi/home/sessions/{work_dir_hash}/{session_id}"
+            )
+            index_path = _write_kimi_session_index(
+                source_home,
+                session_id=session_id,
+                session_dir=overlay_session_dir,
+            )
+            planner = _modern_kimi_launch_planner(root)
+
+            planner._plan_kimi(
+                "/usr/bin/kimi",
+                ["-p", "hello"],
+                {"HOME": str(root / "home"), "KIMI_CODE_HOME": str(source_home)},
+                "/usr/bin/zentty",
+            )
+
+            rewritten = json.loads(index_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(rewritten["sessionDir"], str(durable.resolve()))
 
     def test_resolve_agent_binary_picks_matching_kimi_variant(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Problem

After quitting Zentty and reopening it, restoring a Kimi agent fails with:

```
error: Session not found
Session "session_d1c026d0-7ac1-46d6-92f4-6eecde78a127" was not found
```

## Root cause

Modern Kimi is launched with an ephemeral overlay home (`KIMI_CODE_HOME` pointing to `~/Library/Caches/Zentty/ipc-<PID>-.../launch/.../kimi/home`). Kimi records `sessionDir` as an absolute path under that home in the shared `~/.kimi-code/session_index.jsonl`. Once the overlay is torn down, the recorded path no longer exists, so `kimi -S <id>` cannot find the session on the next launch.

## Fix

Before each modern Kimi launch, scan `~/.kimi-code/session_index.jsonl` and rewrite any `sessionDir` that is not already under `~/.kimi-code` to `~/.kimi-code/sessions/<session-id>`. The read-modify-write is serialized with an `NSLock` because multiple panes can launch Kimi concurrently and all share the same index file.

The new helper is `internal` so a unit test can be added later.

## Testing

This environment is missing the signing certificate and `FrameworksLocal/GhosttyKit.xcframework`, so I could not run the Xcode test targets. I verified the rewrite logic with a standalone Swift script against sample `session_index.jsonl` entries that mirror the stale overlay paths observed in the bug report.
