### PR TITLE
feat(sidebar): add a vivid selection option for the active worklane

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		6910CC9A449CF438EEFE8022 /* ThirdPartyLicenseCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA937E13903E6F4629AE7AA /* ThirdPartyLicenseCatalogTests.swift */; };
 		69EE6C583CFC2132C81D9491 /* JSONKeyAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58B814CCB50A93D946D971E /* JSONKeyAccess.swift */; };
 		6A72B975870E8AE9C0839ADA /* ServerBrowserCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E263ECB14727930372689593 /* ServerBrowserCatalog.swift */; };
+		6AA84BEE902A5824442396CF /* SidebarSelectionEmphasisOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C9A5DCB4929A1E90A3D79A /* SidebarSelectionEmphasisOptionView.swift */; };
 		6AF1CD2BF77470AF7368F0F5 /* ClaudeCodeTitleOverrideReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893F6E481A2B8E457B238DE7 /* ClaudeCodeTitleOverrideReducer.swift */; };
 		6BDA3DD6058C31E9C1635868 /* AgentStatusCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1DB0F3E90C5CCF115A2E27B /* AgentStatusCommand.swift */; };
 		6C9EB4F61C57A150765111CC /* NotificationChromeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C34091F1CB5D75D73EF939 /* NotificationChromeCoordinatorTests.swift */; };
@@ -838,6 +839,7 @@
 		54894343178398AA618315E4 /* PaneFocusHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusHistory.swift; sourceTree = "<group>"; };
 		548FC6076155215F77E6A14B /* ServerPortRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerPortRuleTests.swift; sourceTree = "<group>"; };
 		54B6094A0D5CBAD802D8F6FE /* WorklanePeekController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklanePeekController.swift; sourceTree = "<group>"; };
+		54C9A5DCB4929A1E90A3D79A /* SidebarSelectionEmphasisOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionEmphasisOptionView.swift; sourceTree = "<group>"; };
 		54D167BBBE4C7B3318C151C7 /* WorkspaceTemplateImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateImporter.swift; sourceTree = "<group>"; };
 		555A3E876B04160BA692FCFB /* ClosedPaneRestoreCommandResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedPaneRestoreCommandResolverTests.swift; sourceTree = "<group>"; };
 		559F037FFC52BB9F8C9AE5EB /* SidebarViewDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewDebugging.swift; sourceTree = "<group>"; };
@@ -1882,6 +1884,7 @@
 				BB190F0BEA7609493A5A1AB3 /* SettingsSidebarViewController.swift */,
 				96A00B46795D7A242D2C9107 /* SettingsWindowController.swift */,
 				BF02658BAF6F6B57713BBD05 /* ShortcutsSettingsSectionViewController.swift */,
+				54C9A5DCB4929A1E90A3D79A /* SidebarSelectionEmphasisOptionView.swift */,
 				8D089E7F235904D263884DDE /* UpdatesPrivacySettingsSectionViewController.swift */,
 			);
 			path = Settings;
@@ -2932,6 +2935,7 @@
 				CBA82B1C9557F98AD04A8672 /* SidebarPaneRowViews.swift in Sources */,
 				7AB05C23149C9A7980629EC9 /* SidebarResizeHandleView.swift in Sources */,
 				0889B047795F8D959B7EC555 /* SidebarRowDiff.swift in Sources */,
+				6AA84BEE902A5824442396CF /* SidebarSelectionEmphasisOptionView.swift in Sources */,
 				E94E1DACAFBCE24E8AA485C5 /* SidebarShimmerColorResolver.swift in Sources */,
 				AA417704363C7781CECDFEBF /* SidebarShimmerTextView.swift in Sources */,
 				A1D6E61EF7D669A5DAE672B0 /* SidebarStatusResolver.swift in Sources */,

--- a/Zentty/Config/AppConfig.swift
+++ b/Zentty/Config/AppConfig.swift
@@ -51,12 +51,21 @@ struct AppConfig: Equatable, Sendable {
             case alwaysLight
         }
 
+        /// How strongly the selected worklane row is emphasized in the sidebar.
+        /// `.subtle` keeps the historical recessed look; `.vivid` paints the
+        /// selection with an accent-colored fill matching the focused-pane border.
+        enum SidebarSelectionEmphasis: String, CaseIterable, Equatable, Sendable {
+            case subtle
+            case vivid
+        }
+
         var localThemeName: String?
         var themeMode: ThemeMode
         var preferredDarkThemeName: String?
         var preferredLightThemeName: String?
         var localBackgroundOpacity: CGFloat?
         var syncOpenCodeThemeWithTerminal: Bool
+        var sidebarSelectionEmphasis: SidebarSelectionEmphasis
 
         static let `default` = Appearance(
             localThemeName: nil,
@@ -64,7 +73,8 @@ struct AppConfig: Equatable, Sendable {
             preferredDarkThemeName: nil,
             preferredLightThemeName: nil,
             localBackgroundOpacity: nil,
-            syncOpenCodeThemeWithTerminal: true
+            syncOpenCodeThemeWithTerminal: true,
+            sidebarSelectionEmphasis: .subtle
         )
     }
 

--- a/Zentty/Config/AppConfigTOML.swift
+++ b/Zentty/Config/AppConfigTOML.swift
@@ -76,6 +76,11 @@ enum AppConfigTOML {
                     "sync_opencode_theme_with_terminal = \(config.appearance.syncOpenCodeThemeWithTerminal)"
                 )
             }
+            if config.appearance.sidebarSelectionEmphasis != AppConfig.Appearance.default.sidebarSelectionEmphasis {
+                lines.append(
+                    "sidebar_selection_emphasis = \(encode(string: config.appearance.sidebarSelectionEmphasis.rawValue))"
+                )
+            }
             lines.append("")
         }
 
@@ -596,6 +601,12 @@ enum AppConfigTOML {
                 return false
             }
             config.appearance.syncOpenCodeThemeWithTerminal = value
+        case "sidebar_selection_emphasis":
+            guard let value = decodeString(assignment.value),
+                  let emphasis = AppConfig.Appearance.SidebarSelectionEmphasis(rawValue: value) else {
+                return false
+            }
+            config.appearance.sidebarSelectionEmphasis = emphasis
         default:
             return true
         }

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -296,7 +296,10 @@ final class RootViewController: NSViewController {
                     [weak configStore] in
                     configStore?.current ?? .default
                 })
-            )
+            ),
+            sidebarSelectionEmphasisProvider: { [weak configStore] in
+                configStore?.current.appearance.sidebarSelectionEmphasis ?? .subtle
+            }
         )
         self.notificationCoordinator = NotificationChromeCoordinator(store: notificationStore)
         self.paneLayoutMenuCoordinator = PaneLayoutMenuCoordinator(

--- a/Zentty/UI/Settings/AppearanceSettingsSectionViewController.swift
+++ b/Zentty/UI/Settings/AppearanceSettingsSectionViewController.swift
@@ -97,6 +97,7 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
     private let currentBackgroundOpacityProvider: () -> CGFloat?
 
     private var modeOptionViews: [ThemeModeOptionView] = []
+    private var sidebarSelectionEmphasisOptionViews: [SidebarSelectionEmphasisOptionView] = []
     private let darkSlotView = ThemeSlotTabControl(slot: .dark)
     private let lightSlotView = ThemeSlotTabControl(slot: .light)
     private let currentThemeSummaryLabel = NSTextField(labelWithString: "")
@@ -117,6 +118,7 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
     private var filteredThemes: [ThemePreview] = []
     private var activeThemeName: String?
     private var themePreferences = AppearanceThemePreferences(mode: .alwaysDark, darkThemeName: nil, lightThemeName: nil)
+    private var sidebarSelectionEmphasis = AppConfig.Appearance.SidebarSelectionEmphasis.subtle
     private var editingThemeSlot = AppearanceThemeSlot.dark
     private var hasUserSelectedThemeSlot = false
     private var catalogFilterMode = ThemeCatalogFilterMode.dark
@@ -420,6 +422,65 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
         stackView.addArrangedSubview(openCodeThemeCard)
         openCodeThemeCard.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
 
+        // Sidebar selection emphasis card
+        let sidebarEmphasisCard = SettingsCardView()
+        let sidebarEmphasisStack = NSStackView()
+        sidebarEmphasisStack.orientation = .vertical
+        sidebarEmphasisStack.alignment = .leading
+        sidebarEmphasisStack.spacing = 12
+        sidebarEmphasisStack.translatesAutoresizingMaskIntoConstraints = false
+        sidebarEmphasisCard.addSubview(sidebarEmphasisStack)
+
+        let sidebarEmphasisTitleLabel = NSTextField(labelWithString: "Sidebar selection")
+        sidebarEmphasisTitleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        sidebarEmphasisStack.addArrangedSubview(sidebarEmphasisTitleLabel)
+
+        let sidebarEmphasisSubtitleLabel = NSTextField(
+            labelWithString: "How strongly the active worklane is highlighted."
+        )
+        sidebarEmphasisSubtitleLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        sidebarEmphasisSubtitleLabel.textColor = .secondaryLabelColor
+        sidebarEmphasisSubtitleLabel.lineBreakMode = .byWordWrapping
+        sidebarEmphasisSubtitleLabel.maximumNumberOfLines = 0
+        sidebarEmphasisStack.addArrangedSubview(sidebarEmphasisSubtitleLabel)
+        sidebarEmphasisSubtitleLabel.widthAnchor.constraint(equalTo: sidebarEmphasisStack.widthAnchor).isActive = true
+
+        let sidebarEmphasisOptionsRow = NSStackView()
+        sidebarEmphasisOptionsRow.orientation = .horizontal
+        sidebarEmphasisOptionsRow.alignment = .top
+        sidebarEmphasisOptionsRow.distribution = .fillEqually
+        sidebarEmphasisOptionsRow.spacing = 10
+        sidebarEmphasisOptionsRow.translatesAutoresizingMaskIntoConstraints = false
+
+        sidebarSelectionEmphasisOptionViews = [
+            SidebarSelectionEmphasisOptionView(
+                emphasis: .subtle,
+                title: "Subtle",
+                subtitle: "Quiet tint that blends with the theme."
+            ),
+            SidebarSelectionEmphasisOptionView(
+                emphasis: .vivid,
+                title: "Vivid",
+                subtitle: "Accent-colored highlight, matches the focused pane."
+            ),
+        ]
+        for optionView in sidebarSelectionEmphasisOptionViews {
+            optionView.target = self
+            optionView.action = #selector(handleSidebarSelectionEmphasisSelected(_:))
+            sidebarEmphasisOptionsRow.addArrangedSubview(optionView)
+        }
+        sidebarEmphasisStack.addArrangedSubview(sidebarEmphasisOptionsRow)
+        sidebarEmphasisOptionsRow.widthAnchor.constraint(equalTo: sidebarEmphasisStack.widthAnchor).isActive = true
+
+        NSLayoutConstraint.activate([
+            sidebarEmphasisStack.topAnchor.constraint(equalTo: sidebarEmphasisCard.topAnchor, constant: 16),
+            sidebarEmphasisStack.leadingAnchor.constraint(equalTo: sidebarEmphasisCard.leadingAnchor, constant: 16),
+            sidebarEmphasisStack.trailingAnchor.constraint(equalTo: sidebarEmphasisCard.trailingAnchor, constant: -16),
+            sidebarEmphasisStack.bottomAnchor.constraint(equalTo: sidebarEmphasisCard.bottomAnchor, constant: -16),
+        ])
+        stackView.addArrangedSubview(sidebarEmphasisCard)
+        sidebarEmphasisCard.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -435,6 +496,7 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
         refreshActiveThemeName()
         refreshOpacitySlider()
         refreshOpenCodeThemeSyncSwitch()
+        refreshSidebarSelectionEmphasis()
         Task {
             await reloadThemes()
         }
@@ -446,6 +508,7 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
         refreshActiveThemeName()
         refreshOpacitySlider()
         refreshOpenCodeThemeSyncSwitch()
+        refreshSidebarSelectionEmphasis()
         super.prepareForPresentation()
     }
 
@@ -455,6 +518,7 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
         refreshActiveThemeName()
         refreshOpacitySlider()
         refreshOpenCodeThemeSyncSwitch()
+        refreshSidebarSelectionEmphasis()
     }
 
     // MARK: - Theme State
@@ -490,6 +554,10 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
 
     var isOpenCodeThemeSyncEnabledForTesting: Bool {
         openCodeThemeSyncSwitch.state == .on
+    }
+
+    var sidebarSelectionEmphasisForTesting: AppConfig.Appearance.SidebarSelectionEmphasis {
+        sidebarSelectionEmphasis
     }
 
     private func refreshActiveThemeName() {
@@ -640,6 +708,13 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
     func setOpenCodeThemeSyncEnabledForTesting(_ enabled: Bool) {
         openCodeThemeSyncSwitch.state = enabled ? .on : .off
         handleOpenCodeThemeSyncChanged(openCodeThemeSyncSwitch)
+    }
+
+    func setSidebarSelectionEmphasisForTesting(_ emphasis: AppConfig.Appearance.SidebarSelectionEmphasis) {
+        guard let optionView = sidebarSelectionEmphasisOptionViews.first(where: { $0.emphasis == emphasis }) else {
+            return
+        }
+        handleSidebarSelectionEmphasisSelected(optionView)
     }
 
     func createSharedConfigForTesting() {
@@ -823,6 +898,15 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
         openCodeThemeSyncSwitch.state = configCoordinator.syncOpenCodeThemeWithTerminal ? .on : .off
     }
 
+    private func refreshSidebarSelectionEmphasis() {
+        sidebarSelectionEmphasis = configCoordinator.sidebarSelectionEmphasis
+        updateSidebarSelectionEmphasisViews()
+    }
+
+    private func updateSidebarSelectionEmphasisViews() {
+        sidebarSelectionEmphasisOptionViews.forEach { $0.isSelected = $0.emphasis == sidebarSelectionEmphasis }
+    }
+
     private func updateOpacityLabel(_ opacity: CGFloat) {
         opacityValueLabel.stringValue = "\(Int(round(opacity * 100)))%"
     }
@@ -899,6 +983,17 @@ final class AppearanceSettingsSectionViewController: SettingsScrollableSectionVi
             guard let self else { return }
             await configCoordinator.applyOpenCodeThemeSync(enabled)
             refreshOpenCodeThemeSyncSwitch()
+        }
+    }
+
+    @objc
+    private func handleSidebarSelectionEmphasisSelected(_ sender: SidebarSelectionEmphasisOptionView) {
+        sidebarSelectionEmphasis = sender.emphasis
+        updateSidebarSelectionEmphasisViews()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await configCoordinator.applySidebarSelectionEmphasis(sender.emphasis)
+            refreshSidebarSelectionEmphasis()
         }
     }
 

--- a/Zentty/UI/Settings/GhosttyAppearanceSettingsCoordinator.swift
+++ b/Zentty/UI/Settings/GhosttyAppearanceSettingsCoordinator.swift
@@ -127,12 +127,14 @@ protocol AppearanceSettingsConfigCoordinating {
     var sourceState: AppearanceSettingsSourceState { get }
     var themePreferences: AppearanceThemePreferences { get }
     var syncOpenCodeThemeWithTerminal: Bool { get }
+    var sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis { get }
     func applyTheme(_ name: String, presentingWindow: NSWindow?) async
     func applyTheme(_ name: String, slot: AppearanceThemeSlot, presentingWindow: NSWindow?) async
     func applyThemeMode(_ mode: AppConfig.Appearance.ThemeMode, presentingWindow: NSWindow?) async
     func resetThemePreferences(presentingWindow: NSWindow?) async
     func applyBackgroundOpacity(_ opacity: CGFloat, presentingWindow: NSWindow?) async
     func applyOpenCodeThemeSync(_ enabled: Bool) async
+    func applySidebarSelectionEmphasis(_ emphasis: AppConfig.Appearance.SidebarSelectionEmphasis) async
     func createSharedConfig(presentingWindow: NSWindow?) async
 }
 
@@ -188,6 +190,10 @@ final class GhosttyAppearanceSettingsCoordinator: AppearanceSettingsConfigCoordi
 
     var syncOpenCodeThemeWithTerminal: Bool {
         configStore.current.appearance.syncOpenCodeThemeWithTerminal
+    }
+
+    var sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis {
+        configStore.current.appearance.sidebarSelectionEmphasis
     }
 
     var themePreferences: AppearanceThemePreferences {
@@ -283,6 +289,16 @@ final class GhosttyAppearanceSettingsCoordinator: AppearanceSettingsConfigCoordi
             }
         } catch {
             logger.error("Failed to persist OpenCode theme sync setting: \(error.localizedDescription)")
+        }
+    }
+
+    func applySidebarSelectionEmphasis(_ emphasis: AppConfig.Appearance.SidebarSelectionEmphasis) async {
+        do {
+            try configStore.update { config in
+                config.appearance.sidebarSelectionEmphasis = emphasis
+            }
+        } catch {
+            logger.error("Failed to persist sidebar selection emphasis setting: \(error.localizedDescription)")
         }
     }
 

--- a/Zentty/UI/Settings/SidebarSelectionEmphasisOptionView.swift
+++ b/Zentty/UI/Settings/SidebarSelectionEmphasisOptionView.swift
@@ -1,0 +1,187 @@
+import AppKit
+
+/// Selectable option tile for the "Sidebar selection" appearance card, mirroring
+/// `ThemeModeOptionView`'s selectable-card interaction but with a lightweight preview
+/// of how the active worklane row is highlighted (subtle tint vs. accent-colored fill).
+@MainActor
+final class SidebarSelectionEmphasisOptionView: NSControl {
+    let emphasis: AppConfig.Appearance.SidebarSelectionEmphasis
+
+    var isSelected = false {
+        didSet {
+            guard oldValue != isSelected else { return }
+            updateAppearance()
+        }
+    }
+
+    private let previewView: SidebarSelectionEmphasisPreviewView
+    private let titleLabel: NSTextField
+    private let subtitleLabel: NSTextField
+
+    init(emphasis: AppConfig.Appearance.SidebarSelectionEmphasis, title: String, subtitle: String) {
+        self.emphasis = emphasis
+        self.previewView = SidebarSelectionEmphasisPreviewView(emphasis: emphasis)
+        self.titleLabel = NSTextField(labelWithString: title)
+        self.subtitleLabel = NSTextField(wrappingLabelWithString: subtitle)
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.cornerCurve = .continuous
+        layer?.borderWidth = 1
+
+        let stackView = NSStackView()
+        stackView.orientation = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+
+        previewView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(previewView)
+        previewView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+        previewView.heightAnchor.constraint(equalToConstant: 58).isActive = true
+
+        titleLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        titleLabel.lineBreakMode = .byTruncatingTail
+        stackView.addArrangedSubview(titleLabel)
+
+        subtitleLabel.font = .systemFont(ofSize: 10.5, weight: .regular)
+        subtitleLabel.textColor = .secondaryLabelColor
+        subtitleLabel.maximumNumberOfLines = 2
+        stackView.addArrangedSubview(subtitleLabel)
+        subtitleLabel.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 136),
+        ])
+
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        isHighlighted = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        isHighlighted = false
+        guard bounds.contains(convert(event.locationInWindow, from: nil)) else { return }
+        sendAction(action, to: target)
+    }
+
+    override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        let isDarkMode = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        if isSelected {
+            layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(isDarkMode ? 0.18 : 0.11).cgColor
+            layer?.borderColor = NSColor.controlAccentColor.cgColor
+        } else if isHighlighted {
+            layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.08).cgColor
+            layer?.borderColor = NSColor.controlAccentColor.withAlphaComponent(0.5).cgColor
+        } else {
+            layer?.backgroundColor = NSColor.controlBackgroundColor.withAlphaComponent(isDarkMode ? 0.18 : 0.55).cgColor
+            layer?.borderColor = (isDarkMode
+                ? NSColor.white.withAlphaComponent(0.12)
+                : NSColor.black.withAlphaComponent(0.12)).cgColor
+        }
+        previewView.isSelected = isSelected
+    }
+}
+
+/// Draws a miniature sidebar with three worklane rows, one of them selected, to preview
+/// how strongly the active row stands out under `.subtle` vs. `.vivid` emphasis.
+@MainActor
+private final class SidebarSelectionEmphasisPreviewView: NSView {
+    let emphasis: AppConfig.Appearance.SidebarSelectionEmphasis
+
+    var isSelected = false {
+        didSet { needsDisplay = true }
+    }
+
+    init(emphasis: AppConfig.Appearance.SidebarSelectionEmphasis) {
+        self.emphasis = emphasis
+        super.init(frame: .zero)
+        wantsLayer = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        let accent = NSColor.controlAccentColor
+        let stroke = NSColor.secondaryLabelColor.withAlphaComponent(0.55)
+        let background = NSColor.textBackgroundColor
+        let idleText = NSColor.secondaryLabelColor
+        let rect = bounds.insetBy(dx: 2, dy: 4)
+
+        let shellPath = NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6)
+        stroke.setStroke()
+        shellPath.lineWidth = isSelected ? 1.5 : 1
+        shellPath.stroke()
+        background.setFill()
+        NSBezierPath(roundedRect: rect.insetBy(dx: 0.5, dy: 0.5), xRadius: 6, yRadius: 6).fill()
+
+        let inset = rect.insetBy(dx: 6, dy: 6)
+        let rowHeight: CGFloat = 10
+        let rowSpacing: CGFloat = 4
+        let rowWidths: [CGFloat] = [0.9, 0.7, 0.8]
+        let selectedRowIndex = 1
+
+        for index in 0..<rowWidths.count {
+            let rowRect = NSRect(
+                x: inset.minX,
+                y: inset.minY + CGFloat(index) * (rowHeight + rowSpacing),
+                width: inset.width,
+                height: rowHeight
+            )
+            let rowPath = NSBezierPath(roundedRect: rowRect, xRadius: 3, yRadius: 3)
+
+            if index == selectedRowIndex {
+                switch emphasis {
+                case .subtle:
+                    idleText.withAlphaComponent(0.16).setFill()
+                    rowPath.fill()
+                case .vivid:
+                    accent.withAlphaComponent(0.28).setFill()
+                    rowPath.fill()
+                    accent.setStroke()
+                    rowPath.lineWidth = 1
+                    rowPath.stroke()
+                }
+
+                let textColor = emphasis == .vivid ? accent : idleText
+                let textRect = rowRect.insetBy(dx: 3, dy: 2.5)
+                textColor.setFill()
+                NSBezierPath(roundedRect: textRect.divided(atDistance: textRect.width * rowWidths[index], from: .minXEdge).slice, xRadius: 1, yRadius: 1).fill()
+            } else {
+                let textRect = rowRect.insetBy(dx: 3, dy: 2.5)
+                idleText.withAlphaComponent(0.45).setFill()
+                NSBezierPath(roundedRect: textRect.divided(atDistance: textRect.width * rowWidths[index], from: .minXEdge).slice, xRadius: 1, yRadius: 1).fill()
+            }
+        }
+    }
+}

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -829,7 +829,14 @@ final class SidebarWorklaneRowButton: NSButton {
         appearance = NSAppearance(named: currentTheme.sidebarGlassAppearance.nsAppearanceName)
         updateShimmerState()
 
-        let activeTextColor = currentTheme.sidebarButtonActiveText
+        let selectedChrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+            worklaneColor: summary.color,
+            activeBackground: currentTheme.sidebarButtonActiveBackground,
+            activeBorder: currentTheme.sidebarButtonActiveBorder,
+            activeText: currentTheme.sidebarButtonActiveText,
+            theme: currentTheme
+        )
+        let activeTextColor = selectedChrome.text
         let inactiveTextColor = currentTheme.sidebarButtonInactiveText
 
         topLabel.textColor = SidebarWorklaneRowStyleResolver.topLabelTextColor(
@@ -916,6 +923,8 @@ final class SidebarWorklaneRowButton: NSButton {
         chrome.apply(
             summary: summary,
             theme: currentTheme,
+            activeBackground: selectedChrome.background,
+            activeBorder: selectedChrome.border,
             isWorking: isWorking,
             isHovered: isHovered,
             isPaneRowHovered: isPaneRowHovered,

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowChrome.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowChrome.swift
@@ -90,6 +90,8 @@ final class SidebarWorklaneRowChrome {
     func apply(
         summary: WorklaneSidebarSummary,
         theme: ZenttyTheme,
+        activeBackground: NSColor,
+        activeBorder: NSColor,
         isWorking: Bool,
         isHovered: Bool,
         isPaneRowHovered: Bool,
@@ -97,10 +99,8 @@ final class SidebarWorklaneRowChrome {
         animated: Bool,
         layer: CALayer?
     ) {
-        let activeBackground = theme.sidebarButtonActiveBackground
         let hoverBackground = theme.sidebarButtonHoverBackground
         let inactiveBackground = theme.sidebarButtonInactiveBackground
-        let activeBorder = theme.sidebarButtonActiveBorder
         let inactiveBorder = theme.sidebarButtonInactiveBorder.withAlphaComponent(
             isHovered ? 0.16 : 0.10
         )

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowStyleResolver.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowStyleResolver.swift
@@ -1,6 +1,63 @@
 import AppKit
 
 enum SidebarWorklaneRowStyleResolver {
+    /// Resolved selected-row chrome: the near-opaque fill, its border, and a
+    /// legible active-text color for that fill.
+    struct SelectedRowChrome {
+        let background: NSColor
+        let border: NSColor
+        let text: NSColor
+    }
+
+    /// Selected-row fill / border / text for the current emphasis mode.
+    ///
+    /// - `.subtle`, or `.vivid` without a worklane color: returns the theme's
+    ///   accent-derived values untouched, so those paths stay byte-for-byte as
+    ///   the core theme change produced them.
+    /// - `.vivid` WITH a worklane color: rebuilds the vivid recipe around the
+    ///   lane color so the selected row reads as clearly lane-tinted, mirroring
+    ///   how the focused pane border prefers the worklane color over
+    ///   `theme.paneBorderFocused` (see `PaneContainerView.applyVisualState`).
+    ///   The border uses `WorklaneColor.Alpha.focusedBorder` (0.55) to match the
+    ///   focused-pane stroke, and the text is re-guaranteed against the lane fill
+    ///   via `ensuringTextContrast(on:)`.
+    static func selectedRowChrome(
+        worklaneColor: WorklaneColor?,
+        activeBackground: NSColor,
+        activeBorder: NSColor,
+        activeText: NSColor,
+        theme: ZenttyTheme
+    ) -> SelectedRowChrome {
+        guard theme.sidebarSelectionEmphasis == .vivid, let worklaneColor else {
+            return SelectedRowChrome(
+                background: activeBackground,
+                border: activeBorder,
+                text: activeText
+            )
+        }
+
+        let isDark = theme.sidebarGlassAppearance == .dark
+        let sidebarSurface = theme.sidebarBackground.composited(
+            over: theme.windowBackground
+        )
+        // Mirror AppTheme's vivid fill recipe, swapping the theme accent for the
+        // lane color. Worklane colors are fixed, saturated hues that are never
+        // ~= the sidebar surface, so the accent contrast-floor guard AppTheme
+        // needs is unnecessary here.
+        let laneFill = worklaneColor.tint(alpha: 1)
+            .mixed(towards: sidebarSurface, amount: isDark ? 0.55 : 0.45)
+            .withAlphaComponent(theme.reducedTransparency ? 0.96 : 0.92)
+        let laneBorder = worklaneColor.tint(alpha: WorklaneColor.Alpha.focusedBorder)
+        let laneText = activeText.ensuringTextContrast(
+            on: laneFill.composited(over: sidebarSurface)
+        )
+        return SelectedRowChrome(
+            background: laneFill,
+            border: laneBorder,
+            text: laneText
+        )
+    }
+
     static func tintColor(
         worklaneColor: WorklaneColor?,
         isActive: Bool,

--- a/Zentty/UI/Theme/AppTheme.swift
+++ b/Zentty/UI/Theme/AppTheme.swift
@@ -118,6 +118,7 @@ struct ZenttyTheme: Equatable {
     let sidebarGlassAppearance: ThemeChromeAppearance
     let sidebarGlassOpacity: CGFloat
     let reducedTransparency: Bool
+    let sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis
 
     static let animationDuration: CFTimeInterval = 0.20
 
@@ -184,12 +185,15 @@ struct ZenttyTheme: Equatable {
             && lhs.sidebarGlassAppearance == rhs.sidebarGlassAppearance
             && lhs.sidebarGlassOpacity == rhs.sidebarGlassOpacity
             && lhs.reducedTransparency == rhs.reducedTransparency
+            && lhs.sidebarSelectionEmphasis == rhs.sidebarSelectionEmphasis
     }
 
     init(
         resolvedTheme: GhosttyResolvedTheme,
-        reduceTransparency: Bool = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+        reduceTransparency: Bool = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency,
+        sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis = .subtle
     ) {
+        self.sidebarSelectionEmphasis = sidebarSelectionEmphasis
         let background = resolvedTheme.background.srgbClamped
         let foreground = resolvedTheme.foreground.srgbClamped
         let accent = (resolvedTheme.cursorColor).srgbClamped
@@ -280,18 +284,13 @@ struct ZenttyTheme: Equatable {
         failureOverlayBackground = background.mixed(towards: foreground, amount: 0.08).withAlphaComponent(0.92)
         failurePrimaryText = readableForeground.withAlphaComponent(0.96)
         failureSecondaryText = readableForeground.withAlphaComponent(0.72)
-        sidebarButtonActiveBackground = sidebarRowSelectedBase.withAlphaComponent(
-            reduceTransparency ? 0.94 : (background.isDarkThemeColor ? 0.62 : 0.88)
-        )
         sidebarButtonHoverBackground = sidebarRowHoverBase.withAlphaComponent(
             reduceTransparency ? 0.28 : (background.isDarkThemeColor ? 0.28 : 0.42)
         )
         sidebarButtonInactiveBackground = sidebarRowIdleBase.withAlphaComponent(
             reduceTransparency ? 0.10 : (background.isDarkThemeColor ? 0.12 : 0.08)
         )
-        sidebarButtonActiveBorder = accent.withAlphaComponent(background.isDarkThemeColor ? 0.12 : 0.10)
         sidebarButtonInactiveBorder = foreground.withAlphaComponent(background.isDarkThemeColor ? 0.10 : 0.12)
-        sidebarButtonActiveText = readableSidebarActiveText.withAlphaComponent(background.isDarkThemeColor ? 0.98 : 0.96)
         sidebarButtonInactiveText = readableSidebarText.withAlphaComponent(background.isDarkThemeColor ? 0.74 : 0.72)
         sidebarWorkingTextHighlight = background.isDarkThemeColor
             ? readableSidebarText.mixed(towards: NSColor.white, amount: 0.14)
@@ -318,6 +317,80 @@ struct ZenttyTheme: Equatable {
         statusStopped = paletteRed
         statusReady = paletteGreen
         statusIdle = accent.withAlphaComponent(isDark ? 0.54 : 0.48)
+
+        // Selected-row chrome. `.subtle` keeps the historical recessed fill
+        // (selected reads as the darkest/lightest of selected/hover/idle). `.vivid`
+        // paints the row with an accent-tinted fill cohesive with `paneBorderFocused`.
+        //
+        // Both modes get a separation guard so the active lane stays findable on
+        // themes where the derivation collapses selected ~= idle, but they use
+        // different instruments. `.vivid` uses a WCAG contrast floor (its accent
+        // fill has the luminance headroom to satisfy it). `.subtle` cannot: on the
+        // near-black backgrounds Zentty ships with, two dark translucent fills never
+        // reach a 1.4 WCAG ratio, so a subtle WCAG floor would both alter the shipped
+        // look and invert the selected<hover<idle ordering `.subtle` is defined by.
+        // Instead `.subtle` measures perceptual sRGB distance and, when the fills
+        // collapse, widens the gap along the ordering-preserving axis (darker on
+        // dark, lighter on light); if the surface is too near-black/white to gain
+        // headroom, it compensates with a visible accent border instead.
+        let sidebarSurface = sidebarBackground.composited(over: background)
+        let idleComposited = sidebarButtonInactiveBackground.composited(over: sidebarSurface)
+        // Guard the accent so an accent-colored selection treatment never
+        // degenerates when the cursor color is ~= the sidebar surface: fall back
+        // through palette blue, then a foreground mix, then foreground (the same
+        // escalation the status colors lean on). Vivid uses this for its fill and
+        // border; subtle only reaches for it when the separation guard has to
+        // escalate the border on a collapsed theme.
+        let guardedAccent: NSColor = {
+            if accent.contrastRatio(against: baseSidebar) >= 1.2 {
+                return accent
+            }
+            if paletteBlue.contrastRatio(against: baseSidebar) >= 1.2 {
+                return paletteBlue
+            }
+            let mix = foreground.mixed(towards: accent, amount: 0.35)
+            return mix.contrastRatio(against: baseSidebar) >= 1.2 ? mix : foreground
+        }()
+        switch sidebarSelectionEmphasis {
+        case .subtle:
+            let baseActiveFill = sidebarRowSelectedBase.withAlphaComponent(
+                reduceTransparency ? 0.94 : (isDark ? 0.62 : 0.88)
+            )
+            let baseBorderAlpha: CGFloat = isDark ? 0.12 : 0.10
+            let separated = ZenttyTheme.separatedSubtleSelection(
+                fill: baseActiveFill,
+                idleComposited: idleComposited,
+                sidebarSurface: sidebarSurface,
+                separationTarget: isDark ? NSColor.black : NSColor.white,
+                baseBorderAlpha: baseBorderAlpha,
+                maximumBorderAlpha: isDark ? 0.42 : 0.34
+            )
+            sidebarButtonActiveBackground = separated.fill
+            // When the guard escalates the border it exists to rescue a collapsed
+            // theme, so the border color itself must be visible — use the guarded
+            // accent there. The unescalated path keeps the raw accent so healthy
+            // themes stay byte-identical to the historical derivation.
+            let borderColor = separated.borderAlpha > baseBorderAlpha ? guardedAccent : accent
+            sidebarButtonActiveBorder = borderColor.withAlphaComponent(separated.borderAlpha)
+            sidebarButtonActiveText = readableSidebarActiveText
+                .withAlphaComponent(isDark ? 0.98 : 0.96)
+        case .vivid:
+            let vividFill = guardedAccent
+                .mixed(towards: baseSidebar, amount: isDark ? 0.55 : 0.45)
+                .withAlphaComponent(reduceTransparency ? 0.96 : 0.92)
+            let flooredFill = ZenttyTheme.contrastFlooredActiveFill(
+                vividFill,
+                idleComposited: idleComposited,
+                sidebarSurface: sidebarSurface,
+                foreground: foreground,
+                minimumContrast: 1.4
+            )
+            sidebarButtonActiveBackground = flooredFill
+            sidebarButtonActiveBorder = guardedAccent.withAlphaComponent(isDark ? 0.42 : 0.34)
+            sidebarButtonActiveText = foreground.ensuringTextContrast(
+                on: flooredFill.composited(over: sidebarSurface)
+            )
+        }
 
         openWithChromeBackground = openWithChromeBase.withAlphaComponent(
             reduceTransparency ? 0.96 : (background.isDarkThemeColor ? 0.60 : 0.82)
@@ -395,9 +468,83 @@ struct ZenttyTheme: Equatable {
         underlapShadow = NSColor.black.withAlphaComponent(background.isDarkThemeColor ? 0.12 : 0.06)
     }
 
+    /// Nudges an active-selection fill toward `foreground` until it clears
+    /// `minimumContrast` against the composited idle row, or a small iteration
+    /// bound is hit. A no-op when the fill already separates cleanly. Used only by
+    /// the vivid recipe (see the init note on why `.subtle` skips the floor).
+    private static func contrastFlooredActiveFill(
+        _ fill: NSColor,
+        idleComposited: NSColor,
+        sidebarSurface: NSColor,
+        foreground: NSColor,
+        minimumContrast: CGFloat
+    ) -> NSColor {
+        var result = fill
+        var iterations = 0
+        while result.composited(over: sidebarSurface).contrastRatio(against: idleComposited) < minimumContrast,
+              iterations < 10 {
+            result = result.mixed(towards: foreground, amount: 0.10)
+            iterations += 1
+        }
+        return result
+    }
+
+    /// Ensures the subtle-mode selected row stays perceptually distinct from the
+    /// idle row even when the theme's derivation collapses the two fills together.
+    ///
+    /// Uses sRGB distance (WCAG ratio is useless for near-black dark-on-dark) and
+    /// is a strict no-op above `minimumSeparation`, so healthy themes are untouched.
+    /// When collapsed it first widens the gap by nudging the fill toward
+    /// `separationTarget` (black on dark, white on light) — the direction that
+    /// preserves the selected<hover<idle ordering by construction — and, only if
+    /// the surface is too near-black/white to gain headroom, escalates the border
+    /// alpha toward `maximumBorderAlpha` (the `paneBorderFocused` level) instead.
+    private static func separatedSubtleSelection(
+        fill: NSColor,
+        idleComposited: NSColor,
+        sidebarSurface: NSColor,
+        separationTarget: NSColor,
+        baseBorderAlpha: CGFloat,
+        maximumBorderAlpha: CGFloat,
+        minimumSeparation: CGFloat = 0.012
+    ) -> (fill: NSColor, borderAlpha: CGFloat) {
+        func separation(_ candidate: NSColor) -> CGFloat {
+            candidate.composited(over: sidebarSurface).srgbDistance(to: idleComposited)
+        }
+
+        guard separation(fill) < minimumSeparation else {
+            return (fill, baseBorderAlpha)
+        }
+
+        // Remedy a: widen the fill gap along the ordering-preserving axis.
+        var result = fill
+        var iterations = 0
+        while separation(result) < minimumSeparation, iterations < 8 {
+            let nudged = result.mixed(towards: separationTarget, amount: 0.12)
+            // Stop when there is no headroom left (surface already near-black/white).
+            guard separation(nudged) - separation(result) > 0.0005 else {
+                break
+            }
+            result = nudged
+            iterations += 1
+        }
+
+        let finalSeparation = separation(result)
+        guard finalSeparation < minimumSeparation else {
+            return (result, baseBorderAlpha)
+        }
+
+        // Remedy b: no fill headroom -> give the lane a visible accent outline,
+        // scaled by how collapsed it remains and capped at the focused-pane level.
+        let deficit = min(max((minimumSeparation - finalSeparation) / minimumSeparation, 0), 1)
+        let borderAlpha = baseBorderAlpha + (deficit * (maximumBorderAlpha - baseBorderAlpha))
+        return (result, borderAlpha)
+    }
+
     static func fallback(
         for appearance: NSAppearance?,
-        reduceTransparency: Bool = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+        reduceTransparency: Bool = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency,
+        sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis = .subtle
     ) -> ZenttyTheme {
         let isDarkMode = appearance?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let resolvedTheme = GhosttyResolvedTheme(
@@ -416,7 +563,11 @@ struct ZenttyTheme: Equatable {
             backgroundOpacity: isDarkMode ? 0.92 : 0.94,
             backgroundBlurRadius: 18
         )
-        return ZenttyTheme(resolvedTheme: resolvedTheme, reduceTransparency: reduceTransparency)
+        return ZenttyTheme(
+            resolvedTheme: resolvedTheme,
+            reduceTransparency: reduceTransparency,
+            sidebarSelectionEmphasis: sidebarSelectionEmphasis
+        )
     }
 }
 
@@ -500,6 +651,19 @@ extension NSColor {
         let lighter = max(perceivedLuminance, other.perceivedLuminance)
         let darker = min(perceivedLuminance, other.perceivedLuminance)
         return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    /// Euclidean distance in sRGB space. Unlike WCAG contrast ratio, this stays
+    /// meaningful for two near-black (or near-white) colors, so it is the right
+    /// tool for detecting when two sidebar-row fills have perceptually collapsed
+    /// into each other.
+    func srgbDistance(to other: NSColor) -> CGFloat {
+        let source = srgbClamped
+        let target = other.srgbClamped
+        let red = source.redComponent - target.redComponent
+        let green = source.greenComponent - target.greenComponent
+        let blue = source.blueComponent - target.blueComponent
+        return sqrt((red * red) + (green * green) + (blue * blue))
     }
 
     func ensuringTextContrast(on background: NSColor, minimum: CGFloat = 4.5) -> NSColor {

--- a/Zentty/UI/Theme/ThemeCoordinator.swift
+++ b/Zentty/UI/Theme/ThemeCoordinator.swift
@@ -51,6 +51,7 @@ final class ThemeCoordinator {
     private let themeResolver: GhosttyThemeResolver
     private let themeWatcher: GhosttyThemeWatcher
     private var systemAppearanceObserver: SystemAppearanceObserver?
+    private let sidebarSelectionEmphasisProvider: () -> AppConfig.Appearance.SidebarSelectionEmphasis
 
     // MARK: - Init
 
@@ -58,11 +59,13 @@ final class ThemeCoordinator {
         themeResolver: GhosttyThemeResolver = GhosttyThemeResolver(),
         themeWatcher: GhosttyThemeWatcher = GhosttyThemeWatcher(),
         initialTheme: ZenttyTheme = ZenttyTheme.fallback(for: nil),
-        distributedNotificationCenter: DistributedNotificationCenter = .default()
+        distributedNotificationCenter: DistributedNotificationCenter = .default(),
+        sidebarSelectionEmphasisProvider: @escaping () -> AppConfig.Appearance.SidebarSelectionEmphasis = { .subtle }
     ) {
         self.themeResolver = themeResolver
         self.themeWatcher = themeWatcher
         self.currentTheme = initialTheme
+        self.sidebarSelectionEmphasisProvider = sidebarSelectionEmphasisProvider
 
         themeWatcher.onChange = { [weak self] in
             self?.refreshTheme(for: NSApp.effectiveAppearance, animated: true, forceTerminalReload: true)
@@ -85,14 +88,17 @@ final class ThemeCoordinator {
     ///   to pick up, so we reload even when the resolved theme is unchanged.
     func refreshTheme(for appearance: NSAppearance, animated: Bool, forceTerminalReload: Bool = false) {
         let resolution = themeResolver.resolve(for: appearance)
+        let sidebarSelectionEmphasis = sidebarSelectionEmphasisProvider()
         let theme = resolution.map {
             ZenttyTheme(
                 resolvedTheme: $0.theme,
-                reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+                reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency,
+                sidebarSelectionEmphasis: sidebarSelectionEmphasis
             )
         } ?? ZenttyTheme.fallback(
             for: appearance,
-            reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+            reduceTransparency: NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency,
+            sidebarSelectionEmphasis: sidebarSelectionEmphasis
         )
 
         let didChange = theme != currentTheme

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -583,6 +583,58 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertEqual(store.current.updates.channel, .beta)
     }
 
+    func test_sidebar_selection_emphasis_round_trips_through_store() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        try store.update { config in
+            config.appearance.sidebarSelectionEmphasis = .vivid
+        }
+
+        let reloaded = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(reloaded.current.appearance.sidebarSelectionEmphasis, .vivid)
+    }
+
+    func test_default_sidebar_selection_emphasis_is_omitted_from_encoded_toml() {
+        let encoded = AppConfigTOML.encode(.default)
+        XCTAssertFalse(encoded.contains("sidebar_selection_emphasis"))
+
+        var vivid = AppConfig.default
+        vivid.appearance.sidebarSelectionEmphasis = .vivid
+        XCTAssertTrue(AppConfigTOML.encode(vivid).contains("sidebar_selection_emphasis = \"vivid\""))
+    }
+
+    func test_invalid_sidebar_selection_emphasis_falls_back_to_default() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        try """
+        [appearance]
+        sidebar_selection_emphasis = "neon"
+        """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+
+        XCTAssertEqual(
+            store.current.appearance.sidebarSelectionEmphasis,
+            AppConfig.Appearance.default.sidebarSelectionEmphasis
+        )
+    }
+
     func test_store_writes_shortcut_overrides_and_unbound_entries() throws {
         let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
         let store = AppConfigStore(

--- a/ZenttyLogicTests/AppearanceSettingsSectionViewControllerTests.swift
+++ b/ZenttyLogicTests/AppearanceSettingsSectionViewControllerTests.swift
@@ -25,12 +25,14 @@ final class AppearanceSettingsSectionViewControllerTests: AppKitTestCase {
             lightThemeName: nil
         )
         var syncOpenCodeThemeWithTerminal = false
+        var sidebarSelectionEmphasis: AppConfig.Appearance.SidebarSelectionEmphasis = .subtle
         private(set) var appliedThemes: [String] = []
         private(set) var appliedThemeSlots: [AppearanceThemeSlot] = []
         private(set) var appliedThemeModes: [AppConfig.Appearance.ThemeMode] = []
         private(set) var resetThemePreferencesCallCount = 0
         private(set) var appliedOpacities: [CGFloat] = []
         private(set) var appliedOpenCodeThemeSyncValues: [Bool] = []
+        private(set) var appliedSidebarSelectionEmphasisValues: [AppConfig.Appearance.SidebarSelectionEmphasis] = []
         private(set) var createSharedConfigCallCount = 0
 
         func applyTheme(_ name: String, presentingWindow _: NSWindow?) async {
@@ -63,6 +65,11 @@ final class AppearanceSettingsSectionViewControllerTests: AppKitTestCase {
         func applyOpenCodeThemeSync(_ enabled: Bool) async {
             syncOpenCodeThemeWithTerminal = enabled
             appliedOpenCodeThemeSyncValues.append(enabled)
+        }
+
+        func applySidebarSelectionEmphasis(_ emphasis: AppConfig.Appearance.SidebarSelectionEmphasis) async {
+            sidebarSelectionEmphasis = emphasis
+            appliedSidebarSelectionEmphasisValues.append(emphasis)
         }
 
         func createSharedConfig(presentingWindow _: NSWindow?) async {
@@ -568,6 +575,28 @@ final class AppearanceSettingsSectionViewControllerTests: AppKitTestCase {
         await waitForCondition { coordinator.appliedOpenCodeThemeSyncValues == [true] }
 
         XCTAssertEqual(coordinator.appliedOpenCodeThemeSyncValues, [true])
+    }
+
+    func testSidebarSelectionEmphasisReflectsCoordinatorState() {
+        let coordinator = StubConfigCoordinator()
+        coordinator.sidebarSelectionEmphasis = .vivid
+        let (controller, _, _) = makeController(configCoordinator: coordinator)
+
+        controller.loadViewIfNeeded()
+
+        XCTAssertEqual(controller.sidebarSelectionEmphasisForTesting, .vivid)
+    }
+
+    func testSidebarSelectionEmphasisSelectionCallsCoordinator() async {
+        let coordinator = StubConfigCoordinator()
+        let (controller, _, _) = makeController(configCoordinator: coordinator)
+
+        controller.loadViewIfNeeded()
+        controller.setSidebarSelectionEmphasisForTesting(.vivid)
+        await waitForCondition { coordinator.appliedSidebarSelectionEmphasisValues == [.vivid] }
+
+        XCTAssertEqual(coordinator.appliedSidebarSelectionEmphasisValues, [.vivid])
+        XCTAssertEqual(controller.sidebarSelectionEmphasisForTesting, .vivid)
     }
 
     func testConformsToSettingsAppearanceUpdating() {

--- a/ZenttyLogicTests/GhosttyAppearanceSettingsCoordinatorTests.swift
+++ b/ZenttyLogicTests/GhosttyAppearanceSettingsCoordinatorTests.swift
@@ -673,6 +673,24 @@ final class GhosttyAppearanceSettingsCoordinatorTests: AppKitTestCase {
         )
     }
 
+    func test_applySidebarSelectionEmphasis_persistsToConfigStoreOnly() async throws {
+        let store = makeConfigStore()
+        var reloadCount = 0
+        let coordinator = makeCoordinator(
+            store: store,
+            decisionProvider: { _ in .keepOnlyInZentty },
+            runtimeReload: { reloadCount += 1 }
+        )
+
+        XCTAssertEqual(coordinator.sidebarSelectionEmphasis, .subtle)
+
+        await coordinator.applySidebarSelectionEmphasis(.vivid)
+
+        XCTAssertEqual(coordinator.sidebarSelectionEmphasis, .vivid)
+        XCTAssertEqual(store.current.appearance.sidebarSelectionEmphasis, .vivid)
+        XCTAssertEqual(reloadCount, 0, "sidebar selection emphasis is a pure config-store mutation with no ghostty runtime reload")
+    }
+
     private func makeConfigStore() -> AppConfigStore {
         AppConfigStore(
             fileURL: temporaryDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathComponent("config.toml")

--- a/ZenttyLogicTests/GhosttyThemeResolverTests.swift
+++ b/ZenttyLogicTests/GhosttyThemeResolverTests.swift
@@ -623,6 +623,212 @@ final class GhosttyThemeResolverTests: AppKitTestCase {
         XCTAssertEqual(theme.sidebarGlassAppearance, .light)
     }
 
+    // MARK: - Sidebar selection emphasis (issue #51)
+
+    private func sidebarTheme(
+        background: String,
+        foreground: String,
+        cursor: String,
+        emphasis: AppConfig.Appearance.SidebarSelectionEmphasis,
+        palette: [Int: NSColor] = [:],
+        reduceTransparency: Bool = false
+    ) -> ZenttyTheme {
+        ZenttyTheme(
+            resolvedTheme: GhosttyResolvedTheme(
+                background: NSColor(hexString: background)!,
+                foreground: NSColor(hexString: foreground)!,
+                cursorColor: NSColor(hexString: cursor)!,
+                selectionBackground: nil,
+                selectionForeground: nil,
+                palette: palette,
+                backgroundOpacity: 0.9,
+                backgroundBlurRadius: 25
+            ),
+            reduceTransparency: reduceTransparency,
+            sidebarSelectionEmphasis: emphasis
+        )
+    }
+
+    /// Composited contrast between the selected and idle rows, as they actually
+    /// render (each fill flattened over the sidebar surface over the window).
+    private func selectionVsIdleContrast(_ theme: ZenttyTheme, background: String) -> CGFloat {
+        let bg = NSColor(hexString: background)!.srgbClamped
+        let surface = theme.sidebarBackground.composited(over: bg)
+        let active = theme.sidebarButtonActiveBackground.composited(over: surface)
+        let idle = theme.sidebarButtonInactiveBackground.composited(over: surface)
+        return active.contrastRatio(against: idle)
+    }
+
+    private func activeTextVsFillContrast(_ theme: ZenttyTheme, background: String) -> CGFloat {
+        let bg = NSColor(hexString: background)!.srgbClamped
+        let surface = theme.sidebarBackground.composited(over: bg)
+        let fill = theme.sidebarButtonActiveBackground.composited(over: surface)
+        return theme.sidebarButtonActiveText.contrastRatio(against: fill)
+    }
+
+    func test_subtle_emphasis_healthy_dark_theme_matches_shipped_selection_derivation() {
+        // Byte-for-byte regression guard: the safety floor must be a no-op in
+        // subtle mode on a normal dark theme (values captured from the shipped
+        // derivation, reduceTransparency = false).
+        let theme = sidebarTheme(
+            background: "#0A0C10", foreground: "#F0F3F6", cursor: "#71B7FF",
+            emphasis: .subtle
+        )
+
+        XCTAssertEqual(theme.sidebarButtonActiveBackground.themeToken, "#111316-620")
+        XCTAssertEqual(theme.sidebarButtonActiveBorder.themeToken, "#71B7FF-120")
+        XCTAssertEqual(theme.sidebarButtonActiveText.themeToken, "#F0F3F6-980")
+    }
+
+    func test_vivid_emphasis_dark_theme_pushes_selection_far_above_subtle_contrast() {
+        let subtle = sidebarTheme(
+            background: "#0A0C10", foreground: "#F0F3F6", cursor: "#71B7FF", emphasis: .subtle
+        )
+        let vivid = sidebarTheme(
+            background: "#0A0C10", foreground: "#F0F3F6", cursor: "#71B7FF", emphasis: .vivid
+        )
+
+        let subtleContrast = selectionVsIdleContrast(subtle, background: "#0A0C10")
+        let vividContrast = selectionVsIdleContrast(vivid, background: "#0A0C10")
+
+        // Subtle stays low (that is the #51 pain point); vivid is unmistakable.
+        XCTAssertLessThan(subtleContrast, 1.4)
+        XCTAssertGreaterThanOrEqual(vividContrast, 1.8)
+        XCTAssertGreaterThan(vividContrast, subtleContrast)
+
+        // The vivid fill reads as accent-tinted, not the near-black recessed fill.
+        let accent = NSColor(hexString: "#71B7FF")!
+        XCTAssertLessThan(
+            colorDistance(vivid.sidebarButtonActiveBackground, accent),
+            colorDistance(subtle.sidebarButtonActiveBackground, accent)
+        )
+
+        // Border matches the focused-pane treatment (accent at 0.42 on dark).
+        XCTAssertEqual(vivid.sidebarButtonActiveBorder.srgbClamped.alphaComponent, 0.42, accuracy: 0.001)
+        XCTAssertEqual(
+            vivid.sidebarButtonActiveBorder.srgbClamped.alphaComponent,
+            vivid.paneBorderFocused.srgbClamped.alphaComponent,
+            accuracy: 0.001
+        )
+
+        // Selected label stays legible on the stronger fill.
+        XCTAssertGreaterThanOrEqual(activeTextVsFillContrast(vivid, background: "#0A0C10"), 4.5)
+    }
+
+    func test_vivid_emphasis_light_theme_selection_is_legible_and_accent_bordered() {
+        let vivid = sidebarTheme(
+            background: "#F7FBFF", foreground: "#102030", cursor: "#2F74D0", emphasis: .vivid
+        )
+
+        XCTAssertGreaterThanOrEqual(selectionVsIdleContrast(vivid, background: "#F7FBFF"), 1.8)
+        XCTAssertGreaterThanOrEqual(activeTextVsFillContrast(vivid, background: "#F7FBFF"), 4.5)
+        // Focused-pane treatment on light is accent at 0.34.
+        XCTAssertEqual(vivid.sidebarButtonActiveBorder.srgbClamped.alphaComponent, 0.34, accuracy: 0.001)
+        XCTAssertEqual(
+            vivid.sidebarButtonActiveBorder.srgbClamped.alphaComponent,
+            vivid.paneBorderFocused.srgbClamped.alphaComponent,
+            accuracy: 0.001
+        )
+    }
+
+    func test_vivid_emphasis_survives_degenerate_accent_matching_background() {
+        // Cursor color == background: the raw accent would vanish into the
+        // sidebar. The guarded fallback (palette blue) keeps the selection visible.
+        let vivid = sidebarTheme(
+            background: "#1A1B26", foreground: "#C0CAF5", cursor: "#1A1B26",
+            emphasis: .vivid,
+            palette: [12: NSColor(hexString: "#7AA2F7")!]
+        )
+
+        XCTAssertGreaterThanOrEqual(selectionVsIdleContrast(vivid, background: "#1A1B26"), 1.8)
+        XCTAssertGreaterThanOrEqual(activeTextVsFillContrast(vivid, background: "#1A1B26"), 4.5)
+        XCTAssertNotEqual(
+            vivid.sidebarButtonActiveBackground.themeToken,
+            vivid.sidebarBackground.themeToken
+        )
+    }
+
+    func test_vivid_emphasis_survives_accent_and_palette_matching_background() {
+        // Even when both cursor and the palette blue collapse into the background,
+        // the foreground fallback keeps a visible, legible selection.
+        let vivid = sidebarTheme(
+            background: "#1A1B26", foreground: "#C0CAF5", cursor: "#1A1B26",
+            emphasis: .vivid,
+            palette: [12: NSColor(hexString: "#1B1C27")!]
+        )
+
+        XCTAssertGreaterThanOrEqual(selectionVsIdleContrast(vivid, background: "#1A1B26"), 1.6)
+        XCTAssertGreaterThanOrEqual(activeTextVsFillContrast(vivid, background: "#1A1B26"), 4.5)
+    }
+
+    private func selectionVsIdleSeparation(_ theme: ZenttyTheme, background: String) -> CGFloat {
+        let bg = NSColor(hexString: background)!.srgbClamped
+        let surface = theme.sidebarBackground.composited(over: bg)
+        let active = theme.sidebarButtonActiveBackground.composited(over: surface)
+        let idle = theme.sidebarButtonInactiveBackground.composited(over: surface)
+        return active.srgbDistance(to: idle)
+    }
+
+    func test_subtle_guard_is_noop_on_healthy_light_theme() {
+        // Healthy light theme: separation is well above the guard threshold, so the
+        // fill is untouched and the border stays at the whisper base alpha (0.10).
+        let theme = sidebarTheme(
+            background: "#F7FBFF", foreground: "#102030", cursor: "#2F74D0", emphasis: .subtle
+        )
+
+        XCTAssertGreaterThanOrEqual(selectionVsIdleSeparation(theme, background: "#F7FBFF"), 0.012)
+        XCTAssertEqual(theme.sidebarButtonActiveBorder.srgbClamped.alphaComponent, 0.10, accuracy: 0.001)
+    }
+
+    func test_subtle_guard_rescues_collapsed_dark_theme_by_widening_fill() {
+        // Low-contrast dark theme whose selected/idle fills collapse (~0.011 apart).
+        // Remedy A widens the fill along the darker axis; the border stays base.
+        let collapsed = sidebarTheme(
+            background: "#2A2A2A", foreground: "#323232", cursor: "#343434", emphasis: .subtle
+        )
+
+        XCTAssertGreaterThanOrEqual(selectionVsIdleSeparation(collapsed, background: "#2A2A2A"), 0.012)
+        // Fill headroom was enough, so the border is not escalated.
+        XCTAssertEqual(collapsed.sidebarButtonActiveBorder.srgbClamped.alphaComponent, 0.12, accuracy: 0.001)
+        // Selected stays the darkest row (ordering preserved by construction).
+        XCTAssertLessThan(
+            collapsed.sidebarButtonActiveBackground.perceivedLuminance,
+            collapsed.sidebarButtonInactiveBackground.perceivedLuminance
+        )
+    }
+
+    func test_subtle_guard_escalates_border_when_fill_has_no_headroom() {
+        // Pure-black theme: darkening the fill cannot create separation, so remedy B
+        // raises the accent border alpha toward the focused-pane level (0.42).
+        let collapsed = sidebarTheme(
+            background: "#000000", foreground: "#050505", cursor: "#000000", emphasis: .subtle
+        )
+
+        let borderAlpha = collapsed.sidebarButtonActiveBorder.srgbClamped.alphaComponent
+        XCTAssertGreaterThanOrEqual(borderAlpha, 0.30)
+        XCTAssertLessThanOrEqual(borderAlpha, 0.42)
+    }
+
+    func test_subtle_guard_escalated_border_stays_visible_when_accent_matches_background() {
+        // Same no-headroom theme as the escalation test, but with a black cursor
+        // color and a real palette blue: the escalated rescue border must not
+        // inherit the invisible raw accent — it should fall back through the
+        // guarded-accent chain (landing on palette blue) so the outline is visible.
+        let collapsed = sidebarTheme(
+            background: "#000000", foreground: "#050505", cursor: "#000000", emphasis: .subtle,
+            palette: [4: NSColor(hexString: "#4A8FD4")!, 12: NSColor(hexString: "#71B7FF")!]
+        )
+
+        let border = collapsed.sidebarButtonActiveBorder.srgbClamped
+        XCTAssertGreaterThanOrEqual(border.alphaComponent, 0.30)
+        let sidebarSurface = collapsed.sidebarBackground.composited(over: collapsed.windowBackground)
+        let opaqueBorder = border.withAlphaComponent(1)
+        XCTAssertGreaterThanOrEqual(
+            opaqueBorder.contrastRatio(against: sidebarSurface), 1.2,
+            "Escalated subtle rescue border must remain visible against the sidebar surface"
+        )
+    }
+
     private func colorDistance(_ lhs: NSColor, _ rhs: NSColor) -> CGFloat {
         let left = lhs.srgbClamped
         let right = rhs.srgbClamped

--- a/ZenttyLogicTests/SidebarWorklaneRowButtonColorTests.swift
+++ b/ZenttyLogicTests/SidebarWorklaneRowButtonColorTests.swift
@@ -213,6 +213,179 @@ final class SidebarWorklaneRowButtonColorTests: AppKitTestCase {
         XCTAssertLessThan(unfocusedShimmer.srgbClamped.alphaComponent, focusedShimmer.srgbClamped.alphaComponent)
     }
 
+    // MARK: - Vivid selected-row per-worklane color
+
+    func test_subtle_selected_chrome_with_lane_color_is_identity_dark() {
+        assertSubtleSelectedChromeIsIdentity(theme: makeTheme(dark: true, emphasis: .subtle))
+    }
+
+    func test_subtle_selected_chrome_with_lane_color_is_identity_light() {
+        assertSubtleSelectedChromeIsIdentity(theme: makeTheme(dark: false, emphasis: .subtle))
+    }
+
+    func test_vivid_selected_chrome_without_color_is_identity() {
+        let theme = makeTheme(dark: true, emphasis: .vivid)
+        let bg = NSColor(srgbRed: 0.2, green: 0.3, blue: 0.4, alpha: 0.9)
+        let border = NSColor(srgbRed: 0.5, green: 0.5, blue: 0.6, alpha: 0.42)
+        let text = NSColor.white
+
+        let chrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+            worklaneColor: nil,
+            activeBackground: bg,
+            activeBorder: border,
+            activeText: text,
+            theme: theme
+        )
+
+        assertColorsEqual(chrome.background, bg)
+        assertColorsEqual(chrome.border, border)
+        assertColorsEqual(chrome.text, text.srgbClamped)
+    }
+
+    func test_vivid_selected_chrome_with_lane_color_is_lane_tinted_dark() throws {
+        try assertVividLaneChrome(theme: makeTheme(dark: true, emphasis: .vivid), color: .blue)
+    }
+
+    func test_vivid_selected_chrome_with_lane_color_is_lane_tinted_light() throws {
+        try assertVividLaneChrome(theme: makeTheme(dark: false, emphasis: .vivid), color: .pink)
+    }
+
+    func test_vivid_selected_chrome_lane_fill_is_clearly_separated_from_idle() {
+        let theme = makeTheme(dark: true, emphasis: .vivid)
+        let chrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+            worklaneColor: .green,
+            activeBackground: theme.sidebarButtonActiveBackground,
+            activeBorder: theme.sidebarButtonActiveBorder,
+            activeText: theme.sidebarButtonActiveText,
+            theme: theme
+        )
+        let surface = theme.sidebarBackground.composited(over: theme.windowBackground)
+        let selected = chrome.background.composited(over: surface)
+        let idle = theme.sidebarButtonInactiveBackground.composited(over: surface)
+
+        XCTAssertGreaterThan(srgbDistance(selected, idle), 0.12)
+    }
+
+    func test_vivid_selected_chrome_text_stays_legible_on_lane_fill() throws {
+        for color in WorklaneColor.allCases {
+            for dark in [true, false] {
+                let theme = makeTheme(dark: dark, emphasis: .vivid)
+                let chrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+                    worklaneColor: color,
+                    activeBackground: theme.sidebarButtonActiveBackground,
+                    activeBorder: theme.sidebarButtonActiveBorder,
+                    activeText: theme.sidebarButtonActiveText,
+                    theme: theme
+                )
+                let surface = theme.sidebarBackground.composited(over: theme.windowBackground)
+                let fill = chrome.background.composited(over: surface)
+                XCTAssertGreaterThanOrEqual(
+                    chrome.text.contrastRatio(against: fill),
+                    4.5,
+                    "Lane \(color.rawValue) (dark=\(dark)) selected text must clear WCAG AA on its fill"
+                )
+            }
+        }
+    }
+
+    func test_vivid_active_lane_row_background_is_lane_tinted_and_differs_from_idle() throws {
+        let theme = makeTheme(dark: true, emphasis: .vivid)
+        let activeRow = makeRow()
+        activeRow.configure(with: makeSummary(color: .blue, isActive: true), theme: theme, animated: false)
+        let idleRow = makeRow()
+        idleRow.configure(with: makeSummary(color: .blue, isActive: false), theme: theme, animated: false)
+
+        let activeBackground = try XCTUnwrap(activeRow.debugSnapshotForTesting.backgroundColor)
+        let idleBackground = try XCTUnwrap(idleRow.debugSnapshotForTesting.backgroundColor)
+
+        let laneHue = try XCTUnwrap(hsbComponents(WorklaneColor.blue.tint(alpha: 1))).hue
+        let activeHue = try XCTUnwrap(hsbComponents(activeBackground)).hue
+        XCTAssertEqual(activeHue, laneHue, accuracy: 0.06)
+        XCTAssertGreaterThan(srgbDistance(activeBackground, idleBackground), 0.1)
+    }
+
+    private func assertSubtleSelectedChromeIsIdentity(theme: ZenttyTheme) {
+        let bg = NSColor(srgbRed: 0.11, green: 0.22, blue: 0.33, alpha: 0.88)
+        let border = NSColor(srgbRed: 0.4, green: 0.5, blue: 0.6, alpha: 0.1)
+        let text = NSColor(srgbRed: 0.95, green: 0.96, blue: 0.97, alpha: 1)
+
+        let chrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+            worklaneColor: .red,
+            activeBackground: bg,
+            activeBorder: border,
+            activeText: text,
+            theme: theme
+        )
+
+        assertColorsEqual(chrome.background, bg)
+        assertColorsEqual(chrome.border, border)
+        assertColorsEqual(chrome.text, text.srgbClamped)
+    }
+
+    private func assertVividLaneChrome(theme: ZenttyTheme, color: WorklaneColor) throws {
+        let chrome = SidebarWorklaneRowStyleResolver.selectedRowChrome(
+            worklaneColor: color,
+            activeBackground: theme.sidebarButtonActiveBackground,
+            activeBorder: theme.sidebarButtonActiveBorder,
+            activeText: theme.sidebarButtonActiveText,
+            theme: theme
+        )
+
+        let laneHue = try XCTUnwrap(hsbComponents(color.tint(alpha: 1))).hue
+        let fillHue = try XCTUnwrap(hsbComponents(chrome.background)).hue
+        XCTAssertEqual(fillHue, laneHue, accuracy: 0.06)
+
+        let borderHue = try XCTUnwrap(hsbComponents(chrome.border)).hue
+        XCTAssertEqual(borderHue, laneHue, accuracy: 0.06)
+        XCTAssertEqual(chrome.border.alphaComponent, WorklaneColor.Alpha.focusedBorder, accuracy: 0.001)
+
+        // Fill reads as a real, near-opaque tint (not the low-alpha wash).
+        XCTAssertGreaterThan(chrome.background.alphaComponent, 0.9)
+    }
+
+    private func makeTheme(
+        dark: Bool,
+        emphasis: AppConfig.Appearance.SidebarSelectionEmphasis
+    ) -> ZenttyTheme {
+        ZenttyTheme(
+            resolvedTheme: GhosttyResolvedTheme(
+                background: NSColor(hexString: dark ? "#0A0C10" : "#FBFBFD")!,
+                foreground: NSColor(hexString: dark ? "#F0F3F6" : "#1A1C1F")!,
+                cursorColor: NSColor(hexString: dark ? "#71B7FF" : "#3366CC")!,
+                selectionBackground: nil,
+                selectionForeground: nil,
+                palette: [:],
+                backgroundOpacity: dark ? 0.9 : 1.0,
+                backgroundBlurRadius: 25
+            ),
+            reduceTransparency: false,
+            sidebarSelectionEmphasis: emphasis
+        )
+    }
+
+    private func srgbDistance(_ lhs: NSColor, _ rhs: NSColor) -> CGFloat {
+        let a = lhs.srgbClamped
+        let b = rhs.srgbClamped
+        let dr = a.redComponent - b.redComponent
+        let dg = a.greenComponent - b.greenComponent
+        let db = a.blueComponent - b.blueComponent
+        return (dr * dr + dg * dg + db * db).squareRoot()
+    }
+
+    private func assertColorsEqual(
+        _ lhs: NSColor,
+        _ rhs: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let a = lhs.srgbClamped
+        let b = rhs.srgbClamped
+        XCTAssertEqual(a.redComponent, b.redComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(a.greenComponent, b.greenComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(a.blueComponent, b.blueComponent, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(a.alphaComponent, b.alphaComponent, accuracy: 0.001, file: file, line: line)
+    }
+
     private func makeRow(width: CGFloat = 280, height: CGFloat = 72) -> SidebarWorklaneRowButton {
         let row = SidebarWorklaneRowButton(
             worklaneID: WorklaneID("worklane-main"),

--- a/ZenttyLogicTests/ThemeCoordinatorTests.swift
+++ b/ZenttyLogicTests/ThemeCoordinatorTests.swift
@@ -51,6 +51,24 @@ final class ThemeCoordinatorTests: AppKitTestCase {
         XCTAssertEqual(terminalReloadCount, 1)
     }
 
+    func test_refreshTheme_threads_sidebar_selection_emphasis_from_provider() throws {
+        let appearance = try XCTUnwrap(NSAppearance(named: .darkAqua))
+        let configURL = directoryURL.appendingPathComponent("ghostty-config")
+        var emphasis: AppConfig.Appearance.SidebarSelectionEmphasis = .subtle
+        let coordinator = ThemeCoordinator(
+            themeResolver: GhosttyThemeResolver(configURL: configURL, additionalThemeDirectories: []),
+            initialTheme: ZenttyTheme.fallback(for: appearance),
+            sidebarSelectionEmphasisProvider: { emphasis }
+        )
+
+        coordinator.refreshTheme(for: appearance, animated: false)
+        XCTAssertEqual(coordinator.currentTheme.sidebarSelectionEmphasis, .subtle)
+
+        emphasis = .vivid
+        coordinator.refreshTheme(for: appearance, animated: false)
+        XCTAssertEqual(coordinator.currentTheme.sidebarSelectionEmphasis, .vivid)
+    }
+
     private func makeCoordinator(initialTheme: ZenttyTheme) -> ThemeCoordinator {
         let configURL = directoryURL.appendingPathComponent("ghostty-config")
         return ThemeCoordinator(


### PR DESCRIPTION
## Summary

The active worklane in the sidebar was hard to spot at a glance. On dark themes the selected row is derived by mixing the background toward black while idle rows lighten toward the foreground, and on themes with a compressed background range (Cutie Pro in the report) the two land on nearly the same color. Fixes #51.

This adds a "Sidebar selection" setting to Appearance with two modes:

- **Subtle** (default): the current quiet look, unchanged on every healthy theme.
- **Vivid**: the selected row gets an accent-tinted fill and a border with the exact treatment the focused pane border uses, so the sidebar and the canvas agree on what "focused" looks like. When a worklane has a color assigned, that color takes over as the highlight, mirroring the existing pane-border precedence.

Both modes work in light and dark, and both are protected against degenerate themes:

- Vivid guards the accent (cursor color): if it is invisible against the sidebar it falls back through palette blue, then a foreground mix. A WCAG contrast floor of 1.4 backs it up. Measured active-vs-idle contrast lands at 2.4 on the default dark theme and 2.0 on light, versus roughly 1.02 today.
- Subtle gets a separation guard that fixes the reported bug without changing the default look. It uses perceptual sRGB distance rather than a WCAG ratio, because near-black fills all cluster around a 1.02 ratio regardless of how distinct they look, and forcing a ratio floor would invert subtle's selected-darkest ordering. Collapsed themes get the fill nudged along the ordering-preserving axis; when the background is too close to pure black for that to help, the active border escalates toward focused-pane strength instead.

## Implementation notes

The emphasis value lives in `AppConfig.Appearance` (TOML key `sidebar_selection_emphasis`), is threaded into `ZenttyTheme.init` via a provider closure on `ThemeCoordinator`, and is stored on the theme itself so the sidebar row chrome can branch on it without extra plumbing. Changing the setting re-themes live through the existing appearance diff in `RootViewController`. The settings card reuses the option-tile pattern from the theme-mode picker, with a small drawn preview of each mode.

## Testing

3661 ZenttyLogicTests pass. New coverage: byte-identity regression for subtle on healthy themes, the compressed-theme rescue paths (fill nudge and border escalation, including a black-accent theme where the rescue border must fall back to palette blue), vivid contrast and text legibility on light and dark, worklane-color fills across all 12 colors in both appearances, TOML round-trip with invalid-value fallback, and provider threading through `ThemeCoordinator`.
