### PR TITLE
fix(menubar): keep dropdown row labels correct after theme switch

### DIFF
--- a/Zentty/UI/MenuBar/MenuBarStatusController.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusController.swift
@@ -31,6 +31,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
     private var latestFleetSummary = MenuBarFleetSummary.from(snapshots: [])
     private var latestPresentation: MenuBarStatusPresentation?
     private var isMenuOpen = false
+    private var systemAppearanceObserver: NSObjectProtocol?
 
     init(
         configStore: AppConfigStore,
@@ -62,10 +63,12 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
         item.menu = menu
         statusItem = item
         isStarted = true
+        startObservingSystemAppearance()
         refresh()
     }
 
     func stop() {
+        stopObservingSystemAppearance()
         for entry in subscriptions.values {
             entry.store.unsubscribe(entry.subscription)
         }
@@ -203,12 +206,53 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
         }
     }
 
+    private func startObservingSystemAppearance() {
+        guard systemAppearanceObserver == nil else { return }
+        // Eagerly sync menu.appearance when the system theme flips so the first
+        // click after a light/dark switch does not open against a stale appearance.
+        systemAppearanceObserver = DistributedNotificationCenter.default().addObserver(
+            forName: Notification.Name("AppleInterfaceThemeChangedNotification"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleSystemAppearanceDidChange()
+            }
+        }
+    }
+
+    private func stopObservingSystemAppearance() {
+        if let systemAppearanceObserver {
+            DistributedNotificationCenter.default().removeObserver(systemAppearanceObserver)
+            self.systemAppearanceObserver = nil
+        }
+    }
+
+    private func handleSystemAppearanceDidChange() {
+        guard isStarted else { return }
+        menu.appearance = Self.systemMenuAppearance()
+        // Status-item icon also follows appearance (template rendering); refresh it.
+        latestPresentation = nil
+        refresh()
+        if isMenuOpen {
+            rebuildMenu()
+        }
+    }
+
     private static func systemMenuAppearance() -> NSAppearance? {
-        let globalStyle = (
-            UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleInterfaceStyle"] as? String
-        )
-        let appStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-        let isDark = (globalStyle ?? appStyle) == "Dark"
+        // Prefer the live effective appearance. UserDefaults `AppleInterfaceStyle`
+        // can lag a beat after a system theme switch — exactly when the first
+        // menu open used to paint custom rows with the wrong ink.
+        let isDark: Bool
+        if let app = NSApp {
+            isDark = MenuBarStatusPalette.isDark(app.effectiveAppearance)
+        } else {
+            let globalStyle = (
+                UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleInterfaceStyle"] as? String
+            )
+            let appStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+            isDark = (globalStyle ?? appStyle) == "Dark"
+        }
         return NSAppearance(named: isDark ? .darkAqua : .aqua)
     }
 

--- a/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
@@ -297,6 +297,11 @@ private final class MenuBarAgentRowView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
+        // Keep title/context/age locked to the menu appearance captured at rebuild.
+        // After a system theme switch, AppKit can flip this row's effectiveAppearance
+        // before the next menuNeedsUpdate; dynamic semantic colors would then render
+        // light-mode ink on dark menu chrome (or the reverse) on the first open.
+        applyLabelColors()
         configurePill()
     }
 
@@ -371,15 +376,15 @@ private final class MenuBarAgentRowView: NSView {
         titleLabel.maximumNumberOfLines = 1
 
         contextLabel.font = .systemFont(ofSize: 11, weight: .regular)
-        contextLabel.textColor = .secondaryLabelColor
         contextLabel.lineBreakMode = .byTruncatingMiddle
         contextLabel.maximumNumberOfLines = 1
 
         ageLabel.font = .systemFont(ofSize: 11, weight: .regular)
-        ageLabel.textColor = .secondaryLabelColor
         ageLabel.alignment = .right
         ageLabel.lineBreakMode = .byTruncatingTail
         ageLabel.maximumNumberOfLines = 1
+
+        applyLabelColors()
 
         pillView.onProgressHoverEntered = { [weak self] in
             self?.setHovered(true)
@@ -399,11 +404,31 @@ private final class MenuBarAgentRowView: NSView {
         titleLabel.stringValue = snapshot.primaryText
         contextLabel.stringValue = snapshot.contextText ?? snapshot.agentTool.displayName
         ageLabel.stringValue = ageText(for: snapshot)
+        applyLabelColors()
         configurePill()
 
         setAccessibilityRole(.menuItem)
         setAccessibilityLabel(MenuBarStatusMenuBuilder.itemTitle(for: snapshot))
         setAccessibilityValue(snapshot.contextText)
+    }
+
+    /// Bake label colors against the menu appearance (not live effectiveAppearance).
+    /// Layer-backed custom menu rows otherwise resolve dynamic catalog colors against
+    /// a stale appearance on the first open after a system light/dark switch.
+    private func applyLabelColors() {
+        let appearance = menuAppearance ?? effectiveAppearance
+        titleLabel.textColor = Self.resolvedColor(.labelColor, appearance: appearance)
+        contextLabel.textColor = Self.resolvedColor(.secondaryLabelColor, appearance: appearance)
+        ageLabel.textColor = Self.resolvedColor(.secondaryLabelColor, appearance: appearance)
+    }
+
+    private static func resolvedColor(_ color: NSColor, appearance: NSAppearance?) -> NSColor {
+        guard let appearance else { return color }
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.deviceRGB) ?? color
+        }
+        return resolved
     }
 
     private func configurePill() {

--- a/ZenttyLogicTests/MenuBarStatusMenuBuilderTests.swift
+++ b/ZenttyLogicTests/MenuBarStatusMenuBuilderTests.swift
@@ -156,6 +156,82 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
         )
     }
 
+    func test_row_labels_stay_light_when_dark_menu_row_appearance_changes_after_rebuild() {
+        // After a system theme switch, AppKit can flip a custom menu row's
+        // effectiveAppearance before the next rebuild. Title/context/age must
+        // keep the menu's dark-mode label colors (same contract as the icon),
+        // or the first open renders near-black text on the dark menu chrome.
+        let menu = NSMenu()
+        menu.appearance = NSAppearance(named: .darkAqua)
+        let running = paneSnapshot(fleetState: .active, statusLabel: "Running")
+
+        MenuBarStatusMenuBuilder.rebuild(
+            menu: menu,
+            snapshots: [running],
+            fleetSummary: MenuBarFleetSummary.from(snapshots: [running]),
+            target: nil,
+            rowAction: #selector(NSObject.description),
+            settingsAction: #selector(NSObject.description)
+        )
+
+        let row = try! XCTUnwrap(menu.items[1].view)
+        row.appearance = NSAppearance(named: .aqua)
+        row.viewDidChangeEffectiveAppearance()
+
+        let labels = textFields(in: row)
+        let titleLabel = try! XCTUnwrap(labels.first { $0.stringValue == "Claude Code" })
+        let contextLabel = try! XCTUnwrap(labels.first { $0.stringValue == "zentty · main" })
+
+        assertResolvedLabelColor(
+            titleLabel.textColor,
+            matches: .labelColor,
+            appearance: .darkAqua,
+            expectLightInk: true
+        )
+        assertResolvedLabelColor(
+            contextLabel.textColor,
+            matches: .secondaryLabelColor,
+            appearance: .darkAqua,
+            expectLightInk: true
+        )
+    }
+
+    func test_row_labels_stay_dark_when_light_menu_row_appearance_changes_after_rebuild() {
+        let menu = NSMenu()
+        menu.appearance = NSAppearance(named: .aqua)
+        let running = paneSnapshot(fleetState: .active, statusLabel: "Running")
+
+        MenuBarStatusMenuBuilder.rebuild(
+            menu: menu,
+            snapshots: [running],
+            fleetSummary: MenuBarFleetSummary.from(snapshots: [running]),
+            target: nil,
+            rowAction: #selector(NSObject.description),
+            settingsAction: #selector(NSObject.description)
+        )
+
+        let row = try! XCTUnwrap(menu.items[1].view)
+        row.appearance = NSAppearance(named: .darkAqua)
+        row.viewDidChangeEffectiveAppearance()
+
+        let labels = textFields(in: row)
+        let titleLabel = try! XCTUnwrap(labels.first { $0.stringValue == "Claude Code" })
+        let contextLabel = try! XCTUnwrap(labels.first { $0.stringValue == "zentty · main" })
+
+        assertResolvedLabelColor(
+            titleLabel.textColor,
+            matches: .labelColor,
+            appearance: .aqua,
+            expectLightInk: false
+        )
+        assertResolvedLabelColor(
+            contextLabel.textColor,
+            matches: .secondaryLabelColor,
+            appearance: .aqua,
+            expectLightInk: false
+        )
+    }
+
     private func textFields(in view: NSView) -> [NSTextField] {
         view.subviews.reduce(into: (view as? NSTextField).map { [$0] } ?? []) { result, subview in
             result.append(contentsOf: textFields(in: subview))
@@ -242,6 +318,43 @@ final class MenuBarStatusMenuBuilderTests: XCTestCase {
         XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.001, file: file, line: line)
         XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.001, file: file, line: line)
         XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.001, file: file, line: line)
+    }
+
+    private func assertResolvedLabelColor(
+        _ color: NSColor?,
+        matches semantic: NSColor,
+        appearance named: NSAppearance.Name,
+        expectLightInk: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actual = try! XCTUnwrap(color, file: file, line: line).srgbClamped
+        let appearance = try! XCTUnwrap(NSAppearance(named: named), file: file, line: line)
+        var expected = semantic
+        appearance.performAsCurrentDrawingAppearance {
+            expected = semantic.usingColorSpace(.deviceRGB) ?? semantic
+        }
+        let expectedSRGB = expected.srgbClamped
+        XCTAssertEqual(actual.redComponent, expectedSRGB.redComponent, accuracy: 0.05, file: file, line: line)
+        XCTAssertEqual(actual.greenComponent, expectedSRGB.greenComponent, accuracy: 0.05, file: file, line: line)
+        XCTAssertEqual(actual.blueComponent, expectedSRGB.blueComponent, accuracy: 0.05, file: file, line: line)
+        if expectLightInk {
+            XCTAssertGreaterThan(
+                actual.perceivedLuminance,
+                0.55,
+                "Dark-menu row labels must stay light after a live appearance flip",
+                file: file,
+                line: line
+            )
+        } else {
+            XCTAssertLessThan(
+                actual.perceivedLuminance,
+                0.45,
+                "Light-menu row labels must stay dark after a live appearance flip",
+                file: file,
+                line: line
+            )
+        }
     }
 
     func test_itemTitle_uses_accessibility_summary() {


### PR DESCRIPTION
## Summary
- Custom menu bar rows were baking pill/icon colors against the menu appearance, but title/context labels still used dynamic system colors. After a light/dark switch, the first open could flip those labels to the wrong ink (near-black on dark chrome).
- Labels now resolve against the captured menu appearance, same as the icons/pills.
- Also sync `menu.appearance` eagerly on system theme change, and prefer `NSApp.effectiveAppearance` over laggy `AppleInterfaceStyle` defaults.

## Test plan
- [x] `MenuBarStatusMenuBuilderTests` (incl. new light/dark appearance-flip cases)
- [x] `MenuBarStatusPillViewTests` / `MenuBarStatusPaletteTests`
- [ ] Manual: switch macOS light ↔ dark, open the status menu on the first click — row titles should match Settings/Quit contrast immediately


Made with [Cursor](https://cursor.com)