### PR TITLE
Declare local network access for terminal processes

### DIFF
--- a/Zentty/Info.plist
+++ b/Zentty/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GlitchTipDSN</key>
 	<string>$(GLITCHTIP_DSN)</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>A program running within Zentty would like to access devices on your local network.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>A program running within Zentty would like to use your microphone.</string>
 	<key>SUAutomaticallyUpdate</key>

--- a/ZenttyLogicTests/VendoredGhosttyResourcesTests.swift
+++ b/ZenttyLogicTests/VendoredGhosttyResourcesTests.swift
@@ -61,7 +61,7 @@ final class VendoredGhosttyResourcesTests: XCTestCase {
         XCTAssertTrue(projectYAML.contains("rsync -a --delete \"${RESOURCES_SRC}/terminfo/\" \"${RESOURCES_DST}/terminfo/\""))
     }
 
-    func test_app_privacy_configuration_declares_microphone_access_for_terminal_voice_input() throws {
+    func test_app_privacy_configuration_declares_terminal_resource_access() throws {
         let repoRoot = repoRootURL()
         let entitlements = try propertyListDictionary(
             at: repoRoot.appendingPathComponent("Zentty/Zentty.entitlements")
@@ -71,6 +71,10 @@ final class VendoredGhosttyResourcesTests: XCTestCase {
         )
 
         XCTAssertEqual(entitlements["com.apple.security.device.audio-input"] as? Bool, true)
+        XCTAssertEqual(
+            infoPlist["NSLocalNetworkUsageDescription"] as? String,
+            "A program running within Zentty would like to access devices on your local network."
+        )
         XCTAssertEqual(
             infoPlist["NSMicrophoneUsageDescription"] as? String,
             "A program running within Zentty would like to use your microphone."

--- a/project.yml
+++ b/project.yml
@@ -123,6 +123,7 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundleIconFile: AppIcon
         GlitchTipDSN: $(GLITCHTIP_DSN)
+        NSLocalNetworkUsageDescription: A program running within Zentty would like to access devices on your local network.
         NSMicrophoneUsageDescription: A program running within Zentty would like to use your microphone.
         SUAutomaticallyUpdate: false
         SUEnableAutomaticChecks: true


### PR DESCRIPTION
## Summary

- declare `NSLocalNetworkUsageDescription` in the XcodeGen project specification
- regenerate the committed application `Info.plist`
- extend the existing privacy-configuration test to cover local-network access

## Why

On current macOS versions, commands launched inside a third-party terminal can be denied access to ordinary hosts on the directly attached local network when the containing app does not provide a local-network usage description. The command fails with `EHOSTUNREACH` before traffic is emitted, while the same command works from Terminal.app. Zentty also does not appear under **System Settings → Privacy & Security → Local Network**, so the user cannot grant it access.

Declaring `NSLocalNetworkUsageDescription` allows macOS to present the Local Network permission prompt and gives the user a durable toggle. This follows Apple’s local-network privacy guidance in [TN3179](https://developer.apple.com/documentation/Technotes/tn3179-understanding-local-network-privacy).

## Validation

- `xcodegen generate --spec project.yml`
- `plutil -lint Zentty/Info.plist`
- parsed `project.yml` and verified the generated plist value
- `git diff --check`

A full test/build was attempted with Xcode 27 beta 4 and the repository-pinned Zig 0.15.2. The GhosttyKit bootstrap stopped before Zentty compilation because the local Xcode installation lacks its optional Metal toolchain component and Zig 0.15.2’s bundled libc++ headers are not yet compatible with the macOS 27 SDK (`INFINITY` is undefined). The focused configuration validations above pass, but the updated XCTest was therefore not executed locally.

I have read CLA.md and agree to its terms.
