### PR TITLE
fix(tmux-compat): consume the -- end-of-options terminator (parser fix for #58)

### DIFF
--- a/Zentty/AppState/Agent/TmuxCompatArguments.swift
+++ b/Zentty/AppState/Agent/TmuxCompatArguments.swift
@@ -17,6 +17,16 @@ struct TmuxCompatArguments: Equatable {
 
         while index < arguments.count {
             let argument = arguments[index]
+            if argument == "--" {
+                // POSIX end-of-options terminator: consume `--` and treat every
+                // remaining argument as a positional verbatim. A tmux
+                // `split-window … -- <command>` relies on this so the command
+                // (e.g. the `cat` keep-alive placeholder) is not corrupted into
+                // the `-- cat` string that crashes the launched shell with
+                // `zsh: no such option: cat`. See dedene/zentty#58.
+                positionals.append(contentsOf: arguments[(index + 1)...])
+                break
+            }
             if valueFlags.contains(argument) {
                 if index + 1 < arguments.count {
                     valuesByFlag[argument] = arguments[index + 1]

--- a/ZenttyLogicTests/TmuxCompatArgumentsTests.swift
+++ b/ZenttyLogicTests/TmuxCompatArgumentsTests.swift
@@ -71,6 +71,35 @@ final class TmuxCompatArgumentsTests: XCTestCase {
         XCTAssertTrue(parsed.hasFlag("-P"))
     }
 
+    func test_parseTreatsDoubleDashAsEndOfOptionsTerminator() {
+        // A tmux `split-window … -- <command>` uses `--` to terminate options.
+        // The terminator must be consumed so the command (e.g. the `cat`
+        // keep-alive placeholder) survives intact instead of collapsing to the
+        // crashing `-- cat` string that dies with `zsh: no such option: cat`.
+        // Regression for dedene/zentty#58.
+        let parsed = TmuxCompatArguments.parse(
+            ["-d", "--", "cat"],
+            valueFlags: ["-c", "-F", "-l", "-t"],
+            boolFlags: ["-P", "-b", "-d", "-h", "-v"]
+        )
+
+        XCTAssertTrue(parsed.hasFlag("-d"))
+        XCTAssertEqual(parsed.positionals, ["cat"])
+    }
+
+    func test_parseStopsOptionProcessingAfterDoubleDash() {
+        // Everything after `--` is positional verbatim, even option-like tokens,
+        // so a command carrying its own flags is not mis-parsed.
+        let parsed = TmuxCompatArguments.parse(
+            ["--", "-c", "value"],
+            valueFlags: ["-c", "-F", "-l", "-t"],
+            boolFlags: ["-P", "-b", "-d", "-h", "-v"]
+        )
+
+        XCTAssertNil(parsed.value("-c"))
+        XCTAssertEqual(parsed.positionals, ["-c", "value"])
+    }
+
     func test_sendKeysTranslatesEnterToCarriageReturn() {
         XCTAssertEqual(
             TmuxCompatIPCHandler.sendKeysText(arguments: ["-t", "%pane", "claude", "Enter"], standardInput: nil),


### PR DESCRIPTION
## What

`TmuxCompatArguments.parse` did not treat a bare `--` as the POSIX end-of-options terminator — it fell through to `positionals.append`. A `tmux split-window … -- <command>` (agent-teams IPC) therefore parsed to `positionals == ["--", <command>]`, and the launched pane ran `zsh -lic '-- <command>'`, dying with `zsh: no such option: …`.

This PR consumes `--` and takes the remaining arguments as positionals verbatim (standard POSIX / tmux semantics).

## Scope — please read

This is a **narrow parser fix** and intentionally does **not close #58**.

It removes the crash and fixes any legitimately `--`-terminated split-window command (e.g. `split-window -- htop`). But it does **not** by itself restore agent-teams launch for the Claude Code `-- cat` placeholder flow: with `--` consumed, `commandText == "cat"` is non-empty, so `splitWindowStartupRequest` launches the placeholder immediately instead of returning `isLaunchDeferred`. The follow-up `send-keys` carrying the real command then reaches `launchDeferredPane`, which returns `false` for a non-deferred pane, and the command is typed into the live `cat` instead of exec'ing. Net: the loud crash becomes a silent no-op.

That launch-handshake behaviour touches the intended `split-window` → `send-keys` contract, so I've left it for a separate change and documented the full analysis in #58.

## Tests

Adds `test_parseTreatsDoubleDashAsEndOfOptionsTerminator` and `test_parseStopsOptionProcessingAfterDoubleDash` to `TmuxCompatArgumentsTests`.

Verified the parser in isolation via `swiftc` on the real source (RED→GREEN plus existing-behaviour regression checks); the full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
