### PR TITLE
Preserve dark text on transparent terminal backgrounds

### DIFF
--- a/Zentty/Terminal/LibghosttyRuntime.swift
+++ b/Zentty/Terminal/LibghosttyRuntime.swift
@@ -502,7 +502,9 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
             return nil
         }
 
-        var lines = "background-opacity = 0\n"
+        // Ghostty evaluates contrast against a fully transparent background as black,
+        // which can turn dark foregrounds white. Preserve theme colors on the app backdrop.
+        var lines = "background-opacity = 0\nminimum-contrast = 1\n"
 
         guard !userConfigContainsBackgroundBlur(userConfigContents) else {
             return lines

--- a/Zentty/Terminal/LibghosttyRuntime.swift
+++ b/Zentty/Terminal/LibghosttyRuntime.swift
@@ -503,7 +503,10 @@ final class LibghosttyRuntime: LibghosttyRuntimeProviding {
         }
 
         // Ghostty evaluates contrast against a fully transparent background as black,
-        // which can turn dark foregrounds white. Preserve theme colors on the app backdrop.
+        // which can turn dark foregrounds white. Unlike the other overrides in this file,
+        // this deliberately discards a user-set minimum-contrast: on the forced-transparent
+        // surface the contrast math runs against a background that is not actually visible,
+        // so honoring the user's value would apply a miscomputed adjustment, not their intent.
         var lines = "background-opacity = 0\nminimum-contrast = 1\n"
 
         guard !userConfigContainsBackgroundBlur(userConfigContents) else {

--- a/ZenttyLogicTests/LibghosttyRuntimeTests.swift
+++ b/ZenttyLogicTests/LibghosttyRuntimeTests.swift
@@ -185,15 +185,19 @@ final class LibghosttyRuntimeTests: XCTestCase {
         XCTAssertFalse(contents?.contains("window-padding-y") ?? true)
     }
 
-    func testTransparentBackgroundOverrideContents_forcesTransparentEmbeddedSurfaceAndAddsFallbackBlur() {
+    func testTransparentBackgroundOverrideContents_preservesThemeColorsOnTransparentSurface() {
         let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
             userConfigContents: """
             background-opacity = 0.95
+            minimum-contrast = 1.3
             theme = \(GhosttyThemeLibrary.fallbackPersistedThemeName)
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+        XCTAssertEqual(
+            contents,
+            "background-opacity = 0\nminimum-contrast = 1\nbackground-blur-radius = 20\n"
+        )
     }
 
     func testTransparentBackgroundOverrideContents_keepsTransparencyOverrideWhenBlurRadiusConfigured() {
@@ -204,7 +208,7 @@ final class LibghosttyRuntimeTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\n")
+        XCTAssertEqual(contents, "background-opacity = 0\nminimum-contrast = 1\n")
     }
 
     func testTransparentBackgroundOverrideContents_keepsTransparencyOverrideWhenLegacyBackgroundBlurConfigured() {
@@ -215,7 +219,7 @@ final class LibghosttyRuntimeTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\n")
+        XCTAssertEqual(contents, "background-opacity = 0\nminimum-contrast = 1\n")
     }
 
     func testTransparentBackgroundOverrideContents_skipsTransparencyWhenBackgroundImageConfigured() {
@@ -248,7 +252,10 @@ final class LibghosttyRuntimeTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+        XCTAssertEqual(
+            contents,
+            "background-opacity = 0\nminimum-contrast = 1\nbackground-blur-radius = 20\n"
+        )
     }
 
     func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageIsLaterCleared() {
@@ -259,7 +266,10 @@ final class LibghosttyRuntimeTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+        XCTAssertEqual(
+            contents,
+            "background-opacity = 0\nminimum-contrast = 1\nbackground-blur-radius = 20\n"
+        )
     }
 
     func testTransparentBackgroundOverrideContents_forcesTransparencyWhenBackgroundImageIsCommentedOut() {
@@ -269,7 +279,10 @@ final class LibghosttyRuntimeTests: XCTestCase {
             """
         )
 
-        XCTAssertEqual(contents, "background-opacity = 0\nbackground-blur-radius = 20\n")
+        XCTAssertEqual(
+            contents,
+            "background-opacity = 0\nminimum-contrast = 1\nbackground-blur-radius = 20\n"
+        )
     }
 
     func testPaddingPolicyOverrideContents_injectsDefaultsWhenKeysMissing() {

--- a/ZenttyLogicTests/LibghosttyRuntimeTests.swift
+++ b/ZenttyLogicTests/LibghosttyRuntimeTests.swift
@@ -185,7 +185,9 @@ final class LibghosttyRuntimeTests: XCTestCase {
         XCTAssertFalse(contents?.contains("window-padding-y") ?? true)
     }
 
-    func testTransparentBackgroundOverrideContents_preservesThemeColorsOnTransparentSurface() {
+    // Intentional: a user-set minimum-contrast is discarded on the forced-transparent
+    // surface, where Ghostty would evaluate it against a background that is not visible.
+    func testTransparentBackgroundOverrideContents_overridesUserConfiguredMinimumContrast() {
         let contents = LibghosttyRuntime.transparentBackgroundOverrideContents(
             userConfigContents: """
             background-opacity = 0.95


### PR DESCRIPTION
## Summary

- disable Ghostty's minimum-contrast adjustment when Zentty forces a fully transparent terminal background
- preserve dark foreground and ANSI colors on light themes
- cover the transparent override behavior with regression tests

## Root cause

Zentty forces embedded terminal surfaces to `background-opacity = 0`. Ghostty evaluates minimum contrast against the premultiplied transparent background, which behaves as black during that calculation. With `minimum-contrast > 1`, dark text can therefore be changed to white even when the visible app backdrop is light.

Since Ghostty cannot see the AppKit backdrop behind a fully transparent surface, Zentty now sets `minimum-contrast = 1` alongside its transparency override. Configurations with a background image still skip the transparency override entirely.

## Validation

- `LibghosttyRuntimeTests`: 34 passed, 0 failed
- visual verification with a light theme: default foreground and ANSI bright black render correctly while ANSI white remains distinct

I have read CLA.md and agree to its terms.
