### PR TITLE
fix(cursor): prevent terminal cursor flicker across panes

### DIFF
--- a/Zentty/AppState/Agent/TerminalMetadataChangeClassifier.swift
+++ b/Zentty/AppState/Agent/TerminalMetadataChangeClassifier.swift
@@ -246,6 +246,44 @@ enum TerminalMetadataChangeClassifier {
         realtimeAgentTitleSignature(value, recognizedTool: recognizedTool) != nil
     }
 
+    static func codexActivitySpinnerRange(in value: String) -> Range<String.Index>? {
+        var phaseStart = value.startIndex
+        while phaseStart < value.endIndex, value[phaseStart].isWhitespace {
+            phaseStart = value.index(after: phaseStart)
+        }
+
+        var phaseEnd = phaseStart
+        while phaseEnd < value.endIndex, value[phaseEnd].isLetter {
+            phaseEnd = value.index(after: phaseEnd)
+        }
+        let phase = value[phaseStart..<phaseEnd].lowercased()
+        guard ["working", "thinking", "starting"].contains(phase) else {
+            return nil
+        }
+
+        var spinnerStart = phaseEnd
+        guard spinnerStart < value.endIndex, value[spinnerStart].isWhitespace else {
+            return nil
+        }
+        while spinnerStart < value.endIndex, value[spinnerStart].isWhitespace {
+            spinnerStart = value.index(after: spinnerStart)
+        }
+        guard spinnerStart < value.endIndex else {
+            return nil
+        }
+
+        let spinnerEnd = value.index(after: spinnerStart)
+        let spinner = value[spinnerStart]
+        guard spinner.unicodeScalars.count == 1,
+              let scalar = spinner.unicodeScalars.first,
+              (0x2800...0x28FF).contains(scalar.value),
+              spinnerEnd == value.endIndex || value[spinnerEnd].isWhitespace else {
+            return nil
+        }
+
+        return spinnerStart..<spinnerEnd
+    }
+
     static func codexWaitingTitleKind(for value: String?) -> CodexWaitingTitleKind? {
         guard let rawNormalized = WorklaneContextFormatter.trimmed(value) else {
             return nil

--- a/Zentty/AppState/PaneDisplayIdentityResolver.swift
+++ b/Zentty/AppState/PaneDisplayIdentityResolver.swift
@@ -55,6 +55,27 @@ enum PaneDisplayIdentityResolver {
         return nil
     }
 
+    static func animatesLocalCodexSpinner(
+        pane: PaneState,
+        presentation: PanePresentationState,
+        metadata: TerminalMetadata?
+    ) -> Bool {
+        guard presentation.isWorking,
+              presentation.recognizedTool == .codex,
+              presentation.isRemotePane == false,
+              hasCustomTitle(for: pane) == false,
+              let title = WorklaneContextFormatter.trimmed(metadata?.title),
+              TerminalMetadataChangeClassifier.codexActivitySpinnerRange(in: title) != nil else {
+            return false
+        }
+
+        return primaryLabel(
+            pane: pane,
+            presentation: presentation,
+            metadata: metadata
+        ) == title
+    }
+
     private static func decomposedRememberedTitle(
         _ rememberedTitle: String,
         presentation: PanePresentationState

--- a/Zentty/AppState/WorklaneHeaderSummary.swift
+++ b/Zentty/AppState/WorklaneHeaderSummary.swift
@@ -24,7 +24,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     /// Custom worklane name, shown left of the proxy icon when set.
     var worklaneTitle: String?
     var focusedLabel: String?
-    var focusedPaneIsWorking: Bool
+    var focusedLabelAnimatesLocalCodexSpinner: Bool
     var remoteContextLabel: String?
     var cwdPath: String?
     var branch: String?
@@ -40,7 +40,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     init(
         worklaneTitle: String? = nil,
         focusedLabel: String?,
-        focusedPaneIsWorking: Bool = false,
+        focusedLabelAnimatesLocalCodexSpinner: Bool = false,
         remoteContextLabel: String? = nil,
         cwdPath: String? = nil,
         branch: String?,
@@ -52,7 +52,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     ) {
         self.worklaneTitle = worklaneTitle
         self.focusedLabel = focusedLabel
-        self.focusedPaneIsWorking = focusedPaneIsWorking
+        self.focusedLabelAnimatesLocalCodexSpinner = focusedLabelAnimatesLocalCodexSpinner
         self.remoteContextLabel = remoteContextLabel
         self.cwdPath = cwdPath
         self.branch = branch

--- a/Zentty/AppState/WorklaneHeaderSummary.swift
+++ b/Zentty/AppState/WorklaneHeaderSummary.swift
@@ -24,6 +24,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     /// Custom worklane name, shown left of the proxy icon when set.
     var worklaneTitle: String?
     var focusedLabel: String?
+    var focusedPaneIsWorking: Bool
     var remoteContextLabel: String?
     var cwdPath: String?
     var branch: String?
@@ -39,6 +40,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     init(
         worklaneTitle: String? = nil,
         focusedLabel: String?,
+        focusedPaneIsWorking: Bool = false,
         remoteContextLabel: String? = nil,
         cwdPath: String? = nil,
         branch: String?,
@@ -50,6 +52,7 @@ struct WorklaneChromeSummary: Equatable, Sendable {
     ) {
         self.worklaneTitle = worklaneTitle
         self.focusedLabel = focusedLabel
+        self.focusedPaneIsWorking = focusedPaneIsWorking
         self.remoteContextLabel = remoteContextLabel
         self.cwdPath = cwdPath
         self.branch = branch

--- a/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
+++ b/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
@@ -14,6 +14,7 @@ enum WorklaneHeaderSummaryBuilder {
         return WorklaneChromeSummary(
             worklaneTitle: worklane.title,
             focusedLabel: focusedLabel,
+            focusedPaneIsWorking: presentation?.isWorking ?? false,
             remoteContextLabel: remoteContextLabel,
             cwdPath: visibleLocalCwdPath(from: presentation),
             branch: branch,

--- a/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
+++ b/Zentty/AppState/WorklaneHeaderSummaryBuilder.swift
@@ -14,7 +14,13 @@ enum WorklaneHeaderSummaryBuilder {
         return WorklaneChromeSummary(
             worklaneTitle: worklane.title,
             focusedLabel: focusedLabel,
-            focusedPaneIsWorking: presentation?.isWorking ?? false,
+            focusedLabelAnimatesLocalCodexSpinner: focusedPaneContext.map {
+                PaneDisplayIdentityResolver.animatesLocalCodexSpinner(
+                    pane: $0.pane,
+                    presentation: $0.presentation,
+                    metadata: $0.metadata
+                )
+            } ?? false,
             remoteContextLabel: remoteContextLabel,
             cwdPath: visibleLocalCwdPath(from: presentation),
             branch: branch,

--- a/Zentty/AppState/WorklaneStore+Metadata.swift
+++ b/Zentty/AppState/WorklaneStore+Metadata.swift
@@ -48,11 +48,9 @@ extension WorklaneStore {
         // Volatile-title fast path. When the classifier recognizes a pure
         // supported-agent title tick (phase+subject signature unchanged, only
         // elapsed time differs), skip the full promotion / inference /
-        // normalization pipeline below and emit a surgical
-        // `.volatileAgentTitleUpdated` for the coordinator to apply a direct
-        // label update. The sidebar row and chrome focused label can read
-        // `metadata.title` directly for supported realtime agent titles, so
-        // storing the new metadata is enough for correct rendering.
+        // normalization pipeline below. Codex updates its spinner title at a
+        // high frequency, so store those ticks without repainting AppKit UI.
+        // Other supported agents retain the surgical realtime label update.
         if metadataChangeKind == .volatileTitleOnly,
            shouldTakeVolatileAgentTitleFastPath(
                 in: previousAuxiliaryState,
@@ -68,7 +66,11 @@ extension WorklaneStore {
             )
             worklane.auxiliaryStateByPaneID[paneID, default: PaneAuxiliaryState()].metadata = metadata
             worklanes[worklaneIndex] = worklane
-            emitVolatileAgentTitleUpdateIfAllowed(worklaneID: worklane.id, paneID: paneID)
+            handleVolatileAgentTitleUpdate(
+                worklaneID: worklane.id,
+                paneID: paneID,
+                metadata: metadata
+            )
             return
         }
 
@@ -249,14 +251,15 @@ extension WorklaneStore {
         )
     }
 
-    /// Emits a `.volatileAgentTitleUpdated` notification for realtime agent
-    /// title ticks. Hidden worklanes intentionally stay realtime so the
-    /// sidebar continues to feel active while background agents are working.
-    private func emitVolatileAgentTitleUpdateIfAllowed(
+    private func handleVolatileAgentTitleUpdate(
         worklaneID: WorklaneID,
-        paneID: PaneID
+        paneID: PaneID,
+        metadata: TerminalMetadata
     ) {
         terminalDiagnostics.recordStoreFastPath(paneID: paneID)
+        guard AgentToolRecognizer.recognize(metadata: metadata) != .codex else {
+            return
+        }
         notify(.volatileAgentTitleUpdated(worklaneID: worklaneID, paneID: paneID))
     }
 

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -1568,6 +1568,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     private var currentCursor: NSCursor = .iBeam
     private var cursorApplication: (NSCursor) -> Void = { $0.set() }
     private var mouseTrackingArea: NSTrackingArea?
+    private var cursorTrackingArea: NSTrackingArea?
     private var mouseInteractionSuppressionRects: [CGRect] = []
     private var activeSecondaryMouseRouting: SecondaryMouseRouting?
     private var forwardsActiveSecondaryMouseDrag = false
@@ -1653,14 +1654,25 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         if let existing = mouseTrackingArea {
             removeTrackingArea(existing)
         }
-        let area = NSTrackingArea(
+        if let existing = cursorTrackingArea {
+            removeTrackingArea(existing)
+        }
+        let mouseArea = NSTrackingArea(
             rect: .zero,
-            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate, .activeAlways, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
-        addTrackingArea(area)
-        mouseTrackingArea = area
+        let cursorArea = NSTrackingArea(
+            rect: .zero,
+            options: [.cursorUpdate, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(mouseArea)
+        addTrackingArea(cursorArea)
+        mouseTrackingArea = mouseArea
+        cursorTrackingArea = cursorArea
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -1690,11 +1702,6 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
             return
         }
         forwardMousePosition(event)
-    }
-
-    override func resetCursorRects() {
-        super.resetCursorRects()
-        addCursorRect(bounds, cursor: currentCursor)
     }
 
     override func cursorUpdate(with event: NSEvent) {
@@ -1732,11 +1739,37 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
 
         guard cursor != currentCursor else { return }
         currentCursor = cursor
-        window?.invalidateCursorRects(for: self)
+        applyCurrentCursorIfOwned()
     }
 
     func setCursorApplicationForTesting(_ application: @escaping (NSCursor) -> Void) {
         cursorApplication = application
+    }
+
+    func ownsCursor(at locationInView: CGPoint, hitView: NSView?) -> Bool {
+        guard bounds.contains(locationInView),
+              !isPointInsideSuppressedMouseRegion(locationInView),
+              let hitView
+        else {
+            return false
+        }
+
+        return hitView === self || hitView.isDescendant(of: self)
+    }
+
+    private func applyCurrentCursorIfOwned() {
+        guard let window, let contentView = window.contentView else { return }
+        let locationInWindow = window.mouseLocationOutsideOfEventStream
+        let locationInView = convert(locationInWindow, from: nil)
+        let locationInContentView = contentView.convert(locationInWindow, from: nil)
+        guard ownsCursor(
+            at: locationInView,
+            hitView: contentView.hitTest(locationInContentView)
+        ) else {
+            return
+        }
+
+        cursorApplication(currentCursor)
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -451,9 +451,16 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     private let scrollView: LibghosttyScrollView
     private let overlayHostView = LibghosttyOverlayHostView()
     private let frameMeterSampler: any TerminalScrollFrameSampling
+    private let currentSystemCursorProvider: () -> NSCursor?
     private let frameMeterHUDView = TerminalFrameMeterHUDView(frame: NSRect(x: 0, y: 0, width: 128, height: 48))
     private let documentView: NSView
     private let surfaceView: LibghosttyView
+    private var terminalCursor: NSCursor = .iBeam
+    private var retainedProgrammaticViewportCursor: NSCursor?
+    private var terminalCursorSuppressionRects: [CGRect] = []
+    private var pendingTerminalCursorRefresh: DispatchWorkItem?
+    private var isTerminalScrollCursorActive = false
+    private var isPointerInsideTerminal = false
     private var isLiveScrolling = false
     private var needsLiveScrollReconciliation = false
     private var pendingExplicitWheelScroll = false
@@ -525,12 +532,14 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         paneID: PaneID,
         diagnostics: TerminalDiagnostics,
         scrollFrameSampler: any TerminalScrollFrameSampling = TerminalScrollFrameSampler(),
-        frameMeterSampler: (any TerminalScrollFrameSampling)? = nil
+        frameMeterSampler: (any TerminalScrollFrameSampling)? = nil,
+        currentSystemCursorProvider: @escaping () -> NSCursor? = { NSCursor.currentSystem }
     ) {
         self.paneID = paneID
         self.diagnostics = diagnostics
         self.scrollFrameSampler = scrollFrameSampler
         self.surfaceView = surfaceView
+        self.currentSystemCursorProvider = currentSystemCursorProvider
         self.scrollView = LibghosttyScrollView()
         self.documentView = NSView(frame: .zero)
         self.frameMeterSampler = frameMeterSampler ?? TerminalScrollFrameSampler()
@@ -552,13 +561,17 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         surfaceView.onExplicitWheelScroll = { [weak self] in
             self?.cancelBackingMetricsTransition()
             self?.pendingExplicitWheelScroll = true
+            self?.noteTerminalScrollCursorActivity()
         }
         surfaceView.onSelectionDragStateDidChange = { [weak self] isActive in
             self?.selectionAutoscrollController.setSelectionDragActive(isActive)
             self?.updateSelectionAutoscrollTimerState()
         }
         surfaceView.onMouseLocationDidChange = { [weak self] location in
-            self?.selectionAutoscrollController.setMouseLocation(location)
+            self?.handleSurfaceMouseLocationDidChange(location)
+        }
+        surfaceView.onMouseMotionDidOccur = { [weak self] in
+            self?.handleSurfaceMouseMotionDidOccur()
         }
         surfaceView.onBackingPropertiesDidChange = { [weak self] in
             self?.beginBackingMetricsReconciliation()
@@ -581,6 +594,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         overlayHostView.frame = bounds
         addSubview(overlayHostView)
         overlayHostView.addSubview(frameMeterHUDView)
+        terminalCursor = surfaceView.mouseCursorForHost
         syncFrameMeterHUDVisibility()
 
         surfaceView.scrollbarHandler = self
@@ -626,6 +640,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     deinit {
         NotificationCenter.default.removeObserver(self)
         MainActorShim.assumeIsolated {
+            pendingTerminalCursorRefresh?.cancel()
             surfaceView.onBackingPropertiesDidChange = nil
             surfaceView.onCellSizeDidChange = nil
             scrollFrameSampler.stop()
@@ -636,6 +651,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         super.viewWillMove(toWindow: newWindow)
         if newWindow == nil {
+            isTerminalScrollCursorActive = false
             stopSmoothScrollFrameSampling()
             stopFrameMeterSampling()
             stopSelectionAutoscrollTimer()
@@ -709,8 +725,161 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     }
 
     func setMouseInteractionSuppressionRects(_ rects: [CGRect]) {
+        if terminalCursorSuppressionRects != rects {
+            terminalCursorSuppressionRects = rects
+            window?.invalidateCursorRects(for: self)
+        }
         let surfaceRects = rects.map { surfaceView.convert($0, from: self) }
         surfaceView.setMouseInteractionSuppressionRects(surfaceRects)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        for rect in terminalCursorRects {
+            addCursorRect(rect, cursor: displayedTerminalCursor)
+        }
+    }
+
+    private var displayedTerminalCursor: NSCursor {
+        if isTerminalScrollCursorActive {
+            return .arrow
+        }
+        return retainedProgrammaticViewportCursor ?? terminalCursor
+    }
+
+    private func handleSurfaceMouseLocationDidChange(_ location: CGPoint?) {
+        isPointerInsideTerminal = location != nil
+        selectionAutoscrollController.setMouseLocation(location)
+        if location == nil {
+            let hadRetainedCursor = retainedProgrammaticViewportCursor != nil
+            retainedProgrammaticViewportCursor = nil
+            if hadRetainedCursor {
+                window?.invalidateCursorRects(for: self)
+            }
+            return
+        }
+        guard !isTerminalScrollCursorActive, retainedProgrammaticViewportCursor == nil else { return }
+        handleTerminalPointerActivity(location)
+    }
+
+    private func handleSurfaceMouseMotionDidOccur() {
+        let isRestoringStableCursor = isTerminalScrollCursorActive
+            || retainedProgrammaticViewportCursor != nil
+        guard isRestoringStableCursor else { return }
+        retainedProgrammaticViewportCursor = nil
+        handleTerminalPointerActivity(
+            surfaceView.lastMouseLocationInView,
+            restoringStableCursor: true
+        )
+    }
+
+    private func handleTerminalPointerActivity(
+        _ location: CGPoint?,
+        restoringStableCursor: Bool = false
+    ) {
+        pendingTerminalCursorRefresh?.cancel()
+        pendingTerminalCursorRefresh = nil
+        guard location != nil else { return }
+
+        setTerminalCursor(
+            surfaceView.mouseCursorForHost,
+            restoringStableCursor: isTerminalScrollCursorActive || restoringStableCursor
+        )
+
+        let refresh = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingTerminalCursorRefresh = nil
+            self.setTerminalCursor(self.surfaceView.mouseCursorForHost)
+        }
+        pendingTerminalCursorRefresh = refresh
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.terminalCursorRefreshDelay,
+            execute: refresh
+        )
+    }
+
+    private func setTerminalCursor(
+        _ cursor: NSCursor,
+        restoringStableCursor: Bool = false
+    ) {
+        guard terminalCursor !== cursor || restoringStableCursor else { return }
+        terminalCursor = cursor
+        if restoringStableCursor {
+            isTerminalScrollCursorActive = false
+        }
+        guard !isTerminalScrollCursorActive else { return }
+        window?.invalidateCursorRects(for: self)
+    }
+
+    private static let terminalCursorRefreshDelay: TimeInterval = 0.1
+
+    private func beginTerminalScrollCursorActivity() {
+        guard !isTerminalScrollCursorActive else { return }
+        retainedProgrammaticViewportCursor = nil
+        isTerminalScrollCursorActive = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    private func noteTerminalScrollCursorActivity() {
+        beginTerminalScrollCursorActivity()
+    }
+
+    private func retainCursorForProgrammaticViewportChange() {
+        guard isPointerInsideTerminal,
+              !isTerminalScrollCursorActive,
+              retainedProgrammaticViewportCursor == nil
+        else {
+            return
+        }
+        retainedProgrammaticViewportCursor = currentSystemCursorProvider() ?? NSCursor.current
+    }
+
+    private var terminalCursorRects: [CGRect] {
+        terminalCursorSuppressionRects.reduce(into: [bounds]) { rects, suppressionRect in
+            rects = rects.flatMap { Self.subtract(suppressionRect, from: $0) }
+        }
+    }
+
+    private static func subtract(_ excludedRect: CGRect, from sourceRect: CGRect) -> [CGRect] {
+        let intersection = sourceRect.intersection(excludedRect)
+        guard !intersection.isNull, !intersection.isEmpty else {
+            return [sourceRect]
+        }
+
+        var remaining: [CGRect] = []
+        if intersection.minY > sourceRect.minY {
+            remaining.append(CGRect(
+                x: sourceRect.minX,
+                y: sourceRect.minY,
+                width: sourceRect.width,
+                height: intersection.minY - sourceRect.minY
+            ))
+        }
+        if intersection.maxY < sourceRect.maxY {
+            remaining.append(CGRect(
+                x: sourceRect.minX,
+                y: intersection.maxY,
+                width: sourceRect.width,
+                height: sourceRect.maxY - intersection.maxY
+            ))
+        }
+        if intersection.minX > sourceRect.minX {
+            remaining.append(CGRect(
+                x: sourceRect.minX,
+                y: intersection.minY,
+                width: intersection.minX - sourceRect.minX,
+                height: intersection.height
+            ))
+        }
+        if intersection.maxX < sourceRect.maxX {
+            remaining.append(CGRect(
+                x: intersection.maxX,
+                y: intersection.minY,
+                width: sourceRect.maxX - intersection.maxX,
+                height: intersection.height
+            ))
+        }
+        return remaining
     }
 
     func applyScrollbarUpdate(_ update: LibghosttySurfaceScrollbarUpdate) {
@@ -754,6 +923,40 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         surfaceView
     }
 
+#if DEBUG
+    var terminalCursorRectsForTesting: [CGRect] {
+        terminalCursorRects
+    }
+
+    var terminalCursorOwnerForTesting: NSView {
+        self
+    }
+
+    var displayedTerminalCursorForTesting: NSCursor {
+        displayedTerminalCursor
+    }
+
+    func syncTerminalCursorForPointerActivityForTesting() {
+        handleTerminalPointerActivity(.zero)
+    }
+
+    func syncTerminalCursorForPointerEntryForTesting() {
+        handleSurfaceMouseLocationDidChange(.zero)
+    }
+
+    func syncTerminalCursorForMouseMotionForTesting() {
+        let isRestoringStableCursor = isTerminalScrollCursorActive
+            || retainedProgrammaticViewportCursor != nil
+        retainedProgrammaticViewportCursor = nil
+        handleTerminalPointerActivity(.zero, restoringStableCursor: isRestoringStableCursor)
+    }
+
+    func cancelPendingTerminalCursorRefreshForTesting() {
+        pendingTerminalCursorRefresh?.cancel()
+        pendingTerminalCursorRefresh = nil
+    }
+#endif
+
     var debugFrameMeterHUDSnapshotForTesting: TerminalFrameMeterHUDView.Snapshot {
         frameMeterHUDView.snapshotForTesting
     }
@@ -767,6 +970,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     private func handleWillStartLiveScrollNotification(_ notification: Notification) {
         cancelBackingMetricsTransition()
         isLiveScrolling = true
+        beginTerminalScrollCursorActivity()
         startSmoothScrollFrameSamplingIfNeeded()
     }
 
@@ -1266,6 +1470,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         var autoScrollApplied = false
         var explicitScrollbarSyncAllowed: Bool?
         if abs(documentView.frame.height - targetDocumentHeight) > 0.5 {
+            retainCursorForProgrammaticViewportChange()
             documentView.frame.size.height = targetDocumentHeight
             didChangeGeometry = true
         }
@@ -1306,6 +1511,7 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
                     explicitScrollbarSyncAllowedNow
                 shouldAutoScroll = shouldAutoScrollNow
                 if shouldAutoScrollNow && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                    retainCursorForProgrammaticViewportChange()
                     performProgrammaticScrollUpdate {
                         scrollView.contentView.scroll(to: targetOrigin)
                     }
@@ -1521,6 +1727,85 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
 }
 
 final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiagnosticsContextConfiguring {
+    private enum MouseCursorStyle: Equatable {
+        case arrow
+        case pointingHand
+        case text
+        case crosshair
+        case openHand
+        case closedHand
+        case operationNotAllowed
+        case contextualMenu
+        case verticalText
+        case resizeHorizontal
+        case resizeVertical
+
+        init(shape: ghostty_action_mouse_shape_e) {
+            self = switch shape {
+            case GHOSTTY_MOUSE_SHAPE_POINTER:
+                .pointingHand
+            case GHOSTTY_MOUSE_SHAPE_TEXT:
+                .text
+            case GHOSTTY_MOUSE_SHAPE_CROSSHAIR:
+                .crosshair
+            case GHOSTTY_MOUSE_SHAPE_GRAB:
+                .openHand
+            case GHOSTTY_MOUSE_SHAPE_GRABBING:
+                .closedHand
+            case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED:
+                .operationNotAllowed
+            case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU:
+                .contextualMenu
+            case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT:
+                .verticalText
+            case GHOSTTY_MOUSE_SHAPE_E_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_COL_RESIZE:
+                .resizeHorizontal
+            case GHOSTTY_MOUSE_SHAPE_N_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
+                 GHOSTTY_MOUSE_SHAPE_ROW_RESIZE:
+                .resizeVertical
+            default:
+                .arrow
+            }
+        }
+
+        var cursor: NSCursor {
+            switch self {
+            case .arrow: .arrow
+            case .pointingHand: .pointingHand
+            case .text: .iBeam
+            case .crosshair: .crosshair
+            case .openHand: .openHand
+            case .closedHand: .closedHand
+            case .operationNotAllowed: .operationNotAllowed
+            case .contextualMenu: .contextualMenu
+            case .verticalText: .iBeamCursorForVerticalLayout
+            case .resizeHorizontal: .resizeLeftRight
+            case .resizeVertical: .resizeUpDown
+            }
+        }
+
+        var testingName: String {
+            switch self {
+            case .arrow: "arrow"
+            case .pointingHand: "pointingHand"
+            case .text: "text"
+            case .crosshair: "crosshair"
+            case .openHand: "openHand"
+            case .closedHand: "closedHand"
+            case .operationNotAllowed: "operationNotAllowed"
+            case .contextualMenu: "contextualMenu"
+            case .verticalText: "verticalText"
+            case .resizeHorizontal: "resizeHorizontal"
+            case .resizeVertical: "resizeVertical"
+            }
+        }
+    }
+
     private struct ViewportSignature: Equatable {
         let size: CGSize
         let scale: CGFloat
@@ -1565,10 +1850,10 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     private var markedTextStorage = ""
     private var markedTextSelection = NSRange(location: NSNotFound, length: 0)
     private var selectedTextStorageRange = NSRange(location: NSNotFound, length: 0)
-    private var currentCursor: NSCursor = .iBeam
-    private var cursorApplication: (NSCursor) -> Void = { $0.set() }
+    private var currentCursorStyle: MouseCursorStyle = .text
+    private var requestedCursorStyle: MouseCursorStyle = .text
+    private var pendingTextCursorTransition: DispatchWorkItem?
     private var mouseTrackingArea: NSTrackingArea?
-    private var cursorTrackingArea: NSTrackingArea?
     private var mouseInteractionSuppressionRects: [CGRect] = []
     private var activeSecondaryMouseRouting: SecondaryMouseRouting?
     private var forwardsActiveSecondaryMouseDrag = false
@@ -1582,6 +1867,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     var onExplicitWheelScroll: (() -> Void)?
     var onSelectionDragStateDidChange: ((Bool) -> Void)?
     var onMouseLocationDidChange: ((CGPoint?) -> Void)?
+    var onMouseMotionDidOccur: (() -> Void)?
     var onBackingPropertiesDidChange: (() -> Void)?
     var onCellSizeDidChange: (() -> Void)?
     var contextMenuBuilder: ((NSEvent, NSMenu?) -> NSMenu?)?
@@ -1654,25 +1940,14 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         if let existing = mouseTrackingArea {
             removeTrackingArea(existing)
         }
-        if let existing = cursorTrackingArea {
-            removeTrackingArea(existing)
-        }
         let mouseArea = NSTrackingArea(
             rect: .zero,
             options: [.mouseMoved, .mouseEnteredAndExited, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
-        let cursorArea = NSTrackingArea(
-            rect: .zero,
-            options: [.cursorUpdate, .activeInKeyWindow, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        )
         addTrackingArea(mouseArea)
-        addTrackingArea(cursorArea)
         mouseTrackingArea = mouseArea
-        cursorTrackingArea = cursorArea
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -1702,75 +1977,62 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
             return
         }
         forwardMousePosition(event)
-    }
-
-    override func cursorUpdate(with event: NSEvent) {
-        guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
-            return
-        }
-        cursorApplication(currentCursor)
+        onMouseMotionDidOccur?()
     }
 
     func setMouseCursorShape(_ shape: ghostty_action_mouse_shape_e) {
-        let cursor: NSCursor = switch shape {
-        case GHOSTTY_MOUSE_SHAPE_POINTER:
-            .pointingHand
-        case GHOSTTY_MOUSE_SHAPE_TEXT:
-            .iBeam
-        case GHOSTTY_MOUSE_SHAPE_CROSSHAIR:
-            .crosshair
-        case GHOSTTY_MOUSE_SHAPE_GRAB:
-            .openHand
-        case GHOSTTY_MOUSE_SHAPE_GRABBING:
-            .closedHand
-        case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED:
-            .operationNotAllowed
-        case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU:
-            .contextualMenu
-        case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT:
-            .iBeamCursorForVerticalLayout
-        case GHOSTTY_MOUSE_SHAPE_E_RESIZE, GHOSTTY_MOUSE_SHAPE_W_RESIZE, GHOSTTY_MOUSE_SHAPE_EW_RESIZE, GHOSTTY_MOUSE_SHAPE_COL_RESIZE:
-            .resizeLeftRight
-        case GHOSTTY_MOUSE_SHAPE_N_RESIZE, GHOSTTY_MOUSE_SHAPE_S_RESIZE, GHOSTTY_MOUSE_SHAPE_NS_RESIZE, GHOSTTY_MOUSE_SHAPE_ROW_RESIZE:
-            .resizeUpDown
-        default:
-            .arrow
-        }
+        let cursorStyle = MouseCursorStyle(shape: shape)
 
-        guard cursor != currentCursor else { return }
-        currentCursor = cursor
-        applyCurrentCursorIfOwned()
-    }
+        pendingTextCursorTransition?.cancel()
+        pendingTextCursorTransition = nil
+        requestedCursorStyle = cursorStyle
 
-    func setCursorApplicationForTesting(_ application: @escaping (NSCursor) -> Void) {
-        cursorApplication = application
-    }
-
-    func ownsCursor(at locationInView: CGPoint, hitView: NSView?) -> Bool {
-        guard bounds.contains(locationInView),
-              !isPointInsideSuppressedMouseRegion(locationInView),
-              let hitView
-        else {
-            return false
-        }
-
-        return hitView === self || hitView.isDescendant(of: self)
-    }
-
-    private func applyCurrentCursorIfOwned() {
-        guard let window, let contentView = window.contentView else { return }
-        let locationInWindow = window.mouseLocationOutsideOfEventStream
-        let locationInView = convert(locationInWindow, from: nil)
-        let locationInContentView = contentView.convert(locationInWindow, from: nil)
-        guard ownsCursor(
-            at: locationInView,
-            hitView: contentView.hitTest(locationInContentView)
-        ) else {
+        guard cursorStyle != currentCursorStyle else { return }
+        guard Self.isArrowTextTransition(from: currentCursorStyle, to: cursorStyle) else {
+            applyMouseCursorStyle(cursorStyle)
             return
         }
 
-        cursorApplication(currentCursor)
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.commitTextCursorTransition(cursorStyle)
+        }
+        pendingTextCursorTransition = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.textCursorTransitionDelay,
+            execute: workItem
+        )
     }
+
+    private func commitTextCursorTransition(_ cursorStyle: MouseCursorStyle) {
+        guard requestedCursorStyle == cursorStyle else { return }
+        pendingTextCursorTransition = nil
+        applyMouseCursorStyle(cursorStyle)
+    }
+
+    private func applyMouseCursorStyle(_ cursorStyle: MouseCursorStyle) {
+        guard currentCursorStyle != cursorStyle else { return }
+        currentCursorStyle = cursorStyle
+    }
+
+    private static func isArrowTextTransition(
+        from current: MouseCursorStyle,
+        to next: MouseCursorStyle
+    ) -> Bool {
+        (current == .arrow && next == .text)
+            || (current == .text && next == .arrow)
+    }
+
+    private static let textCursorTransitionDelay: TimeInterval = 0.1
+
+#if DEBUG
+    var currentMouseCursorStyleForTesting: String {
+        currentCursorStyle.testingName
+    }
+
+    func flushPendingTextCursorTransitionForTesting() {
+        pendingTextCursorTransition?.perform()
+    }
+#endif
 
     override func mouseDown(with event: NSEvent) {
         guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
@@ -2043,8 +2305,12 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     }
 
     func setMouseInteractionSuppressionRects(_ rects: [CGRect]) {
+        guard mouseInteractionSuppressionRects != rects else { return }
         mouseInteractionSuppressionRects = rects
-        window?.invalidateCursorRects(for: self)
+    }
+
+    fileprivate var mouseCursorForHost: NSCursor {
+        currentCursorStyle.cursor
     }
 
     private func isPointInsideSuppressedMouseRegion(_ point: CGPoint) -> Bool {

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -1566,6 +1566,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     private var markedTextSelection = NSRange(location: NSNotFound, length: 0)
     private var selectedTextStorageRange = NSRange(location: NSNotFound, length: 0)
     private var currentCursor: NSCursor = .iBeam
+    private var cursorApplication: (NSCursor) -> Void = { $0.set() }
     private var mouseTrackingArea: NSTrackingArea?
     private var mouseInteractionSuppressionRects: [CGRect] = []
     private var activeSecondaryMouseRouting: SecondaryMouseRouting?
@@ -1700,7 +1701,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         guard !isPointInsideSuppressedMouseRegion(convert(event.locationInWindow, from: nil)) else {
             return
         }
-        currentCursor.set()
+        cursorApplication(currentCursor)
     }
 
     func setMouseCursorShape(_ shape: ghostty_action_mouse_shape_e) {
@@ -1731,15 +1732,11 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
 
         guard cursor != currentCursor else { return }
         currentCursor = cursor
-        if let window {
-            let location = convert(window.mouseLocationOutsideOfEventStream, from: nil)
-            if !isPointInsideSuppressedMouseRegion(location) {
-                currentCursor.set()
-            }
-        } else {
-            currentCursor.set()
-        }
         window?.invalidateCursorRects(for: self)
+    }
+
+    func setCursorApplicationForTesting(_ application: @escaping (NSCursor) -> Void) {
+        cursorApplication = application
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -458,7 +458,6 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     private var terminalCursor: NSCursor = .iBeam
     private var retainedProgrammaticViewportCursor: NSCursor?
     private var terminalCursorSuppressionRects: [CGRect] = []
-    private var pendingTerminalCursorRefresh: DispatchWorkItem?
     private var isTerminalScrollCursorActive = false
     private var isPointerInsideTerminal = false
     private var isLiveScrolling = false
@@ -573,6 +572,9 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         surfaceView.onMouseMotionDidOccur = { [weak self] in
             self?.handleSurfaceMouseMotionDidOccur()
         }
+        surfaceView.onPointerDrivenMouseCursorResolved = { [weak self] cursor in
+            self?.handlePointerDrivenMouseCursorResolved(cursor)
+        }
         surfaceView.onBackingPropertiesDidChange = { [weak self] in
             self?.beginBackingMetricsReconciliation()
         }
@@ -640,9 +642,9 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
     deinit {
         NotificationCenter.default.removeObserver(self)
         MainActorShim.assumeIsolated {
-            pendingTerminalCursorRefresh?.cancel()
             surfaceView.onBackingPropertiesDidChange = nil
             surfaceView.onCellSizeDidChange = nil
+            surfaceView.onPointerDrivenMouseCursorResolved = nil
             scrollFrameSampler.stop()
             frameMeterSampler.stop()
         }
@@ -777,25 +779,21 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         _ location: CGPoint?,
         restoringStableCursor: Bool = false
     ) {
-        pendingTerminalCursorRefresh?.cancel()
-        pendingTerminalCursorRefresh = nil
         guard location != nil else { return }
 
         setTerminalCursor(
             surfaceView.mouseCursorForHost,
             restoringStableCursor: isTerminalScrollCursorActive || restoringStableCursor
         )
+    }
 
-        let refresh = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            self.pendingTerminalCursorRefresh = nil
-            self.setTerminalCursor(self.surfaceView.mouseCursorForHost)
+    private func handlePointerDrivenMouseCursorResolved(_ cursor: NSCursor) {
+        guard isPointerInsideTerminal,
+              !isTerminalScrollCursorActive,
+              retainedProgrammaticViewportCursor == nil else {
+            return
         }
-        pendingTerminalCursorRefresh = refresh
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + Self.terminalCursorRefreshDelay,
-            execute: refresh
-        )
+        setTerminalCursor(cursor)
     }
 
     private func setTerminalCursor(
@@ -810,8 +808,6 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
         guard !isTerminalScrollCursorActive else { return }
         window?.invalidateCursorRects(for: self)
     }
-
-    private static let terminalCursorRefreshDelay: TimeInterval = 0.1
 
     private func beginTerminalScrollCursorActivity() {
         guard !isTerminalScrollCursorActive else { return }
@@ -949,11 +945,6 @@ final class LibghosttySurfaceScrollHostView: NSView, TerminalViewportSyncControl
             || retainedProgrammaticViewportCursor != nil
         retainedProgrammaticViewportCursor = nil
         handleTerminalPointerActivity(.zero, restoringStableCursor: isRestoringStableCursor)
-    }
-
-    func cancelPendingTerminalCursorRefreshForTesting() {
-        pendingTerminalCursorRefresh?.cancel()
-        pendingTerminalCursorRefresh = nil
     }
 #endif
 
@@ -1853,6 +1844,9 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     private var currentCursorStyle: MouseCursorStyle = .text
     private var requestedCursorStyle: MouseCursorStyle = .text
     private var pendingTextCursorTransition: DispatchWorkItem?
+    private var pendingTextCursorTransitionResolvesPointerRequest = false
+    private var nextPointerCursorRequestID: UInt64 = 0
+    private var pendingPointerCursorRequestID: UInt64?
     private var mouseTrackingArea: NSTrackingArea?
     private var mouseInteractionSuppressionRects: [CGRect] = []
     private var activeSecondaryMouseRouting: SecondaryMouseRouting?
@@ -1868,6 +1862,7 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
     var onSelectionDragStateDidChange: ((Bool) -> Void)?
     var onMouseLocationDidChange: ((CGPoint?) -> Void)?
     var onMouseMotionDidOccur: (() -> Void)?
+    var onPointerDrivenMouseCursorResolved: ((NSCursor) -> Void)?
     var onBackingPropertiesDidChange: (() -> Void)?
     var onCellSizeDidChange: (() -> Void)?
     var contextMenuBuilder: ((NSEvent, NSMenu?) -> NSMenu?)?
@@ -1982,36 +1977,71 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
 
     func setMouseCursorShape(_ shape: ghostty_action_mouse_shape_e) {
         let cursorStyle = MouseCursorStyle(shape: shape)
+        // Redraws can repeat the same shape while an arrow/text transition is
+        // stabilizing. Preserve pointer causality across that duplicate only;
+        // a different shape remains a background update until pointer motion.
+        let preservesPendingPointerResolution = pendingTextCursorTransition != nil
+            && pendingTextCursorTransitionResolvesPointerRequest
+            && requestedCursorStyle == cursorStyle
+        let resolvesPointerCursorRequest = pendingPointerCursorRequestID != nil
+            || preservesPendingPointerResolution
+        pendingPointerCursorRequestID = nil
 
         pendingTextCursorTransition?.cancel()
         pendingTextCursorTransition = nil
+        pendingTextCursorTransitionResolvesPointerRequest = false
         requestedCursorStyle = cursorStyle
 
-        guard cursorStyle != currentCursorStyle else { return }
+        guard cursorStyle != currentCursorStyle else {
+            if resolvesPointerCursorRequest {
+                onPointerDrivenMouseCursorResolved?(currentCursorStyle.cursor)
+            }
+            return
+        }
         guard Self.isArrowTextTransition(from: currentCursorStyle, to: cursorStyle) else {
-            applyMouseCursorStyle(cursorStyle)
+            applyMouseCursorStyle(
+                cursorStyle,
+                resolvesPointerCursorRequest: resolvesPointerCursorRequest
+            )
             return
         }
 
         let workItem = DispatchWorkItem { [weak self] in
-            self?.commitTextCursorTransition(cursorStyle)
+            self?.commitTextCursorTransition(
+                cursorStyle,
+                resolvesPointerCursorRequest: resolvesPointerCursorRequest
+            )
         }
         pendingTextCursorTransition = workItem
+        pendingTextCursorTransitionResolvesPointerRequest = resolvesPointerCursorRequest
         DispatchQueue.main.asyncAfter(
             deadline: .now() + Self.textCursorTransitionDelay,
             execute: workItem
         )
     }
 
-    private func commitTextCursorTransition(_ cursorStyle: MouseCursorStyle) {
+    private func commitTextCursorTransition(
+        _ cursorStyle: MouseCursorStyle,
+        resolvesPointerCursorRequest: Bool
+    ) {
         guard requestedCursorStyle == cursorStyle else { return }
         pendingTextCursorTransition = nil
-        applyMouseCursorStyle(cursorStyle)
+        pendingTextCursorTransitionResolvesPointerRequest = false
+        applyMouseCursorStyle(
+            cursorStyle,
+            resolvesPointerCursorRequest: resolvesPointerCursorRequest
+        )
     }
 
-    private func applyMouseCursorStyle(_ cursorStyle: MouseCursorStyle) {
+    private func applyMouseCursorStyle(
+        _ cursorStyle: MouseCursorStyle,
+        resolvesPointerCursorRequest: Bool = false
+    ) {
         guard currentCursorStyle != cursorStyle else { return }
         currentCursorStyle = cursorStyle
+        if resolvesPointerCursorRequest {
+            onPointerDrivenMouseCursorResolved?(cursorStyle.cursor)
+        }
     }
 
     private static func isArrowTextTransition(
@@ -2763,10 +2793,21 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         onMouseLocationDidChange?(point)
         lastMouseModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let position = CGPoint(x: point.x, y: bounds.height - point.y)
+        nextPointerCursorRequestID &+= 1
+        let pointerCursorRequestID = nextPointerCursorRequestID
+        pendingPointerCursorRequestID = pointerCursorRequestID
         surfaceController?.sendMousePosition(
             position,
             modifiers: event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         )
+        // Ghostty enqueues its main-queue action drain during the synchronous
+        // mouse-position call. Queue cleanup afterward so only that response
+        // can consume this request; the ID prevents older cleanup blocks from
+        // clearing a newer pointer request.
+        DispatchQueue.main.async { [weak self] in
+            guard self?.pendingPointerCursorRequestID == pointerCursorRequestID else { return }
+            self?.pendingPointerCursorRequestID = nil
+        }
     }
 
     fileprivate func forwardSyntheticMousePosition(_ point: CGPoint) {

--- a/Zentty/UI/Bookmarks/SidebarBookmarksButton.swift
+++ b/Zentty/UI/Bookmarks/SidebarBookmarksButton.swift
@@ -103,7 +103,6 @@ final class SidebarBookmarksButton: NSButton {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         NSCursor.pointingHand.set()
     }
 

--- a/Zentty/UI/Chrome/WindowChromeView.swift
+++ b/Zentty/UI/Chrome/WindowChromeView.swift
@@ -413,8 +413,7 @@ final class WindowChromeView: NSView {
 
     private func syncFocusedSpinnerPresentation() {
         let text = focusedLabel.stringValue
-        let animatesSpinner = currentSummary.focusedPaneIsWorking
-            && SidebarShimmerTextView.containsBrailleSpinner(in: text)
+        let animatesSpinner = currentSummary.focusedLabelAnimatesLocalCodexSpinner
 
         focusedSpinnerLabel.stringValue = text
         focusedSpinnerLabel.animatesBrailleSpinner = animatesSpinner

--- a/Zentty/UI/Chrome/WindowChromeView.swift
+++ b/Zentty/UI/Chrome/WindowChromeView.swift
@@ -90,6 +90,7 @@ final class WindowChromeView: NSView {
         font: .systemFont(ofSize: 12, weight: .medium),
         lineBreakMode: .byTruncatingTail
     )
+    private let focusedSpinnerLabel = SidebarShimmerTextView()
     private let remoteContextLabel = WindowChromeView.makeLabel(
         text: "",
         color: .tertiaryLabelColor,
@@ -101,6 +102,7 @@ final class WindowChromeView: NSView {
     private let urlOpener: (URL) -> Void
     private let pathRevealer: (URL) -> Void
     private let computerLocationOpener: (URL) -> Void
+    private let reducedMotionProvider: () -> Bool
 
     private var currentTheme = ZenttyTheme.fallback(for: nil)
     private var shortcutManager = ShortcutManager(shortcuts: .default)
@@ -133,11 +135,15 @@ final class WindowChromeView: NSView {
         frame frameRect: NSRect,
         urlOpener: @escaping (URL) -> Void = { NSWorkspace.shared.open($0) },
         pathRevealer: @escaping (URL) -> Void = { NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: $0.path) },
-        computerLocationOpener: @escaping (URL) -> Void = { NSWorkspace.shared.open($0) }
+        computerLocationOpener: @escaping (URL) -> Void = { NSWorkspace.shared.open($0) },
+        reducedMotionProvider: @escaping () -> Bool = {
+            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        }
     ) {
         self.urlOpener = urlOpener
         self.pathRevealer = pathRevealer
         self.computerLocationOpener = computerLocationOpener
+        self.reducedMotionProvider = reducedMotionProvider
         super.init(frame: frameRect)
         setup()
     }
@@ -165,6 +171,7 @@ final class WindowChromeView: NSView {
         if newWindow == nil {
             reviewStalenessRecheckTimer?.invalidate()
             reviewStalenessRecheckTimer = nil
+            focusedSpinnerLabel.isVisibleForSharedAnimation = false
         }
     }
 
@@ -176,6 +183,7 @@ final class WindowChromeView: NSView {
         layoutServerControl()
         syncVisibleRowContent(forceChipRefresh: false)
         layoutRowContent(animated: animatesRowLayout)
+        syncFocusedSpinnerFrameAndVisibility()
     }
 
     func animateNextRowLayoutForSidebarTransition() {
@@ -193,6 +201,12 @@ final class WindowChromeView: NSView {
         focusedProxyIconView.openComputerLocation = computerLocationOpener
         focusedLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         focusedLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        focusedSpinnerLabel.font = focusedLabel.font ?? .systemFont(ofSize: 12, weight: .medium)
+        focusedSpinnerLabel.lineBreakMode = focusedLabel.lineBreakMode
+        focusedSpinnerLabel.lineHeight = focusedLabel.intrinsicContentSize.height
+        focusedSpinnerLabel.shimmerColor = .clear
+        focusedSpinnerLabel.ignoresHitTesting = true
+        focusedSpinnerLabel.isHidden = true
         remoteContextLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         remoteContextLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         branchLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
@@ -309,6 +323,7 @@ final class WindowChromeView: NSView {
         openWithContainerView.addSubview(openWithDividerView)
         openWithContainerView.addSubview(openWithPrimaryButton)
         openWithContainerView.addSubview(openWithMenuButton)
+        rowContainerView.addSubview(focusedSpinnerLabel)
         [worklaneTitleLabel, focusedProxyIconView, focusedLabel, remoteContextLabel, branchLabel, pullRequestButton].forEach {
             rowContainerView.addSubview($0)
         }
@@ -333,6 +348,7 @@ final class WindowChromeView: NSView {
         focusedLabel.isHidden = trimmed.isEmpty
         focusedLabel.invalidateIntrinsicContentSize()
         currentSummary.focusedLabel = trimmed.isEmpty ? nil : trimmed
+        syncFocusedSpinnerPresentation()
         needsLayout = true
     }
 
@@ -347,6 +363,7 @@ final class WindowChromeView: NSView {
         let focusedText = summary.focusedLabel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         focusedLabel.stringValue = focusedText
         focusedLabel.isHidden = focusedText.isEmpty
+        syncFocusedSpinnerPresentation()
 
         let remoteContextText = summary.remoteContextLabel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         remoteContextLabel.stringValue = remoteContextText
@@ -375,8 +392,8 @@ final class WindowChromeView: NSView {
         currentTheme = theme
 
         worklaneTitleLabel.textColor = theme.secondaryText
-        focusedLabel.textColor = theme.secondaryText
         remoteContextLabel.textColor = theme.tertiaryText
+        syncFocusedSpinnerPresentation()
         renderFocusedProxyIcon()
         updateBranchAppearance(animated: animated)
         updatePullRequestAppearance(animated: animated)
@@ -387,6 +404,37 @@ final class WindowChromeView: NSView {
         performThemeAnimation(animated: animated) {
             self.layer?.backgroundColor = theme.topChromeBackground.cgColor
         }
+    }
+
+    func setShimmerCoordinator(_ coordinator: SidebarShimmerCoordinator?) {
+        focusedSpinnerLabel.shimmerCoordinator = coordinator
+        syncFocusedSpinnerFrameAndVisibility()
+    }
+
+    private func syncFocusedSpinnerPresentation() {
+        let text = focusedLabel.stringValue
+        let animatesSpinner = currentSummary.focusedPaneIsWorking
+            && SidebarShimmerTextView.containsBrailleSpinner(in: text)
+
+        focusedSpinnerLabel.stringValue = text
+        focusedSpinnerLabel.animatesBrailleSpinner = animatesSpinner
+        focusedSpinnerLabel.animatedSpinnerBaseColor = animatesSpinner
+            ? currentTheme.secondaryText
+            : nil
+        focusedSpinnerLabel.isShimmering = animatesSpinner
+        focusedSpinnerLabel.reducedMotion = reducedMotionProvider()
+        focusedSpinnerLabel.isHidden = !animatesSpinner
+        focusedLabel.textColor = animatesSpinner ? .clear : currentTheme.secondaryText
+        syncFocusedSpinnerFrameAndVisibility()
+    }
+
+    private func syncFocusedSpinnerFrameAndVisibility() {
+        focusedSpinnerLabel.frame = focusedLabel.frame
+        focusedSpinnerLabel.isVisibleForSharedAnimation =
+            !focusedSpinnerLabel.isHidden
+            && !focusedLabel.isHidden
+            && !rowContainerView.isHidden
+            && focusedLabel.frame.width > 0.5
     }
 
     func render(server state: WindowChromeServerState?) {
@@ -1334,6 +1382,25 @@ final class WindowChromeView: NSView {
     var focusedProxyIconImage: NSImage? { focusedProxyIconView.image }
     var focusedLabelText: String { focusedLabel.stringValue }
     var focusedLabelFrame: NSRect { focusedLabel.frame }
+#if DEBUG
+    var focusedLabelUsesLocalBrailleAnimationForTesting: Bool {
+        focusedSpinnerLabel.animatesBrailleSpinner
+    }
+    var focusedSpinnerDisplayedTextForTesting: String {
+        focusedSpinnerLabel.displayedStringValueForTesting
+    }
+    var focusedSpinnerBaseColorForTesting: NSColor? {
+        focusedSpinnerLabel.animatedSpinnerBaseColor
+    }
+    var focusedSpinnerReducedMotionForTesting: Bool {
+        focusedSpinnerLabel.reducedMotion
+    }
+    var focusedSpinnerIgnoresHitTestingForTesting: Bool {
+        focusedSpinnerLabel.hitTest(
+            NSPoint(x: focusedSpinnerLabel.bounds.midX, y: focusedSpinnerLabel.bounds.midY)
+        ) == nil
+    }
+#endif
     var remoteContextLabelText: String { remoteContextLabel.stringValue }
     var remoteContextLabelFrame: NSRect { remoteContextLabel.frame }
     var branchText: String { branchLabel.stringValue }
@@ -1420,6 +1487,14 @@ final class WindowChromeView: NSView {
     }
     var openWithPrimaryTintTokenForTesting: String { openWithPrimaryButton.contentTintColor?.themeToken ?? "" }
     var openWithMenuTintTokenForTesting: String { openWithMenuButton.contentTintColor?.themeToken ?? "" }
+
+#if DEBUG
+    func advanceFocusedBrailleSpinnerForTesting() {
+        for _ in 0..<SidebarShimmerTextView.spinnerTicksPerFrameForTesting {
+            focusedSpinnerLabel.applySharedShimmerState(phase: 0.5, inSweep: true)
+        }
+    }
+#endif
 
     func performOpenWithPrimaryClickForTesting() {
         openWithPrimaryButton.performClick(openWithPrimaryButton)

--- a/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
+++ b/Zentty/UI/MenuBar/MenuBarStatusMenuBuilder.swift
@@ -280,7 +280,6 @@ private final class MenuBarAgentRowView: NSView {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         NSCursor.arrow.set()
     }
 

--- a/Zentty/UI/PaneStrip/PaneContainerView.swift
+++ b/Zentty/UI/PaneStrip/PaneContainerView.swift
@@ -335,6 +335,8 @@ final class PaneContainerView: NSView {
     private var isZoomedOutBackdropVisible = false
     private var currentWorklaneColor: WorklaneColor?
     private var lastRenderedSearchState = PaneSearchState()
+    private var hasRenderedSearchState = false
+    private var leadingMouseInteractionOcclusionWidth: CGFloat = 0
     private var terminalResizePreview: TerminalResizePreview?
     private var hoverTrackingArea: NSTrackingArea?
     var rightPaneCommandPresentationProvider: (() -> PaneRightCommandPresentation)?
@@ -1684,9 +1686,14 @@ final class PaneContainerView: NSView {
     }
 
     private func updateSearchHUD(_ search: PaneSearchState) {
+        guard !hasRenderedSearchState || lastRenderedSearchState != search else {
+            return
+        }
+
         let didVisibilityChange = lastRenderedSearchState.isHUDVisible != search.isHUDVisible
         let didBecomeVisible = !lastRenderedSearchState.isHUDVisible && search.isHUDVisible
         lastRenderedSearchState = search
+        hasRenderedSearchState = true
         terminalHostView.applySearchHUD(search)
         updateSearchHUDMouseSuppression()
         if didVisibilityChange {
@@ -1705,11 +1712,27 @@ final class PaneContainerView: NSView {
 
     private func updateSearchHUDMouseSuppression() {
         var suppressionRects = [dragZoneSuppressionRect]
+        if leadingMouseInteractionOcclusionWidth > 0 {
+            let paneRect = CGRect(
+                x: bounds.minX,
+                y: bounds.minY,
+                width: min(leadingMouseInteractionOcclusionWidth, bounds.width),
+                height: bounds.height
+            )
+            suppressionRects.append(terminalHostView.convert(paneRect, from: self))
+        }
         if lastRenderedSearchState.isHUDVisible {
             suppressionRects.append(terminalHostView.searchHUDFrameInHostCoordinates)
         }
 
         terminalHostView.setMouseInteractionSuppressionRects(suppressionRects)
+    }
+
+    func setLeadingMouseInteractionOcclusionWidth(_ width: CGFloat) {
+        let resolvedWidth = max(0, width)
+        guard abs(leadingMouseInteractionOcclusionWidth - resolvedWidth) > 0.5 else { return }
+        leadingMouseInteractionOcclusionWidth = resolvedWidth
+        updateSearchHUDMouseSuppression()
     }
 
     private var dragZoneSuppressionRect: CGRect {

--- a/Zentty/UI/PaneStrip/PaneDragZoneView.swift
+++ b/Zentty/UI/PaneStrip/PaneDragZoneView.swift
@@ -196,7 +196,6 @@ final class PaneDragZoneView: NSView {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         resolvedCursor.set()
     }
 

--- a/Zentty/UI/PaneStrip/PaneStripView.swift
+++ b/Zentty/UI/PaneStrip/PaneStripView.swift
@@ -167,6 +167,7 @@ final class PaneStripView: NSView {
     private var currentPresentation: StripPresentation?
     private var shortcutManager = ShortcutManager(shortcuts: .default)
     private var paneViews: [PaneID: PaneContainerView] = [:]
+    private var cursorRectSignature: [PaneCursorRect]?
     private var dragZoneViews: [PaneID: PaneDragZoneView] = [:]
     private var dividerViews: [PaneDivider: PaneDividerHandleView] = [:]
     private var lastRenderedSize: CGSize = .zero
@@ -200,7 +201,13 @@ final class PaneStripView: NSView {
     var onHostDrivenResizeRenderRequested: (() -> Void)?
     #if DEBUG
         private(set) var renderSnapshotsForTesting: [RenderSnapshot] = []
+        private(set) var cursorRectInvalidationCountForTesting = 0
     #endif
+
+    private struct PaneCursorRect: Equatable {
+        let paneID: PaneID
+        let frame: CGRect
+    }
 
     private struct DividerDragSession {
         let target: PaneResizeTarget
@@ -1069,8 +1076,7 @@ final class PaneStripView: NSView {
         if isResizeSuppressedRender {
             renderGuard.clearResizeSuppression(forGeneration: settleGeneration)
         }
-        discardCursorRects()
-        window?.invalidateCursorRects(for: self)
+        invalidateCursorRectsIfNeeded()
         syncFocusedTerminal(with: state.focusedPaneID)
         #if DEBUG
             renderSnapshotsForTesting.append(
@@ -1096,6 +1102,29 @@ final class PaneStripView: NSView {
         }
 
         return nil
+    }
+
+    private func invalidateCursorRectsIfNeeded() {
+        let nextSignature = paneViews.compactMap { paneID, paneView -> PaneCursorRect? in
+            guard let frameInPane = paneView.interactiveBorderContextFrameInSelf else {
+                return nil
+            }
+            return PaneCursorRect(
+                paneID: paneID,
+                frame: convert(frameInPane, from: paneView)
+            )
+        }
+        .sorted { $0.paneID.rawValue < $1.paneID.rawValue }
+
+        guard cursorRectSignature != nextSignature else {
+            return
+        }
+        cursorRectSignature = nextSignature
+        discardCursorRects()
+        window?.invalidateCursorRects(for: self)
+#if DEBUG
+        cursorRectInvalidationCountForTesting &+= 1
+#endif
     }
 
     private func sharesAnyPane(
@@ -1268,6 +1297,9 @@ final class PaneStripView: NSView {
                 dx: -resolvedOffset(offset),
                 dy: 0
             )
+            paneView.setLeadingMouseInteractionOcclusionWidth(
+                leadingMouseInteractionOcclusionWidth(for: targetFrame)
+            )
             let targetAlpha: CGFloat
             if panePresentation.paneID == dropSettleCoveredPaneID {
                 targetAlpha = 0
@@ -1412,6 +1444,9 @@ final class PaneStripView: NSView {
                         inactiveOpacity: currentInactivePaneOpacity
                     )
                 }
+                paneView.setLeadingMouseInteractionOcclusionWidth(
+                    leadingMouseInteractionOcclusionWidth(for: paneView.frame)
+                )
                 paneViews[panePresentation.paneID] = paneView
                 viewportView.addSubview(paneView)
                 if startsWithViewportSyncSuspended {
@@ -1473,6 +1508,10 @@ final class PaneStripView: NSView {
 
             lastFocusedPaneID = lastFocusedPaneID.flatMap { paneViews[$0] == nil ? nil : $0 }
         }
+    }
+
+    private func leadingMouseInteractionOcclusionWidth(for paneFrame: CGRect) -> CGFloat {
+        min(paneFrame.width, max(0, resolvedLeadingVisibleInset - paneFrame.minX))
     }
 
     private func suspendedPaneIDs(
@@ -3142,7 +3181,6 @@ private final class PaneDividerHandleView: NSView {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         resolvedCursor.set()
     }
 

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -106,6 +106,8 @@ final class RootViewController: NSViewController {
 
     private enum SidebarLayout {
         static let hoverRailWidth: CGFloat = 8
+        static let resizeHandleWidth = SidebarResizeHandleView.hitWidth
+            + ShellMetrics.canvasSidebarGap
         static let defaultTrafficLightAnchor = NSPoint(
             x: ChromeGeometry.trafficLightLeadingInset + 48, y: 0)
     }
@@ -118,6 +120,7 @@ final class RootViewController: NSViewController {
     private let serverOpenService: ServerOpening
     private let taskRunnerDiscoveryService = TaskRunnerDiscoveryService()
     private let sidebarView = SidebarView()
+    private let sidebarOuterResizeHandleView = SidebarResizeHandleView()
     private let sidebarHoverRailView = SidebarHoverRailView()
     private let sidebarToggleButton = SidebarToggleButton()
     private let runtimeRegistry: PaneRuntimeRegistry
@@ -175,6 +178,7 @@ final class RootViewController: NSViewController {
     private var sidebarWidthConstraint: NSLayoutConstraint?
     private var sidebarLeadingConstraint: NSLayoutConstraint?
     private var toggleLeadingConstraint: NSLayoutConstraint?
+    private var outerSidebarResizeStartWidth = SidebarWidthPreference.defaultWidth
 #if DEBUG
     private(set) var lastSidebarChromeFrameMotionForTesting: SidebarChromeFrameMotionRecord?
 #endif
@@ -558,6 +562,10 @@ final class RootViewController: NSViewController {
         appCanvasView.translatesAutoresizingMaskIntoConstraints = false
         windowChromeView.translatesAutoresizingMaskIntoConstraints = false
         sidebarView.translatesAutoresizingMaskIntoConstraints = false
+        sidebarOuterResizeHandleView.translatesAutoresizingMaskIntoConstraints = false
+        sidebarOuterResizeHandleView.onPan = { [weak self] recognizer in
+            self?.handleOuterSidebarResizePan(recognizer)
+        }
         sidebarHoverRailView.translatesAutoresizingMaskIntoConstraints = false
         peekView.translatesAutoresizingMaskIntoConstraints = false
         peekView.isHidden = true
@@ -568,6 +576,7 @@ final class RootViewController: NSViewController {
         view.addSubview(windowChromeView)
         view.addSubview(sidebarHoverRailView)
         view.addSubview(sidebarView)
+        view.addSubview(sidebarOuterResizeHandleView)
         view.addSubview(dragOverlayView)
         view.addSubview(leadingChromeControlsBar)
         sidebarView.setUpdateAvailable(isUpdateAvailable)
@@ -599,6 +608,16 @@ final class RootViewController: NSViewController {
             sidebarView.bottomAnchor.constraint(
                 equalTo: view.bottomAnchor, constant: -ShellMetrics.outerInset),
             sidebarWidthConstraint,
+
+            sidebarOuterResizeHandleView.topAnchor.constraint(equalTo: sidebarView.topAnchor),
+            sidebarOuterResizeHandleView.leadingAnchor.constraint(
+                equalTo: sidebarView.trailingAnchor,
+                constant: -SidebarResizeHandleView.hitWidth
+            ),
+            sidebarOuterResizeHandleView.bottomAnchor.constraint(equalTo: sidebarView.bottomAnchor),
+            sidebarOuterResizeHandleView.widthAnchor.constraint(
+                equalToConstant: SidebarLayout.resizeHandleWidth
+            ),
 
             appCanvasView.topAnchor.constraint(
                 equalTo: windowChromeView.bottomAnchor,
@@ -1122,9 +1141,6 @@ final class RootViewController: NSViewController {
         }
         sidebarView.onCheckForUpdatesRequested = { [weak self] in
             self?.onCheckForUpdatesRequested?()
-        }
-        sidebarView.onResized = { [weak self] width in
-            self?.handleSidebarWidthChange(width)
         }
         sidebarView.onPointerEntered = { [weak self] in
             self?.sidebarMotionCoordinator.handle(.sidebarEntered)
@@ -2164,8 +2180,28 @@ final class RootViewController: NSViewController {
         updateSidebarWidth(width, persist: true)
     }
 
+    private func handleOuterSidebarResizePan(_ recognizer: NSPanGestureRecognizer) {
+        guard sidebarMotionCoordinator.showsResizeHandle else { return }
+
+        switch recognizer.state {
+        case .began:
+            outerSidebarResizeStartWidth = sidebarMotionCoordinator.currentSidebarWidth
+        case .changed, .ended:
+            let translation = recognizer.translation(in: view).x
+            handleSidebarWidthChange(
+                SidebarResizeModel.proposedWidth(
+                    startWidth: outerSidebarResizeStartWidth,
+                    translation: translation
+                )
+            )
+        default:
+            break
+        }
+    }
+
     private func syncSidebarVisibilityControls(animated: Bool) {
-        sidebarView.setResizeEnabled(sidebarMotionCoordinator.showsResizeHandle)
+        let showsResizeHandle = sidebarMotionCoordinator.showsResizeHandle
+        sidebarOuterResizeHandleView.setEnabled(showsResizeHandle)
         sidebarToggleButton.configure(
             theme: currentTheme,
             isActive: sidebarMotionCoordinator.mode == .pinnedOpen,
@@ -2542,6 +2578,15 @@ final class RootViewController: NSViewController {
 
         var pathCopiedToastViewForTesting: PathCopiedToastView? {
             toasts.currentToastViewForTesting
+        }
+
+        func rootPointerCursorForTesting(at localPoint: NSPoint) -> NSCursor? {
+            guard let resizeHandle = view.hitTest(localPoint) as? SidebarResizeHandleView,
+                  resizeHandle.isEnabled
+            else {
+                return nil
+            }
+            return .resizeLeftRight
         }
 
         func insertRemoteImageUploadTaskForTesting(
@@ -3109,6 +3154,7 @@ private final class WindowContentView: NSView {
         super.viewDidChangeEffectiveAppearance()
         onEffectiveAppearanceDidChange?()
     }
+
 }
 
 // MARK: - Bookmarks popover

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -337,6 +337,7 @@ final class RootViewController: NSViewController {
             reviewStateResolver: reviewStateResolver
         )
         super.init(nibName: nil, bundle: nil)
+        windowChromeView.setShimmerCoordinator(sidebarView.sharedShimmerCoordinator)
         toasts = WindowToastPresenter(
             hostViewProvider: { [weak self] in self?.appCanvasView },
             themeProvider: { [weak self] in self?.currentTheme ?? ZenttyTheme.fallback(for: nil) }

--- a/Zentty/UI/Sidebar/SidebarCreateWorklaneButton.swift
+++ b/Zentty/UI/Sidebar/SidebarCreateWorklaneButton.swift
@@ -135,7 +135,6 @@ final class SidebarCreateWorklaneButton: NSButton {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         NSCursor.pointingHand.set()
     }
 

--- a/Zentty/UI/Sidebar/SidebarGlobalSearchButton.swift
+++ b/Zentty/UI/Sidebar/SidebarGlobalSearchButton.swift
@@ -109,7 +109,6 @@ final class SidebarGlobalSearchButton: NSButton {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
         NSCursor.pointingHand.set()
     }
 

--- a/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
@@ -562,6 +562,7 @@ final class SidebarPaneRowButton: NSButton {
     private var activeContextPicker: WorklaneColorMenuItemView?
 
     private let contentStack = NSStackView()
+    private var contentViews: [NSView] = []
     private var isHovered = false
     private var trackingArea: NSTrackingArea?
     private var hoverBackgroundColor: NSColor = .clear
@@ -596,6 +597,7 @@ final class SidebarPaneRowButton: NSButton {
         contentStack.orientation = .vertical
         contentStack.spacing = ShellMetrics.sidebarRowInterlineSpacing
         contentStack.alignment = .leading
+        contentStack.detachesHiddenViews = true
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         contentStack.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         addSubview(contentStack)
@@ -676,8 +678,24 @@ final class SidebarPaneRowButton: NSButton {
         return true
     }
 
-    func setContent(_ views: [NSView]) {
-        contentStack.setViews(views, in: .top)
+    func setContent(allViews: [NSView], visibleViews: [NSView]) {
+        if contentViews.elementsEqual(allViews, by: { $0 === $1 }) == false {
+            contentViews = allViews
+            contentStack.setViews(allViews, in: .top)
+#if DEBUG
+            contentStackReplacementCountForTesting &+= 1
+#endif
+        }
+
+        let visibleViewIDs = Set(visibleViews.map(ObjectIdentifier.init))
+        for view in contentViews {
+            let priority: NSStackView.VisibilityPriority = visibleViewIDs.contains(ObjectIdentifier(view))
+                ? .mustHold
+                : .notVisible
+            if contentStack.visibilityPriority(for: view) != priority {
+                contentStack.setVisibilityPriority(priority, for: view)
+            }
+        }
     }
 
     func updateTheme(hoverColor: NSColor, pressedColor: NSColor) {
@@ -710,11 +728,9 @@ final class SidebarPaneRowButton: NSButton {
         layer?.cornerRadius ?? 0
     }
 
-    // MARK: - Cursor
-
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .pointingHand)
-    }
+#if DEBUG
+    private(set) var contentStackReplacementCountForTesting = 0
+#endif
 
     // MARK: - Hover
 

--- a/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
@@ -1,5 +1,18 @@
 import AppKit
 
+extension NSStackView {
+    @discardableResult
+    func setSidebarViewsIfNeeded(_ views: [NSView], in gravity: NSStackView.Gravity) -> Bool {
+        let currentViews = self.views(in: gravity)
+        guard !currentViews.elementsEqual(views, by: { $0 === $1 }) else {
+            return false
+        }
+
+        setViews(views, in: gravity)
+        return true
+    }
+}
+
 @MainActor
 final class SidebarPaneRowRenderer {
     struct Callbacks {
@@ -225,6 +238,7 @@ final class SidebarWorklaneRowContentRenderer {
 
     private weak var textStack: NSStackView?
     private let textWrapperInset: CGFloat
+    private var insetContainersByContentID: [ObjectIdentifier: SidebarInsetContainerView] = [:]
 
     init(
         textStack: NSStackView,
@@ -245,11 +259,31 @@ final class SidebarWorklaneRowContentRenderer {
                 return insetWrappedView(for: view(for: row, labels: labels, paneRows: paneRows))
             case .pane(let index, let rows):
                 paneRows.buttons[index].setContent(
-                    rows.map { view(for: $0, labels: labels, paneRows: paneRows) }
+                    allViews: allViews(forPaneAt: index, labels: labels, paneRows: paneRows),
+                    visibleViews: rows.map { view(for: $0, labels: labels, paneRows: paneRows) }
                 )
                 return paneRows.containers[index]
             }
         }
+    }
+
+    private func allViews(
+        forPaneAt index: Int,
+        labels: Labels,
+        paneRows: PaneRows
+    ) -> [NSView] {
+        var views = [
+            paneRows.primaryRows[index],
+            paneRows.detailLabels[index],
+        ]
+        if index == 0 {
+            views.append(labels.contextPrefixLabel)
+        }
+        views.append(contentsOf: [
+            paneRows.statusRows[index],
+            paneRows.serverRows[index],
+        ])
+        return views
     }
 
     private func insetWrappedView(for view: NSView) -> NSView {
@@ -257,11 +291,18 @@ final class SidebarWorklaneRowContentRenderer {
             return view
         }
 
-        return SidebarInsetContainerView(
+        let contentID = ObjectIdentifier(view)
+        if let container = insetContainersByContentID[contentID] {
+            return container
+        }
+
+        let container = SidebarInsetContainerView(
             contentView: view,
             horizontalInset: textWrapperInset,
             referenceWidthView: textStack
         )
+        insetContainersByContentID[contentID] = container
+        return container
     }
 
     private func view(

--- a/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
@@ -658,6 +658,14 @@ final class SidebarPanePrimaryRowView: NSView {
         trailingLabelView.textColor ?? .clear
     }
 
+    var animatesBrailleSpinnerForTesting: Bool {
+        shimmerLabel.animatesBrailleSpinner
+    }
+
+    var baseLabelIsHiddenForTesting: Bool {
+        baseLabel.isHidden
+    }
+
     var remoteIconIsVisibleForTesting: Bool {
         remoteIconView.isHidden == false
     }
@@ -828,6 +836,11 @@ final class SidebarPanePrimaryRowView: NSView {
         shimmerLabel.isShimmering = isShimmering
         shimmerLabel.reducedMotion = reducedMotion
         shimmerLabel.shimmerColor = shimmerColor
+        let animatesBrailleSpinner = isShimmering
+            && SidebarShimmerTextView.containsBrailleSpinner(in: primaryText)
+        shimmerLabel.animatesBrailleSpinner = animatesBrailleSpinner
+        shimmerLabel.animatedSpinnerBaseColor = animatesBrailleSpinner ? primaryColor : nil
+        baseLabel.isHidden = animatesBrailleSpinner
     }
 
     func setShimmerCoordinator(_ coordinator: SidebarShimmerCoordinator?) {

--- a/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
@@ -821,11 +821,11 @@ final class SidebarPanePrimaryRowView: NSView {
         trailingColor: NSColor,
         isShimmering: Bool,
         shimmerColor: NSColor,
-        reducedMotion: Bool
+        reducedMotion: Bool,
+        animatesLocalCodexSpinner: Bool = false
     ) {
         self.primaryColor = primaryColor
         self.trailingColor = trailingColor
-        baseLabel.textColor = primaryColor
         trailingLabelView.textColor = trailingColor
         remoteIconView.contentTintColor = trailingColor
         // The pane row primary stays single-line with tail truncation (see
@@ -836,11 +836,13 @@ final class SidebarPanePrimaryRowView: NSView {
         shimmerLabel.isShimmering = isShimmering
         shimmerLabel.reducedMotion = reducedMotion
         shimmerLabel.shimmerColor = shimmerColor
-        let animatesBrailleSpinner = isShimmering
-            && SidebarShimmerTextView.containsBrailleSpinner(in: primaryText)
+        let animatesBrailleSpinner = isShimmering && animatesLocalCodexSpinner
+        // Keep the native text field present for accessibility while the
+        // CoreText overlay supplies the visible animated glyphs.
+        baseLabel.textColor = animatesBrailleSpinner ? .clear : primaryColor
         shimmerLabel.animatesBrailleSpinner = animatesBrailleSpinner
         shimmerLabel.animatedSpinnerBaseColor = animatesBrailleSpinner ? primaryColor : nil
-        baseLabel.isHidden = animatesBrailleSpinner
+        baseLabel.isHidden = false
     }
 
     func setShimmerCoordinator(_ coordinator: SidebarShimmerCoordinator?) {

--- a/Zentty/UI/Sidebar/SidebarResizeHandleView.swift
+++ b/Zentty/UI/Sidebar/SidebarResizeHandleView.swift
@@ -1,10 +1,11 @@
 import AppKit
 
 final class SidebarResizeHandleView: NSView {
+    nonisolated static let hitWidth: CGFloat = 4
+
     var onPan: ((NSPanGestureRecognizer) -> Void)?
 
     private var panRecognizer: NSPanGestureRecognizer?
-    private var trackingArea: NSTrackingArea?
     private(set) var isEnabled = true
 
     override init(frame frameRect: NSRect) {
@@ -23,39 +24,9 @@ final class SidebarResizeHandleView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-
-        if let trackingArea {
-            removeTrackingArea(trackingArea)
-        }
-
-        let trackingArea = NSTrackingArea(
-            rect: bounds,
-            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited, .cursorUpdate],
-            owner: self,
-            userInfo: nil
-        )
-        addTrackingArea(trackingArea)
-        self.trackingArea = trackingArea
-    }
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         invalidatePointerAffordances()
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        super.mouseEntered(with: event)
-        guard isEnabled else {
-            return
-        }
-
-        NSCursor.resizeLeftRight.set()
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        super.mouseExited(with: event)
     }
 
     override func resetCursorRects() {
@@ -64,15 +35,6 @@ final class SidebarResizeHandleView: NSView {
             return
         }
         addCursorRect(bounds, cursor: .resizeLeftRight)
-    }
-
-    override func cursorUpdate(with event: NSEvent) {
-        super.cursorUpdate(with: event)
-        guard isEnabled else {
-            return
-        }
-
-        NSCursor.resizeLeftRight.set()
     }
 
     func apply(theme _: ZenttyTheme, animated: Bool) {
@@ -102,7 +64,6 @@ final class SidebarResizeHandleView: NSView {
     }
 
     private func invalidatePointerAffordances() {
-        updateTrackingAreas()
         discardCursorRects()
         window?.invalidateCursorRects(for: self)
     }

--- a/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
+++ b/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
@@ -45,7 +45,10 @@ final class SidebarShimmerTextView: NSView {
         static let velocity: CGFloat = 130      // pts/sec — constant across all widths
         static let bandWidth: CGFloat = 48
         static let frameInterval: TimeInterval = 1.0 / 30.0
+        static let spinnerTicksPerFrame = 3
     }
+
+    private static let brailleSpinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
     private static let textLeadingInset: CGFloat = 0
 
@@ -81,6 +84,22 @@ final class SidebarShimmerTextView: NSView {
         didSet {
             guard oldValue != shimmerColor else { return }
             needsDisplay = true
+        }
+    }
+
+    var animatedSpinnerBaseColor: NSColor? {
+        didSet {
+            guard oldValue != animatedSpinnerBaseColor else { return }
+            invalidateLayout()
+        }
+    }
+
+    var animatesBrailleSpinner = false {
+        didSet {
+            guard oldValue != animatesBrailleSpinner else { return }
+            spinnerTick = 0
+            spinnerFrameIndex = 0
+            invalidateLayout()
         }
     }
 
@@ -136,6 +155,8 @@ final class SidebarShimmerTextView: NSView {
 
     private var sharedShimmerPhase: CGFloat = 0.5
     private var sharedShimmerInSweep = false
+    private var spinnerTick = 0
+    private var spinnerFrameIndex = 0
     private var cachedWidth: CGFloat = -1
     private var cachedStringValue = ""
     private var cachedFont: NSFont?
@@ -197,6 +218,15 @@ final class SidebarShimmerTextView: NSView {
             return
         }
 
+        if let animatedSpinnerBaseColor {
+            context.saveGState()
+            context.textMatrix = .identity
+            context.textPosition = layout.origin
+            context.setFillColor(animatedSpinnerBaseColor.cgColor)
+            CTLineDraw(layout.line, context)
+            context.restoreGState()
+        }
+
         guard canAnimateSharedShimmer, sharedShimmerInSweep else {
             return
         }
@@ -249,13 +279,14 @@ final class SidebarShimmerTextView: NSView {
 
     private func layoutSnapshot(forWidth width: CGFloat) -> LayoutSnapshot? {
         let availableWidth = width - Self.textLeadingInset
-        guard availableWidth > 0, stringValue.isEmpty == false else {
+        let displayedStringValue = displayedStringValue
+        guard availableWidth > 0, displayedStringValue.isEmpty == false else {
             return nil
         }
 
         if let cachedLayout,
             abs(cachedWidth - width) <= .ulpOfOne,
-            cachedStringValue == stringValue,
+            cachedStringValue == displayedStringValue,
             cachedFont == font,
             cachedLineBreakMode == lineBreakMode
         {
@@ -263,10 +294,11 @@ final class SidebarShimmerTextView: NSView {
         }
 
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: font
+            .font: font,
+            .foregroundColor: animatedSpinnerBaseColor ?? NSColor.labelColor,
         ]
         let line = CTLineCreateWithAttributedString(
-            NSAttributedString(string: stringValue, attributes: attributes)
+            NSAttributedString(string: displayedStringValue, attributes: attributes)
         )
         let drawLine = truncatedLine(
             from: line, attributes: attributes, availableWidth: availableWidth)
@@ -286,12 +318,43 @@ final class SidebarShimmerTextView: NSView {
         )
 
         cachedWidth = width
-        cachedStringValue = stringValue
+        cachedStringValue = displayedStringValue
         cachedFont = font
         cachedLineBreakMode = lineBreakMode
         cachedLayout = snapshot
 
         return snapshot
+    }
+
+    static func containsBrailleSpinner(in text: String) -> Bool {
+        text.contains { character in
+            guard character.unicodeScalars.count == 1,
+                  let value = character.unicodeScalars.first?.value else {
+                return false
+            }
+            return (0x2800...0x28FF).contains(value)
+        }
+    }
+
+    private var displayedStringValue: String {
+        guard animatesBrailleSpinner,
+              Self.brailleSpinnerFrames.indices.contains(spinnerFrameIndex),
+              let spinnerIndex = stringValue.firstIndex(where: { character in
+                  guard character.unicodeScalars.count == 1,
+                        let value = character.unicodeScalars.first?.value else {
+                      return false
+                  }
+                  return (0x2800...0x28FF).contains(value)
+              }) else {
+            return stringValue
+        }
+
+        var value = stringValue
+        value.replaceSubrange(
+            spinnerIndex..<value.index(after: spinnerIndex),
+            with: Self.brailleSpinnerFrames[spinnerFrameIndex]
+        )
+        return value
     }
 
     private func truncatedLine(
@@ -355,6 +418,14 @@ final class SidebarShimmerTextView: NSView {
     func applySharedShimmerState(phase: CGFloat, inSweep: Bool) {
         sharedShimmerPhase = phase
         sharedShimmerInSweep = inSweep
+        if animatesBrailleSpinner, canAnimateSharedShimmer {
+            spinnerTick += 1
+            if spinnerTick >= Animation.spinnerTicksPerFrame {
+                spinnerTick = 0
+                spinnerFrameIndex = (spinnerFrameIndex + 1) % Self.brailleSpinnerFrames.count
+                cachedLayout = nil
+            }
+        }
         needsDisplay = true
     }
 
@@ -367,6 +438,16 @@ final class SidebarShimmerTextView: NSView {
     fileprivate var canAnimateSharedShimmer: Bool {
         isShimmering && isVisibleForSharedAnimation && reducedMotion == false
     }
+
+#if DEBUG
+    static var spinnerTicksPerFrameForTesting: Int {
+        Animation.spinnerTicksPerFrame
+    }
+
+    var displayedStringValueForTesting: String {
+        displayedStringValue
+    }
+#endif
 
     private func refreshSharedShimmerParticipation() {
         guard let shimmerCoordinator else {

--- a/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
+++ b/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
@@ -332,32 +332,20 @@ final class SidebarShimmerTextView: NSView {
         return snapshot
     }
 
-    static func containsBrailleSpinner(in text: String) -> Bool {
-        text.contains { character in
-            guard character.unicodeScalars.count == 1,
-                  let value = character.unicodeScalars.first?.value else {
-                return false
-            }
-            return (0x2800...0x28FF).contains(value)
-        }
-    }
-
     private var displayedStringValue: String {
         guard animatesBrailleSpinner,
-              Self.brailleSpinnerFrames.indices.contains(spinnerFrameIndex),
-              let spinnerIndex = stringValue.firstIndex(where: { character in
-                  guard character.unicodeScalars.count == 1,
-                        let value = character.unicodeScalars.first?.value else {
-                      return false
-                  }
-                  return (0x2800...0x28FF).contains(value)
-              }) else {
+              Self.brailleSpinnerFrames.indices.contains(spinnerFrameIndex) else {
             return stringValue
         }
 
         var value = stringValue
+        guard let spinnerRange = TerminalMetadataChangeClassifier.codexActivitySpinnerRange(
+            in: value
+        ) else {
+            return stringValue
+        }
         value.replaceSubrange(
-            spinnerIndex..<value.index(after: spinnerIndex),
+            spinnerRange,
             with: Self.brailleSpinnerFrames[spinnerFrameIndex]
         )
         return value

--- a/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
+++ b/Zentty/UI/Sidebar/SidebarShimmerTextView.swift
@@ -141,6 +141,8 @@ final class SidebarShimmerTextView: NSView {
         }
     }
 
+    var ignoresHitTesting = false
+
     weak var shimmerCoordinator: SidebarShimmerCoordinator? {
         didSet {
             guard oldValue !== shimmerCoordinator else {
@@ -169,6 +171,10 @@ final class SidebarShimmerTextView: NSView {
 
     override var allowsVibrancy: Bool {
         false
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        ignoresHitTesting ? nil : super.hitTest(point)
     }
 
     override var intrinsicContentSize: NSSize {

--- a/Zentty/UI/Sidebar/SidebarView.swift
+++ b/Zentty/UI/Sidebar/SidebarView.swift
@@ -176,7 +176,7 @@ final class SidebarView: NSView {
         static let updateRowHeight: CGFloat = 28
         static let updateRowBottomInset: CGFloat = ShellMetrics.sidebarContentInset
         static let updateRowSpacing: CGFloat = 8
-        static let resizeHandleWidth: CGFloat = 4
+        static let resizeHandleWidth = SidebarResizeHandleView.hitWidth
         static let headerButtonSpacing: CGFloat = 4
         static let headerAccessoryHeight: CGFloat = ShellMetrics.sidebarCreateWorklaneButtonHeight
         static let pinnedSearchBookmarkSpacing: CGFloat = 0
@@ -223,7 +223,6 @@ final class SidebarView: NSView {
     var moveToWorklaneCatalogProvider: ((PaneID) -> WorklaneDestinationCatalog?)?
     var restoredRerunnableCommandProvider: ((PaneID) -> String?)?
     var onCheckForUpdatesRequested: (() -> Void)?
-    var onResized: ((CGFloat) -> Void)?
     var onPointerEntered: (() -> Void)?
     var onPointerExited: (() -> Void)?
 
@@ -240,7 +239,6 @@ final class SidebarView: NSView {
     private let globalSearchButton = SidebarGlobalSearchButton()
     private let globalSearchRowView = SidebarGlobalSearchRowView()
     private let bookmarksButton = SidebarBookmarksButton()
-    private let resizeHandleView = SidebarResizeHandleView()
     private let shimmerCoordinator = SidebarShimmerCoordinator()
     private let activeWorklaneAutoScroller = SidebarActiveWorklaneAutoScroller()
     private let windowRenderabilityResolver: (NSWindow?) -> Bool
@@ -254,8 +252,7 @@ final class SidebarView: NSView {
         globalSearchButton: globalSearchButton,
         globalSearchRowView: globalSearchRowView,
         bookmarksButton: bookmarksButton,
-        updateAvailableRowView: updateAvailableRowView,
-        resizeHandleView: resizeHandleView
+        updateAvailableRowView: updateAvailableRowView
     )
     private lazy var dragCoordinator = SidebarDragCoordinator(sidebarView: self)
     private lazy var paneDropPresenter = SidebarPaneDropPresenter(targetStack: listStack, lineContainer: listDocumentView)
@@ -283,9 +280,7 @@ final class SidebarView: NSView {
 #endif
     private var headerPinnedContentMinX = Layout.defaultHeaderContentMinX
     private var headerVisibilityMode: SidebarVisibilityMode = .pinnedOpen
-    private var resizeStartWidth: CGFloat = SidebarWidthPreference.defaultWidth
     private var trackingArea: NSTrackingArea?
-    private var isResizeEnabled = true
     private var isUpdateAvailable = false
     private var isGlobalSearchPresented = false
 
@@ -339,7 +334,6 @@ final class SidebarView: NSView {
             name: NSView.boundsDidChangeNotification,
             object: listScrollView.contentView
         )
-
         addWorklaneButton.translatesAutoresizingMaskIntoConstraints = false
         addWorklaneButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
         addWorklaneButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
@@ -370,10 +364,6 @@ final class SidebarView: NSView {
         bookmarksButton.action = #selector(handleOpenBookmarksPopover)
         bookmarksButton.setSegmentPosition(.trailing)
 
-        resizeHandleView.translatesAutoresizingMaskIntoConstraints = false
-        resizeHandleView.onPan = { [weak self] recognizer in
-            self?.handleResizePan(recognizer)
-        }
         updateAvailableRowView.onPressed = { [weak self] in
             self?.handleCheckForUpdates()
         }
@@ -384,7 +374,6 @@ final class SidebarView: NSView {
         addSubview(globalSearchRowView)
         addSubview(headerDividerView)
         addSubview(updateAvailableRowView)
-        addSubview(resizeHandleView)
 
         headerView.addSubview(headerBandView)
         headerView.addSubview(headerAccessoryGroupView)
@@ -506,11 +495,6 @@ final class SidebarView: NSView {
             listStack.leadingAnchor.constraint(equalTo: listDocumentView.leadingAnchor),
             listStack.trailingAnchor.constraint(equalTo: listDocumentView.trailingAnchor),
             listStack.bottomAnchor.constraint(equalTo: listDocumentView.bottomAnchor),
-
-            resizeHandleView.topAnchor.constraint(equalTo: topAnchor),
-            resizeHandleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            resizeHandleView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            resizeHandleView.widthAnchor.constraint(equalToConstant: Layout.resizeHandleWidth),
         ])
 
         updateHeaderLayoutConstraints()
@@ -533,7 +517,7 @@ final class SidebarView: NSView {
 
         let trackingArea = NSTrackingArea(
             rect: bounds,
-            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -549,6 +533,10 @@ final class SidebarView: NSView {
         onPointerExited?()
     }
 
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+    }
+
     override func layout() {
         updateHeaderLayoutConstraints()
         super.layout()
@@ -559,14 +547,6 @@ final class SidebarView: NSView {
         super.viewDidMoveToWindow()
         updateWindowVisibilityObservation()
         syncShimmerVisibility()
-    }
-
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        guard isResizeEnabled, !resizeHandleView.isHidden, resizeHandleView.frame.contains(point) else {
-            return super.hitTest(point)
-        }
-
-        return resizeHandleView
     }
 
     /// Surgical label update for the volatile agent title fast path.
@@ -849,11 +829,6 @@ final class SidebarView: NSView {
         needsLayout = true
     }
 
-    func setResizeEnabled(_ isEnabled: Bool) {
-        isResizeEnabled = isEnabled
-        resizeHandleView.setEnabled(isEnabled)
-    }
-
     func setUpdateAvailable(_ isUpdateAvailable: Bool) {
         guard self.isUpdateAvailable != isUpdateAvailable else {
             return
@@ -1131,27 +1106,6 @@ final class SidebarView: NSView {
         }
     }
 
-    private func handleResizePan(_ recognizer: NSPanGestureRecognizer) {
-        guard isResizeEnabled else {
-            return
-        }
-
-        switch recognizer.state {
-        case .began:
-            resizeStartWidth = bounds.width
-        case .changed, .ended:
-            let translation = recognizer.translation(in: self).x
-            onResized?(
-                SidebarResizeModel.proposedWidth(
-                    startWidth: resizeStartWidth,
-                    translation: translation
-                )
-            )
-        default:
-            break
-        }
-    }
-
 #if DEBUG
     var debugAccessForTesting: SidebarViewDebugAccess {
         SidebarViewDebugAccess(
@@ -1162,7 +1116,6 @@ final class SidebarView: NSView {
             worklaneSummaries: worklaneSummaries,
             listStack: listStack,
             reorderSpacerView: reorderSpacerView,
-            resizeHandleView: resizeHandleView,
             updateAvailableRowView: updateAvailableRowView,
             addWorklaneButton: addWorklaneButton,
             globalSearchButton: globalSearchButton,

--- a/Zentty/UI/Sidebar/SidebarView.swift
+++ b/Zentty/UI/Sidebar/SidebarView.swift
@@ -240,6 +240,9 @@ final class SidebarView: NSView {
     private let globalSearchRowView = SidebarGlobalSearchRowView()
     private let bookmarksButton = SidebarBookmarksButton()
     private let shimmerCoordinator = SidebarShimmerCoordinator()
+    var sharedShimmerCoordinator: SidebarShimmerCoordinator {
+        shimmerCoordinator
+    }
     private let activeWorklaneAutoScroller = SidebarActiveWorklaneAutoScroller()
     private let windowRenderabilityResolver: (NSWindow?) -> Bool
     private lazy var chrome = SidebarViewChrome(

--- a/Zentty/UI/Sidebar/SidebarViewChrome.swift
+++ b/Zentty/UI/Sidebar/SidebarViewChrome.swift
@@ -12,7 +12,6 @@ final class SidebarViewChrome {
     private let globalSearchRowView: SidebarGlobalSearchRowView
     private let bookmarksButton: SidebarBookmarksButton
     private let updateAvailableRowView: SidebarUpdateAvailableRowView
-    private let resizeHandleView: SidebarResizeHandleView
 
     init(
         hostView: NSView,
@@ -24,8 +23,7 @@ final class SidebarViewChrome {
         globalSearchButton: SidebarGlobalSearchButton,
         globalSearchRowView: SidebarGlobalSearchRowView,
         bookmarksButton: SidebarBookmarksButton,
-        updateAvailableRowView: SidebarUpdateAvailableRowView,
-        resizeHandleView: SidebarResizeHandleView
+        updateAvailableRowView: SidebarUpdateAvailableRowView
     ) {
         self.hostView = hostView
         self.backgroundView = backgroundView
@@ -37,7 +35,6 @@ final class SidebarViewChrome {
         self.globalSearchRowView = globalSearchRowView
         self.bookmarksButton = bookmarksButton
         self.updateAvailableRowView = updateAvailableRowView
-        self.resizeHandleView = resizeHandleView
     }
 
     func apply(theme: ZenttyTheme, animated: Bool) {
@@ -51,7 +48,6 @@ final class SidebarViewChrome {
         globalSearchRowView.apply(theme: theme, animated: animated)
         bookmarksButton.configure(theme: theme, animated: animated)
         updateAvailableRowView.configure(theme: theme, animated: animated)
-        resizeHandleView.apply(theme: theme, animated: animated)
         backgroundView.apply(theme: theme, animated: animated)
 
         performThemeAnimation(animated: animated) {

--- a/Zentty/UI/Sidebar/SidebarViewDebugging.swift
+++ b/Zentty/UI/Sidebar/SidebarViewDebugging.swift
@@ -8,7 +8,6 @@ struct SidebarViewDebugSnapshot {
     let arrangedWorklaneIDs: [WorklaneID]
     let reorderSpacerHeight: CGFloat
     let worklaneRowFramesForReordering: [(WorklaneID, CGRect)]
-    let resizeHandleWidth: CGFloat
     let appearanceMatch: NSAppearance.Name?
     let shimmerDriverIsRunning: Bool
     let isUpdateRowHidden: Bool
@@ -32,7 +31,6 @@ struct SidebarViewDebugAccess {
     let worklaneSummaries: [WorklaneSidebarSummary]
     let listStack: NSStackView
     let reorderSpacerView: SidebarReorderSpacerView?
-    let resizeHandleView: SidebarResizeHandleView
     let updateAvailableRowView: SidebarUpdateAvailableRowView
     let addWorklaneButton: SidebarCreateWorklaneButton
     let globalSearchButton: SidebarGlobalSearchButton
@@ -57,7 +55,6 @@ struct SidebarViewDebugAccess {
             },
             reorderSpacerHeight: reorderSpacerView?.spacerHeight ?? 0,
             worklaneRowFramesForReordering: sidebarView.worklaneRowFramesForReordering(),
-            resizeHandleWidth: resizeHandleView.frame.width,
             appearanceMatch: appearance?.bestMatch(from: [.darkAqua, .aqua]),
             shimmerDriverIsRunning: shimmerDriverIsRunning,
             isUpdateRowHidden: updateAvailableRowView.isHidden,
@@ -401,30 +398,6 @@ extension SidebarView {
 
     func performGlobalSearchNextCommandForTesting() {
         debugAccessForTesting.globalSearchRowView.performNextCommandForTesting()
-    }
-
-    var resizeHandleMinX: CGFloat {
-        debugAccessForTesting.resizeHandleView.frame.minX
-    }
-
-    var resizeHandleMaxX: CGFloat {
-        debugAccessForTesting.resizeHandleView.frame.maxX
-    }
-
-    var resizeHandleFillAlpha: CGFloat {
-        debugAccessForTesting.resizeHandleView.fillAlpha
-    }
-
-    var isResizeHandleHidden: Bool {
-        debugAccessForTesting.resizeHandleView.isHidden
-    }
-
-    var trailingEdgeHitTargetsResizeHandle: Bool {
-        hitTest(NSPoint(x: bounds.maxX - 1, y: bounds.midY)) === debugAccessForTesting.resizeHandleView
-    }
-
-    func hitTargetsResizeHandle(atX x: CGFloat) -> Bool {
-        hitTest(NSPoint(x: x, y: bounds.midY)) === debugAccessForTesting.resizeHandleView
     }
 
     var isUpdateAvailableRowVisible: Bool {

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -648,14 +648,16 @@ final class SidebarWorklaneRowButton: NSButton {
             configurePaneRows(for: renderPlan.paneRows, animated: animated)
         }
 
-        textStack.setViews(
-            contentRenderer.groupedViews(
-                for: renderPlan,
-                labels: contentLabels(),
-                paneRows: contentPaneRows()
-            ),
-            in: .top
+        let groupedViews = contentRenderer.groupedViews(
+            for: renderPlan,
+            labels: contentLabels(),
+            paneRows: contentPaneRows()
         )
+        if textStack.setSidebarViewsIfNeeded(groupedViews, in: .top) {
+#if DEBUG
+            contentStackReplacementCountForTesting &+= 1
+#endif
+        }
         heightConstraint?.constant = renderPlan.rowHeight
         invalidateIntrinsicContentSize()
 
@@ -862,6 +864,13 @@ final class SidebarWorklaneRowButton: NSButton {
                 isShimmering: summary.isWorking,
                 treatment: .shadow
             )
+            let animatesBrailleSpinner = summary.isWorking
+                && SidebarShimmerTextView.containsBrailleSpinner(in: summary.primaryText)
+            primaryLabel.animatesBrailleSpinner = animatesBrailleSpinner
+            primaryLabel.animatedSpinnerBaseColor = animatesBrailleSpinner
+                ? primaryBaseLabel.textColor
+                : nil
+            primaryBaseLabel.isHidden = animatesBrailleSpinner
             statusBaseLabel.textColor = SidebarWorklaneRowStyleResolver.statusTextColor(
                 attentionState: summary.attentionState,
                 theme: currentTheme
@@ -902,6 +911,9 @@ final class SidebarWorklaneRowButton: NSButton {
                 )
             }
         } else {
+            primaryLabel.animatesBrailleSpinner = false
+            primaryLabel.animatedSpinnerBaseColor = nil
+            primaryBaseLabel.isHidden = false
             applyPaneRowColors(
                 paneRows: summary.paneRows,
                 activeTextColor: activeTextColor,
@@ -1176,6 +1188,8 @@ final class SidebarWorklaneRowButton: NSButton {
     }
 
 #if DEBUG
+    private(set) var contentStackReplacementCountForTesting = 0
+
     var debugAccessForTesting: SidebarWorklaneRowDebugAccess {
         SidebarWorklaneRowDebugAccess(
             owner: self,

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -859,18 +859,21 @@ final class SidebarWorklaneRowButton: NSButton {
                 activeTextColor: activeTextColor,
                 inactiveTextColor: inactiveTextColor
             )
-            primaryBaseLabel.textColor = SidebarWorklaneRowStyleResolver.renderedBaseTextColor(
+            let primaryBaseTextColor = SidebarWorklaneRowStyleResolver.renderedBaseTextColor(
                 primaryColor,
                 isShimmering: summary.isWorking,
                 treatment: .shadow
             )
             let animatesBrailleSpinner = summary.isWorking
-                && SidebarShimmerTextView.containsBrailleSpinner(in: summary.primaryText)
+                && summary.primaryAnimatesLocalCodexSpinner
+            // Keep the native text field present for accessibility while the
+            // CoreText overlay supplies the visible animated glyphs.
+            primaryBaseLabel.textColor = animatesBrailleSpinner ? .clear : primaryBaseTextColor
             primaryLabel.animatesBrailleSpinner = animatesBrailleSpinner
             primaryLabel.animatedSpinnerBaseColor = animatesBrailleSpinner
-                ? primaryBaseLabel.textColor
+                ? primaryBaseTextColor
                 : nil
-            primaryBaseLabel.isHidden = animatesBrailleSpinner
+            primaryBaseLabel.isHidden = false
             statusBaseLabel.textColor = SidebarWorklaneRowStyleResolver.statusTextColor(
                 attentionState: summary.attentionState,
                 theme: currentTheme
@@ -1049,7 +1052,8 @@ final class SidebarWorklaneRowButton: NSButton {
                     isActive: isActive,
                     theme: currentTheme
                 ),
-                reducedMotion: reducedMotionProvider()
+                reducedMotion: reducedMotionProvider(),
+                animatesLocalCodexSpinner: paneRow.animatesLocalCodexSpinner
             )
             paneDetailLabels[index].textColor = SidebarWorklaneRowStyleResolver.paneDetailTextColor(
                 isFocused: paneRow.isFocused,

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
@@ -19,6 +19,7 @@ struct WorklaneSidebarPaneRow: Equatable {
     let paneID: PaneID
     let primaryText: String
     let usesCustomTitle: Bool
+    let animatesLocalCodexSpinner: Bool
     let trailingText: String?
     let detailText: String?
     let statusText: String?
@@ -38,6 +39,7 @@ struct WorklaneSidebarPaneRow: Equatable {
         paneID: PaneID,
         primaryText: String,
         usesCustomTitle: Bool = false,
+        animatesLocalCodexSpinner: Bool = false,
         trailingText: String?,
         detailText: String?,
         statusText: String?,
@@ -56,6 +58,7 @@ struct WorklaneSidebarPaneRow: Equatable {
         self.paneID = paneID
         self.primaryText = primaryText
         self.usesCustomTitle = usesCustomTitle
+        self.animatesLocalCodexSpinner = animatesLocalCodexSpinner
         self.trailingText = trailingText
         self.detailText = detailText
         self.statusText = statusText
@@ -78,6 +81,7 @@ struct WorklaneSidebarSummary: Equatable {
     let badgeText: String
     let topLabel: String?
     let primaryText: String
+    let primaryAnimatesLocalCodexSpinner: Bool
     let contextPrefixText: String?
     let focusedPaneLineIndex: Int
     let statusText: String?
@@ -112,6 +116,7 @@ struct WorklaneSidebarSummary: Equatable {
         badgeText: String,
         topLabel: String? = nil,
         primaryText: String,
+        primaryAnimatesLocalCodexSpinner: Bool = false,
         contextPrefixText: String? = nil,
         focusedPaneLineIndex: Int = 0,
         statusText: String? = nil,
@@ -133,6 +138,7 @@ struct WorklaneSidebarSummary: Equatable {
         self.badgeText = badgeText
         self.topLabel = topLabel
         self.primaryText = primaryText
+        self.primaryAnimatesLocalCodexSpinner = primaryAnimatesLocalCodexSpinner
         self.contextPrefixText = contextPrefixText
         self.focusedPaneLineIndex = focusedPaneLineIndex
         self.statusText = statusText

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
@@ -34,6 +34,21 @@ enum WorklaneSidebarSummaryBuilder {
         let primaryText: String
         let cwdPath: String?
         let isCwdDerived: Bool
+        let animatesLocalCodexSpinner: Bool
+
+        init(
+            paneID: PaneID?,
+            primaryText: String,
+            cwdPath: String?,
+            isCwdDerived: Bool,
+            animatesLocalCodexSpinner: Bool = false
+        ) {
+            self.paneID = paneID
+            self.primaryText = primaryText
+            self.cwdPath = cwdPath
+            self.isCwdDerived = isCwdDerived
+            self.animatesLocalCodexSpinner = animatesLocalCodexSpinner
+        }
     }
 
     private enum PaneIdentityStyle {
@@ -153,6 +168,7 @@ enum WorklaneSidebarSummaryBuilder {
             badgeText: badgeText,
             topLabel: topLabel,
             primaryText: primaryText,
+            primaryAnimatesLocalCodexSpinner: identity.animatesLocalCodexSpinner,
             focusedPaneLineIndex: focusedPaneLineIndex,
             statusText: statusPresentation.statusText,
             statusSymbolName: statusPresentation.statusSymbolName,
@@ -258,6 +274,7 @@ enum WorklaneSidebarSummaryBuilder {
                 paneID: paneContext.paneID,
                 primaryText: paneIdentity.primaryText,
                 usesCustomTitle: paneIdentity.usesCustomTitle,
+                animatesLocalCodexSpinner: paneIdentity.animatesLocalCodexSpinner,
                 trailingText: paneIdentity.trailingText,
                 detailText: paneIdentity.detailText,
                 statusText: statusPresentation.statusText,
@@ -475,7 +492,8 @@ enum WorklaneSidebarSummaryBuilder {
             primaryText: primaryText,
             cwdPath: presentation.cwd,
             isCwdDerived: !paneIdentity.usesCustomTitle
-                && primaryText == compactSidebarContextText(for: presentation)
+                && primaryText == compactSidebarContextText(for: presentation),
+            animatesLocalCodexSpinner: paneIdentity.animatesLocalCodexSpinner
         )
     }
 
@@ -484,6 +502,21 @@ enum WorklaneSidebarSummaryBuilder {
         let trailingText: String?
         let detailText: String?
         let usesCustomTitle: Bool
+        let animatesLocalCodexSpinner: Bool
+
+        init(
+            primaryText: String,
+            trailingText: String?,
+            detailText: String?,
+            usesCustomTitle: Bool,
+            animatesLocalCodexSpinner: Bool = false
+        ) {
+            self.primaryText = primaryText
+            self.trailingText = trailingText
+            self.detailText = detailText
+            self.usesCustomTitle = usesCustomTitle
+            self.animatesLocalCodexSpinner = animatesLocalCodexSpinner
+        }
     }
 
     private static func paneIdentity(
@@ -544,7 +577,12 @@ enum WorklaneSidebarSummaryBuilder {
                 primaryText: volatileTitle,
                 trailingText: branch,
                 detailText: workingDirectory,
-                usesCustomTitle: false
+                usesCustomTitle: false,
+                animatesLocalCodexSpinner: PaneDisplayIdentityResolver.animatesLocalCodexSpinner(
+                    pane: pane,
+                    presentation: presentation,
+                    metadata: metadata
+                )
             )
         }
 
@@ -1022,6 +1060,7 @@ enum WorklaneSidebarSummaryBuilder {
                 badgeText: summary.badgeText,
                 topLabel: worklane.title,
                 primaryText: summary.primaryText,
+                primaryAnimatesLocalCodexSpinner: summary.primaryAnimatesLocalCodexSpinner,
                 contextPrefixText: contextPrefixText,
                 focusedPaneLineIndex: summary.focusedPaneLineIndex,
                 statusText: summary.statusText,

--- a/ZenttyLogicTests/LibghosttySurfaceScrollHostViewTests.swift
+++ b/ZenttyLogicTests/LibghosttySurfaceScrollHostViewTests.swift
@@ -5,6 +5,174 @@ import XCTest
 
 @MainActor
 final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
+    func test_fixed_overlay_owns_terminal_cursor_rects_when_surface_moves() throws {
+        let harness = makeScrollHostHarness(smoothScrollingEnabled: true)
+        let hostView = harness.hostView
+        hostView.setMouseInteractionSuppressionRects([
+            CGRect(x: 0, y: 0, width: 200, height: 160),
+            CGRect(x: 0, y: 120, width: 800, height: 40),
+        ])
+
+        let owner = hostView.terminalCursorOwnerForTesting
+        let initialOwnerFrame = owner.frame
+        let initialRects = hostView.terminalCursorRectsForTesting
+        let scrollView = try scrollView(from: hostView)
+        scrollView.contentView.scroll(to: CGPoint(x: 0, y: 32))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        NotificationCenter.default.post(name: NSView.boundsDidChangeNotification, object: scrollView.contentView)
+
+        XCTAssertEqual(owner.frame, initialOwnerFrame)
+        XCTAssertEqual(hostView.terminalCursorRectsForTesting, initialRects)
+        XCTAssertEqual(initialRects, [CGRect(x: 200, y: 0, width: 600, height: 120)])
+        XCTAssertEqual(harness.surfaceView.frame.origin.y, 32, accuracy: 0.01)
+    }
+
+    func test_redraw_mouse_shape_change_does_not_invalidate_fixed_cursor_owner() {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        let window = HostCursorInvalidationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        window.contentView = hostView
+        addTeardownBlock {
+            window.contentView = nil
+            window.close()
+        }
+        window.resetInvalidatedViews()
+
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+
+        XCTAssertTrue(
+            window.invalidatedViews.filter { $0 === hostView.terminalCursorOwnerForTesting }.isEmpty
+        )
+        XCTAssertTrue(window.invalidatedViews.filter { $0 === harness.surfaceView }.isEmpty)
+    }
+
+    func test_pointer_activity_applies_latest_mouse_shape_to_fixed_cursor_owner() {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        let window = HostCursorInvalidationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        window.contentView = hostView
+        addTeardownBlock {
+            hostView.cancelPendingTerminalCursorRefreshForTesting()
+            window.contentView = nil
+            window.close()
+        }
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        window.resetInvalidatedViews()
+
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+
+        XCTAssertEqual(
+            window.invalidatedViews.filter { $0 === hostView.terminalCursorOwnerForTesting }.count,
+            1
+        )
+        XCTAssertTrue(window.invalidatedViews.filter { $0 === harness.surfaceView }.isEmpty)
+    }
+
+    func test_live_scroll_uses_arrow_until_pointer_moves() throws {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        let scrollView = try scrollView(from: hostView)
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+        hostView.cancelPendingTerminalCursorRefreshForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView
+        )
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.didEndLiveScrollNotification,
+            object: scrollView
+        )
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+
+        hostView.syncTerminalCursorForPointerEntryForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+    }
+
+    func test_terminalInputScroll_usesArrow_until_pointer_moves() throws {
+        let harness = makeScrollHostHarness(smoothScrollingEnabled: false)
+        let hostView = harness.hostView
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+        hostView.cancelPendingTerminalCursorRefreshForTesting()
+
+        harness.surfaceView.scrollWheel(
+            with: try makeScrollEvent(
+                deltaY: 8,
+                precise: true,
+                momentumPhase: .changed
+            )
+        )
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+
+        hostView.syncTerminalCursorForPointerEntryForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+    }
+
+    func test_outputDrivenViewportGrowth_preservesSemanticCursor() {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        hostView.applyScrollbarUpdate(.init(total: 200, offset: 190, len: 10))
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+        hostView.cancelPendingTerminalCursorRefreshForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+
+        hostView.applyScrollbarUpdate(.init(total: 210, offset: 200, len: 10))
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+    }
+
+    func test_outputDrivenViewportGrowth_retainsDisplayedCursor_untilPointerMoves() {
+        let displayedCursor = NSCursor.openHand
+        let harness = makeScrollHostHarness(
+            currentSystemCursorProvider: { displayedCursor }
+        )
+        let hostView = harness.hostView
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        hostView.applyScrollbarUpdate(.init(total: 200, offset: 190, len: 10))
+        hostView.syncTerminalCursorForPointerActivityForTesting()
+        hostView.syncTerminalCursorForPointerEntryForTesting()
+        hostView.cancelPendingTerminalCursorRefreshForTesting()
+
+        hostView.applyScrollbarUpdate(.init(total: 210, offset: 200, len: 10))
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === displayedCursor)
+
+        hostView.syncTerminalCursorForMouseMotionForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
+    }
+
     func test_scrollbar_update_does_not_follow_when_user_scrolled_away_without_active_selection_drag() throws {
         let harness = makeScrollHostHarness()
         let hostView = harness.hostView
@@ -404,6 +572,24 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
 
         XCTAssertTrue(harness.surface.sentScrollOffsets.isEmpty)
         XCTAssertEqual(harness.surface.sentScrollEvents.count, 0)
+    }
+
+    func test_native_scroll_does_not_install_an_overlapping_cursor_region() throws {
+        let harness = makeScrollHostHarness(smoothScrollingEnabled: true)
+        let scrollView = try scrollView(from: harness.hostView)
+        harness.surfaceView.updateTrackingAreas()
+
+        XCTAssertNil(scrollView.documentCursor)
+        XCTAssertFalse(
+            harness.surfaceView.trackingAreas.contains { $0.options.contains(.cursorUpdate) }
+        )
+
+        scrollView.scrollWheel(with: try makeScrollEvent(deltaY: 8, precise: true))
+
+        XCTAssertNil(scrollView.documentCursor)
+        XCTAssertFalse(
+            harness.surfaceView.trackingAreas.contains { $0.options.contains(.cursorUpdate) }
+        )
     }
 
     func test_terminal_input_scroll_is_sent_to_surface_even_when_smooth_enabled() throws {
@@ -1255,6 +1441,19 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
     }
 }
 
+private final class HostCursorInvalidationWindow: NSWindow {
+    private(set) var invalidatedViews: [NSView] = []
+
+    override func invalidateCursorRects(for view: NSView) {
+        invalidatedViews.append(view)
+        super.invalidateCursorRects(for: view)
+    }
+
+    func resetInvalidatedViews() {
+        invalidatedViews.removeAll()
+    }
+}
+
 @MainActor
 private func waitForMainQueue(
     file: StaticString = #filePath,
@@ -1274,7 +1473,8 @@ private func makeScrollHostHarness(
     scrollFrameSampler: any TerminalScrollFrameSampling = ScrollFrameSamplerSpy(),
     frameMeterSampler: (any TerminalScrollFrameSampling)? = nil,
     backingScale: CGFloat = 1,
-    cellHeight: CGFloat = 16
+    cellHeight: CGFloat = 16,
+    currentSystemCursorProvider: @escaping () -> NSCursor? = { NSCursor.currentSystem }
 ) -> (
     surfaceView: LibghosttyView,
     surface: ScrollHostSurfaceSpy,
@@ -1290,7 +1490,8 @@ private func makeScrollHostHarness(
         paneID: PaneID("test-pane"),
         diagnostics: .shared,
         scrollFrameSampler: scrollFrameSampler,
-        frameMeterSampler: frameMeterSampler
+        frameMeterSampler: frameMeterSampler,
+        currentSystemCursorProvider: currentSystemCursorProvider
     )
     hostView.smoothScrollingEnabled = smoothScrollingEnabled
     hostView.frame = NSRect(x: 0, y: 0, width: 800, height: 160)

--- a/ZenttyLogicTests/LibghosttySurfaceScrollHostViewTests.swift
+++ b/ZenttyLogicTests/LibghosttySurfaceScrollHostViewTests.swift
@@ -62,7 +62,6 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
         ).prepareForAppKitTesting()
         window.contentView = hostView
         addTeardownBlock {
-            hostView.cancelPendingTerminalCursorRefreshForTesting()
             window.contentView = nil
             window.close()
         }
@@ -78,13 +77,75 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
         XCTAssertTrue(window.invalidatedViews.filter { $0 === harness.surfaceView }.isEmpty)
     }
 
+    func test_pointer_driven_delayed_mouse_shape_commit_updates_fixed_cursor_owner() throws {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        let window = HostCursorInvalidationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        window.contentView = hostView
+        addTeardownBlock {
+            window.contentView = nil
+            window.close()
+        }
+        harness.surface.onSendMousePosition = { [weak surfaceView = harness.surfaceView] in
+            DispatchQueue.main.async {
+                surfaceView?.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_DEFAULT)
+            }
+        }
+
+        harness.surfaceView.mouseMoved(
+            with: try makeMouseEvent(type: .mouseMoved, location: CGPoint(x: 120, y: 80))
+        )
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.iBeam)
+
+        waitForMainQueue()
+        harness.surfaceView.flushPendingTextCursorTransitionForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+    }
+
+    func test_duplicate_delayed_mouse_shape_keeps_pointer_driven_cursor_resolution() throws {
+        let harness = makeScrollHostHarness()
+        let hostView = harness.hostView
+        let window = HostCursorInvalidationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        window.contentView = hostView
+        addTeardownBlock {
+            window.contentView = nil
+            window.close()
+        }
+        harness.surface.onSendMousePosition = { [weak surfaceView = harness.surfaceView] in
+            DispatchQueue.main.async {
+                surfaceView?.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_DEFAULT)
+            }
+        }
+
+        harness.surfaceView.mouseMoved(
+            with: try makeMouseEvent(type: .mouseMoved, location: CGPoint(x: 120, y: 80))
+        )
+        waitForMainQueue()
+
+        harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_DEFAULT)
+        harness.surfaceView.flushPendingTextCursorTransitionForTesting()
+
+        XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.arrow)
+    }
+
     func test_live_scroll_uses_arrow_until_pointer_moves() throws {
         let harness = makeScrollHostHarness()
         let hostView = harness.hostView
         let scrollView = try scrollView(from: hostView)
         harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
         hostView.syncTerminalCursorForPointerActivityForTesting()
-        hostView.cancelPendingTerminalCursorRefreshForTesting()
 
         XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
 
@@ -116,7 +177,6 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
         let hostView = harness.hostView
         harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
         hostView.syncTerminalCursorForPointerActivityForTesting()
-        hostView.cancelPendingTerminalCursorRefreshForTesting()
 
         harness.surfaceView.scrollWheel(
             with: try makeScrollEvent(
@@ -143,7 +203,6 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
         harness.surfaceView.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
         hostView.applyScrollbarUpdate(.init(total: 200, offset: 190, len: 10))
         hostView.syncTerminalCursorForPointerActivityForTesting()
-        hostView.cancelPendingTerminalCursorRefreshForTesting()
 
         XCTAssertTrue(hostView.displayedTerminalCursorForTesting === NSCursor.pointingHand)
 
@@ -162,7 +221,6 @@ final class LibghosttySurfaceScrollHostViewTests: AppKitTestCase {
         hostView.applyScrollbarUpdate(.init(total: 200, offset: 190, len: 10))
         hostView.syncTerminalCursorForPointerActivityForTesting()
         hostView.syncTerminalCursorForPointerEntryForTesting()
-        hostView.cancelPendingTerminalCursorRefreshForTesting()
 
         hostView.applyScrollbarUpdate(.init(total: 210, offset: 200, len: 10))
 
@@ -1537,6 +1595,7 @@ private final class ScrollHostSurfaceSpy: LibghosttySurfaceControlling {
     private(set) var bindingActions: [String] = []
     private(set) var events: [Event] = []
     var mouseButtonResults: [ghostty_input_mouse_button_e: Bool] = [:]
+    var onSendMousePosition: (() -> Void)?
 
     func updateViewport(size: CGSize, scale: CGFloat, displayID: UInt32?) {}
     func setFocused(_ isFocused: Bool) {}
@@ -1556,6 +1615,7 @@ private final class ScrollHostSurfaceSpy: LibghosttySurfaceControlling {
     }
     func sendMousePosition(_ position: CGPoint, modifiers: NSEvent.ModifierFlags) {
         sentMousePositions.append((position, modifiers))
+        onSendMousePosition?()
     }
     func sendMouseButton(
         state: ghostty_input_mouse_state_e,

--- a/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
+++ b/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
@@ -51,44 +51,59 @@ final class LibghosttyViewScrollRoutingTests: AppKitTestCase {
         XCTAssertTrue(view.trackingAreas.contains { $0.options.contains(.activeAlways) })
     }
 
-    func test_cursor_tracking_area_uses_supported_key_window_activation() throws {
+    func test_surface_does_not_install_an_overlapping_cursor_tracking_area() {
         view.updateTrackingAreas()
 
-        let cursorArea = try XCTUnwrap(
-            view.trackingAreas.first { $0.options.contains(.cursorUpdate) }
-        )
-        XCTAssertTrue(cursorArea.options.contains(.activeInKeyWindow))
-        XCTAssertFalse(cursorArea.options.contains(.activeAlways))
+        XCTAssertFalse(view.trackingAreas.contains { $0.options.contains(.cursorUpdate) })
     }
 
-    func test_mouse_shape_change_defers_cursor_application_until_cursor_update() throws {
-        var appliedCursors: [NSCursor] = []
-        view.setCursorApplicationForTesting { appliedCursors.append($0) }
+    func test_mouse_shape_change_does_not_invalidate_moving_surface_cursor_rect() {
+        let window = CursorInvalidationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        ).prepareForAppKitTesting()
+        window.contentView = view
+        addTeardownBlock {
+            window.contentView = nil
+            window.close()
+        }
+        window.resetInvalidatedViews()
 
         view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
 
-        XCTAssertTrue(appliedCursors.isEmpty)
-
-        view.cursorUpdate(with: try makeMouseEvent(type: .mouseMoved, location: CGPoint(x: 120, y: 180)))
-
-        XCTAssertEqual(appliedCursors, [.pointingHand])
+        XCTAssertTrue(window.invalidatedViews.filter { $0 === view }.isEmpty)
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "pointingHand")
     }
 
-    func test_cursor_ownership_requires_terminal_to_be_topmost_at_pointer() {
-        let point = CGPoint(x: 120, y: 180)
-        let overlay = NSView(frame: view.bounds)
-        let terminalChild = NSView(frame: view.bounds)
-        view.addSubview(terminalChild)
+    func test_transient_arrow_text_cycle_keeps_text_cursor_style() {
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_DEFAULT)
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_TEXT)
+        view.flushPendingTextCursorTransitionForTesting()
 
-        XCTAssertTrue(view.ownsCursor(at: point, hitView: view))
-        XCTAssertTrue(view.ownsCursor(at: point, hitView: terminalChild))
-        XCTAssertFalse(view.ownsCursor(at: point, hitView: overlay))
-        XCTAssertFalse(view.ownsCursor(at: CGPoint(x: -1, y: -1), hitView: view))
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "text")
+    }
 
-        view.setMouseInteractionSuppressionRects([
-            CGRect(x: 100, y: 160, width: 40, height: 40),
-        ])
-        XCTAssertFalse(view.ownsCursor(at: point, hitView: view))
+    func test_repeated_semantic_mouse_shape_commits_once() {
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "pointingHand")
+    }
+
+    func test_stable_arrow_text_changes_commit_after_transition_delay() {
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_DEFAULT)
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "text")
+
+        view.flushPendingTextCursorTransitionForTesting()
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "arrow")
+
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_TEXT)
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "arrow")
+
+        view.flushPendingTextCursorTransitionForTesting()
+        XCTAssertEqual(view.currentMouseCursorStyleForTesting, "text")
     }
 
     func test_detached_view_does_not_push_viewport_size() {
@@ -390,6 +405,19 @@ final class LibghosttyViewScrollRoutingTests: AppKitTestCase {
         let position = try XCTUnwrap(surface.sentMousePositions.last?.position)
         XCTAssertEqual(position.x, 150, accuracy: 0.01)
         XCTAssertEqual(position.y, 390, accuracy: 0.01)
+    }
+}
+
+private final class CursorInvalidationWindow: NSWindow {
+    private(set) var invalidatedViews: [NSView] = []
+
+    override func invalidateCursorRects(for view: NSView) {
+        invalidatedViews.append(view)
+        super.invalidateCursorRects(for: view)
+    }
+
+    func resetInvalidatedViews() {
+        invalidatedViews.removeAll()
     }
 }
 

--- a/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
+++ b/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
@@ -51,6 +51,19 @@ final class LibghosttyViewScrollRoutingTests: AppKitTestCase {
         XCTAssertTrue(view.trackingAreas.contains { $0.options.contains(.activeAlways) })
     }
 
+    func test_mouse_shape_change_defers_cursor_application_until_cursor_update() throws {
+        var appliedCursors: [NSCursor] = []
+        view.setCursorApplicationForTesting { appliedCursors.append($0) }
+
+        view.setMouseCursorShape(GHOSTTY_MOUSE_SHAPE_POINTER)
+
+        XCTAssertTrue(appliedCursors.isEmpty)
+
+        view.cursorUpdate(with: try makeMouseEvent(type: .mouseMoved, location: CGPoint(x: 120, y: 180)))
+
+        XCTAssertEqual(appliedCursors, [.pointingHand])
+    }
+
     func test_detached_view_does_not_push_viewport_size() {
         view.frame = NSRect(x: 0, y: 0, width: 3200, height: 900)
 

--- a/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
+++ b/ZenttyLogicTests/LibghosttyViewScrollRoutingTests.swift
@@ -51,6 +51,16 @@ final class LibghosttyViewScrollRoutingTests: AppKitTestCase {
         XCTAssertTrue(view.trackingAreas.contains { $0.options.contains(.activeAlways) })
     }
 
+    func test_cursor_tracking_area_uses_supported_key_window_activation() throws {
+        view.updateTrackingAreas()
+
+        let cursorArea = try XCTUnwrap(
+            view.trackingAreas.first { $0.options.contains(.cursorUpdate) }
+        )
+        XCTAssertTrue(cursorArea.options.contains(.activeInKeyWindow))
+        XCTAssertFalse(cursorArea.options.contains(.activeAlways))
+    }
+
     func test_mouse_shape_change_defers_cursor_application_until_cursor_update() throws {
         var appliedCursors: [NSCursor] = []
         view.setCursorApplicationForTesting { appliedCursors.append($0) }
@@ -62,6 +72,23 @@ final class LibghosttyViewScrollRoutingTests: AppKitTestCase {
         view.cursorUpdate(with: try makeMouseEvent(type: .mouseMoved, location: CGPoint(x: 120, y: 180)))
 
         XCTAssertEqual(appliedCursors, [.pointingHand])
+    }
+
+    func test_cursor_ownership_requires_terminal_to_be_topmost_at_pointer() {
+        let point = CGPoint(x: 120, y: 180)
+        let overlay = NSView(frame: view.bounds)
+        let terminalChild = NSView(frame: view.bounds)
+        view.addSubview(terminalChild)
+
+        XCTAssertTrue(view.ownsCursor(at: point, hitView: view))
+        XCTAssertTrue(view.ownsCursor(at: point, hitView: terminalChild))
+        XCTAssertFalse(view.ownsCursor(at: point, hitView: overlay))
+        XCTAssertFalse(view.ownsCursor(at: CGPoint(x: -1, y: -1), hitView: view))
+
+        view.setMouseInteractionSuppressionRects([
+            CGRect(x: 100, y: 160, width: 40, height: 40),
+        ])
+        XCTAssertFalse(view.ownsCursor(at: point, hitView: view))
     }
 
     func test_detached_view_does_not_push_viewport_size() {

--- a/ZenttyLogicTests/PaneContainerViewTests.swift
+++ b/ZenttyLogicTests/PaneContainerViewTests.swift
@@ -1356,6 +1356,38 @@ final class PaneContainerViewTests: AppKitTestCase {
         XCTAssertEqual(terminalView.mouseInteractionSuppressionRects, [dragZoneRect])
     }
 
+    func test_metadata_updates_do_not_reapply_unchanged_search_hud_suppression() {
+        let terminalView = OverlayHostingTerminalView()
+        let adapter = PaneContainerTerminalAdapterSpy(terminalView: terminalView)
+        let pane = PaneState(id: PaneID("shell"), title: "shell")
+        let runtime = PaneRuntime(
+            pane: pane,
+            adapter: adapter,
+            metadataSink: { _, _ in },
+            eventSink: { _, _ in }
+        )
+        let paneView = PaneContainerView(
+            pane: pane,
+            width: 420,
+            height: 520,
+            emphasis: 1,
+            isFocused: true,
+            runtime: runtime,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        let initialUpdateCount = terminalView.mouseInteractionSuppressionUpdateCount
+
+        adapter.metadataDidChange?(TerminalMetadata(currentWorkingDirectory: "/tmp/one"))
+        adapter.metadataDidChange?(TerminalMetadata(currentWorkingDirectory: "/tmp/two"))
+
+        XCTAssertGreaterThan(initialUpdateCount, 0)
+        XCTAssertEqual(
+            terminalView.mouseInteractionSuppressionUpdateCount,
+            initialUpdateCount
+        )
+        XCTAssertFalse(paneView.isSearchHUDVisible)
+    }
+
     func test_drag_strip_suppresses_terminal_mouse_interaction_when_search_hud_is_hidden() {
         let terminalView = OverlayHostingTerminalView()
         let adapter = PaneContainerTerminalAdapterSpy(terminalView: terminalView)
@@ -1388,6 +1420,42 @@ final class PaneContainerViewTests: AppKitTestCase {
                 height: PaneContainerView.dragZoneHeight
             )
         )
+    }
+
+    func test_sidebar_overlap_suppresses_terminal_mouse_interaction() {
+        let terminalView = OverlayHostingTerminalView()
+        let adapter = PaneContainerTerminalAdapterSpy(terminalView: terminalView)
+        let pane = PaneState(id: PaneID("shell"), title: "shell")
+        let runtime = PaneRuntime(
+            pane: pane,
+            adapter: adapter,
+            metadataSink: { _, _ in },
+            eventSink: { _, _ in }
+        )
+        let paneView = PaneContainerView(
+            pane: pane,
+            width: 420,
+            height: 520,
+            emphasis: 1,
+            isFocused: true,
+            runtime: runtime,
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        paneView.layoutSubtreeIfNeeded()
+
+        paneView.setLeadingMouseInteractionOcclusionWidth(160)
+
+        XCTAssertTrue(terminalView.mouseInteractionSuppressionRects.contains(
+            CGRect(x: 0, y: 0, width: 160, height: terminalView.bounds.height)
+        ))
+        XCTAssertTrue(terminalView.mouseInteractionSuppressionRects.contains(
+            CGRect(
+                x: 0,
+                y: terminalView.bounds.height - PaneContainerView.dragZoneHeight,
+                width: terminalView.bounds.width,
+                height: PaneContainerView.dragZoneHeight
+            )
+        ))
     }
 
     func test_search_hud_and_drag_strip_both_suppress_terminal_mouse_interaction() {
@@ -2010,6 +2078,7 @@ private final class OverlayHostingTerminalView: NSView, TerminalFocusReporting, 
     let overlayHostView = NSView()
     var onFocusDidChange: ((Bool) -> Void)?
     private(set) var mouseInteractionSuppressionRects: [CGRect] = []
+    private(set) var mouseInteractionSuppressionUpdateCount = 0
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -2045,6 +2114,7 @@ private final class OverlayHostingTerminalView: NSView, TerminalFocusReporting, 
 
 extension OverlayHostingTerminalView: TerminalMouseInteractionSuppressionControlling {
     func setMouseInteractionSuppressionRects(_ rects: [CGRect]) {
+        mouseInteractionSuppressionUpdateCount += 1
         mouseInteractionSuppressionRects = rects
     }
 }

--- a/ZenttyLogicTests/PaneDisplayIdentityResolverTests.swift
+++ b/ZenttyLogicTests/PaneDisplayIdentityResolverTests.swift
@@ -59,4 +59,82 @@ final class PaneDisplayIdentityResolverTests: XCTestCase {
         let pane = PaneState(id: PaneID("pn_a"), title: "shell", customTitle: nil)
         XCTAssertFalse(PaneDisplayIdentityResolver.hasCustomTitle(for: pane))
     }
+
+    func test_local_codex_spinner_animation_requires_live_metadata_title() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell")
+        let presentation = PanePresentationState(
+            recognizedTool: .codex,
+            isWorking: true
+        )
+        let metadata = TerminalMetadata(title: "Working ⠋ preserve ⠸ subject")
+
+        XCTAssertTrue(
+            PaneDisplayIdentityResolver.animatesLocalCodexSpinner(
+                pane: pane,
+                presentation: presentation,
+                metadata: metadata
+            )
+        )
+    }
+
+    func test_custom_title_with_braille_never_animates_as_codex_spinner() {
+        let pane = PaneState(
+            id: PaneID("pn_a"),
+            title: "shell",
+            customTitle: "Working ⠋ literal braille"
+        )
+        let presentation = PanePresentationState(
+            recognizedTool: .codex,
+            isWorking: true
+        )
+        let metadata = TerminalMetadata(title: "Working ⠹ actual status")
+
+        XCTAssertFalse(
+            PaneDisplayIdentityResolver.animatesLocalCodexSpinner(
+                pane: pane,
+                presentation: presentation,
+                metadata: metadata
+            )
+        )
+    }
+
+    func test_remote_codex_spinner_title_never_animates_locally() {
+        let pane = PaneState(id: PaneID("pn_a"), title: "shell")
+        let presentation = PanePresentationState(
+            isRemoteShell: true,
+            recognizedTool: .codex,
+            isWorking: true
+        )
+        let metadata = TerminalMetadata(title: "Working ⠹ remote status")
+
+        XCTAssertFalse(
+            PaneDisplayIdentityResolver.animatesLocalCodexSpinner(
+                pane: pane,
+                presentation: presentation,
+                metadata: metadata
+            )
+        )
+    }
+
+    func test_codex_spinner_range_requires_phase_delimiter_and_exact_braille_token() {
+        let validTitle = "  Thinking\t⠙ review ⠸ accessibility"
+        let range = TerminalMetadataChangeClassifier.codexActivitySpinnerRange(in: validTitle)
+
+        XCTAssertEqual(range.map { String(validTitle[$0]) }, "⠙")
+        XCTAssertNil(
+            TerminalMetadataChangeClassifier.codexActivitySpinnerRange(
+                in: "Working on ⠙ literal braille"
+            )
+        )
+        XCTAssertNil(
+            TerminalMetadataChangeClassifier.codexActivitySpinnerRange(
+                in: "Working ⠙without-delimiter"
+            )
+        )
+        XCTAssertNil(
+            TerminalMetadataChangeClassifier.codexActivitySpinnerRange(
+                in: "Ready ⠙ zentty"
+            )
+        )
+    }
 }

--- a/ZenttyLogicTests/PaneStripStoreTests.swift
+++ b/ZenttyLogicTests/PaneStripStoreTests.swift
@@ -10090,18 +10090,12 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertNil(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.reviewState)
     }
 
-    func test_updating_codex_spinner_title_variant_notifies_sidebar_immediately() throws {
+    func test_updating_codex_spinner_title_variant_doesNotInvalidateUI() throws {
         let store = WorklaneStore()
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
         store.knownNonRepositoryPaths.insert("/tmp/project")
-        // Notification can arrive via either channel:
-        //   1. `.auxiliaryStateUpdated(.sidebar)` via the slow path (e.g. for
-        //      meaningful changes like cwd/branch/phase transitions)
-        //   2. `.volatileAgentTitleUpdated` via the fast path when the
-        //      classifier recognizes a pure codex spinner variant tick
-        // Both channels ultimately update the sidebar row label for the
-        // changed pane. The test asserts the intent — "sidebar is notified
-        // of the spinner change" — without binding to the specific channel.
+        // Spinner-only title ticks remain stored for state inference but do
+        // not repaint sidebar or window chrome labels.
         var sidebarNotified = false
         var headerNotified = false
         let subscription = store.subscribe { change in
@@ -10141,7 +10135,7 @@ final class PaneStripStoreTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sidebarNotified, "sidebar must be notified of the spinner variant change")
+        XCTAssertFalse(sidebarNotified, "spinner-only Codex ticks must not invalidate sidebar UI")
         XCTAssertFalse(
             headerNotified,
             "chrome header must not be structurally invalidated for a pure spinner tick"

--- a/ZenttyLogicTests/PaneStripViewTests.swift
+++ b/ZenttyLogicTests/PaneStripViewTests.swift
@@ -91,6 +91,26 @@ final class PaneStripViewTests: AppKitTestCase {
     }
 
     @MainActor
+    func test_identical_render_does_not_reinvalidate_cursor_rects() {
+        let paneStripView = makePaneStripView()
+        let state = PaneStripState(
+            panes: [makePane("shell")],
+            focusedPaneID: PaneID("shell")
+        )
+
+        paneStripView.render(state, animated: false)
+        let invalidationCount = paneStripView.cursorRectInvalidationCountForTesting
+
+        paneStripView.render(state, animated: false)
+
+        XCTAssertEqual(
+            paneStripView.cursorRectInvalidationCountForTesting,
+            invalidationCount,
+            "content-only renders must preserve the pane strip's cursor rectangles"
+        )
+    }
+
+    @MainActor
     func test_single_pane_keeps_full_width_and_uses_balanced_bottom_gutter() throws {
         let paneStripView = makePaneStripView()
         let state = PaneStripState(
@@ -1481,6 +1501,38 @@ final class PaneStripViewTests: AppKitTestCase {
             assertRetinaAligned(paneView.frame.minY)
             assertRetinaAligned(paneView.frame.maxY)
         }
+    }
+
+    @MainActor
+    func test_sidebar_inset_suppresses_cursor_ownership_for_panes_under_sidebar() throws {
+        let adapterFactory = TerminalAdapterFactorySpy()
+        let runtimeRegistry = PaneRuntimeRegistry(adapterFactory: adapterFactory.makeAdapter)
+        let paneStripView = PaneStripView(
+            frame: NSRect(x: 0, y: 0, width: 1200, height: 680),
+            runtimeRegistry: runtimeRegistry
+        )
+        paneStripView.leadingVisibleInset = sidebarInset
+        let state = PaneStripState(
+            panes: [makePane("logs"), makePane("editor"), makePane("tests")],
+            focusedPaneID: PaneID("tests")
+        )
+
+        paneStripView.render(state, animated: false)
+        paneStripView.layoutSubtreeIfNeeded()
+
+        let coveredPane = try XCTUnwrap(
+            paneStripView.descendantPaneViews().first { $0.frame.minX < sidebarInset }
+        )
+        let adapter = try XCTUnwrap(adapterFactory.adapter(for: coveredPane.paneID))
+        let expectedWidth = min(coveredPane.frame.width, sidebarInset - coveredPane.frame.minX)
+        XCTAssertTrue(adapter.terminalView.mouseInteractionSuppressionRects.contains(
+            CGRect(
+                x: 0,
+                y: 0,
+                width: expectedWidth,
+                height: adapter.terminalView.bounds.height
+            )
+        ))
     }
 
     @MainActor
@@ -4553,7 +4605,13 @@ private final class PaneStripTerminalAdapterSpy: TerminalAdapter {
     }
 }
 
-private final class PaneStripTerminalViewSpy: NSView, TerminalViewportSyncControlling, TerminalFocusReporting, TerminalFocusTargetProviding {
+private final class PaneStripTerminalViewSpy:
+    NSView,
+    TerminalViewportSyncControlling,
+    TerminalFocusReporting,
+    TerminalFocusTargetProviding,
+    TerminalMouseInteractionSuppressionControlling
+{
     var onFocusDidChange: ((Bool) -> Void)?
     private(set) var hasValidViewportSync = false
     private(set) var viewportSyncSuspensionUpdates: [Bool] = []
@@ -4562,6 +4620,7 @@ private final class PaneStripTerminalViewSpy: NSView, TerminalViewportSyncContro
     private(set) var forceViewportSyncCallCount = 0
     private(set) var displayIfNeededCallCount = 0
     private(set) var layoutPassCount = 0
+    private(set) var mouseInteractionSuppressionRects: [CGRect] = []
     let detachedFocusTarget = NSView()
     var usesDetachedFocusTarget = false
 
@@ -4588,6 +4647,10 @@ private final class PaneStripTerminalViewSpy: NSView, TerminalViewportSyncContro
     func forceViewportSync() {
         hasValidViewportSync = true
         forceViewportSyncCallCount += 1
+    }
+
+    func setMouseInteractionSuppressionRects(_ rects: [CGRect]) {
+        mouseInteractionSuppressionRects = rects
     }
 
     func simulateFocusChange(_ isFocused: Bool) {

--- a/ZenttyLogicTests/RootViewCompositionTests.swift
+++ b/ZenttyLogicTests/RootViewCompositionTests.swift
@@ -1711,30 +1711,52 @@ final class RootViewCompositionTests: AppKitTestCase {
         XCTAssertGreaterThan(sidebarView.addWorklaneIconAlpha, restingIconAlpha)
     }
 
-    func test_sidebar_resize_hit_area_is_centered_on_outer_edge_without_visible_indicator() {
+    func test_sidebar_has_no_embedded_resize_cursor_owner() {
         let sidebarView = SidebarView(frame: NSRect(x: 0, y: 0, width: 280, height: 500))
 
         sidebarView.layoutSubtreeIfNeeded()
 
-        XCTAssertEqual(sidebarView.debugSnapshotForTesting.resizeHandleWidth, 4, accuracy: 0.001)
-        XCTAssertEqual(
-            sidebarView.resizeHandleMinX,
-            sidebarView.bounds.maxX - sidebarView.debugSnapshotForTesting.resizeHandleWidth,
-            accuracy: 0.001
-        )
-        XCTAssertEqual(sidebarView.resizeHandleMaxX, sidebarView.bounds.maxX, accuracy: 0.001)
-        XCTAssertEqual(sidebarView.resizeHandleFillAlpha, 0, accuracy: 0.001)
-        XCTAssertFalse(sidebarView.isResizeHandleHidden)
-        XCTAssertTrue(sidebarView.trailingEdgeHitTargetsResizeHandle)
-        XCTAssertFalse(sidebarView.hitTargetsResizeHandle(atX: sidebarView.bounds.maxX - 5))
+        XCTAssertFalse(sidebarView.subviews.contains { $0 is SidebarResizeHandleView })
     }
 
-    func test_sidebar_hides_resize_handle_when_resize_is_disabled() {
-        let sidebarView = SidebarView(frame: NSRect(x: 0, y: 0, width: 280, height: 500))
+    func test_root_resize_hit_area_continues_across_sidebar_outer_edge() throws {
+        let controller = makeController()
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        controller.view.layoutSubtreeIfNeeded()
 
-        sidebarView.setResizeEnabled(false)
+        let sidebar = try XCTUnwrap(
+            controller.view.subviews.first { $0 is SidebarView } as? SidebarView
+        )
+        let outerHandle = try XCTUnwrap(
+            controller.view.subviews.first { $0 is SidebarResizeHandleView }
+                as? SidebarResizeHandleView
+        )
+        let innerPoint = NSPoint(x: sidebar.frame.maxX - 1, y: sidebar.frame.midY)
+        let outerPoint = NSPoint(
+            x: sidebar.frame.maxX + ShellMetrics.canvasSidebarGap - 1,
+            y: sidebar.frame.midY
+        )
 
-        XCTAssertTrue(sidebarView.isResizeHandleHidden)
+        XCTAssertEqual(
+            outerHandle.frame.minX,
+            sidebar.frame.maxX - SidebarResizeHandleView.hitWidth,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            outerHandle.frame.width,
+            SidebarResizeHandleView.hitWidth + ShellMetrics.canvasSidebarGap,
+            accuracy: 0.001
+        )
+        XCTAssertTrue(controller.view.hitTest(innerPoint) === outerHandle)
+        XCTAssertTrue(controller.view.hitTest(outerPoint) === outerHandle)
+        XCTAssertFalse(outerHandle.trackingAreas.contains { $0.options.contains(.cursorUpdate) })
+        XCTAssertTrue(
+            controller.rootPointerCursorForTesting(at: innerPoint) === NSCursor.resizeLeftRight
+        )
+        XCTAssertTrue(
+            controller.rootPointerCursorForTesting(at: outerPoint) === NSCursor.resizeLeftRight
+        )
     }
 
     func test_sidebar_glass_forces_dark_appearance_for_dark_themes() {

--- a/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
+++ b/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
@@ -66,4 +66,46 @@ final class SidebarPanePrimaryRowViewTests: AppKitTestCase {
 
         XCTAssertEqual(view.remoteIconTintColorForTesting, trailingColor)
     }
+
+    func test_working_braille_title_uses_local_spinner_renderer() {
+        let view = SidebarPanePrimaryRowView()
+        view.configure(
+            primaryText: "Working ⠋ zentty",
+            trailingText: nil,
+            presentationMode: .inline,
+            lineCount: 1
+        )
+
+        view.applyColors(
+            primaryColor: .labelColor,
+            trailingColor: .secondaryLabelColor,
+            isShimmering: true,
+            shimmerColor: .controlAccentColor,
+            reducedMotion: false
+        )
+
+        XCTAssertTrue(view.animatesBrailleSpinnerForTesting)
+        XCTAssertTrue(view.baseLabelIsHiddenForTesting)
+    }
+
+    func test_non_braille_title_keeps_static_base_label() {
+        let view = SidebarPanePrimaryRowView()
+        view.configure(
+            primaryText: "Working zentty",
+            trailingText: nil,
+            presentationMode: .inline,
+            lineCount: 1
+        )
+
+        view.applyColors(
+            primaryColor: .labelColor,
+            trailingColor: .secondaryLabelColor,
+            isShimmering: true,
+            shimmerColor: .controlAccentColor,
+            reducedMotion: false
+        )
+
+        XCTAssertFalse(view.animatesBrailleSpinnerForTesting)
+        XCTAssertFalse(view.baseLabelIsHiddenForTesting)
+    }
 }

--- a/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
+++ b/ZenttyLogicTests/SidebarPanePrimaryRowViewTests.swift
@@ -81,11 +81,13 @@ final class SidebarPanePrimaryRowViewTests: AppKitTestCase {
             trailingColor: .secondaryLabelColor,
             isShimmering: true,
             shimmerColor: .controlAccentColor,
-            reducedMotion: false
+            reducedMotion: false,
+            animatesLocalCodexSpinner: true
         )
 
         XCTAssertTrue(view.animatesBrailleSpinnerForTesting)
-        XCTAssertTrue(view.baseLabelIsHiddenForTesting)
+        XCTAssertFalse(view.baseLabelIsHiddenForTesting)
+        XCTAssertEqual(view.renderedPrimaryTextColorForTesting, .clear)
     }
 
     func test_non_braille_title_keeps_static_base_label() {
@@ -107,5 +109,58 @@ final class SidebarPanePrimaryRowViewTests: AppKitTestCase {
 
         XCTAssertFalse(view.animatesBrailleSpinnerForTesting)
         XCTAssertFalse(view.baseLabelIsHiddenForTesting)
+    }
+
+    func test_custom_braille_title_keeps_static_base_label() {
+        let view = SidebarPanePrimaryRowView()
+        view.configure(
+            primaryText: "Working ⠋ literal custom title",
+            trailingText: nil,
+            presentationMode: .inline,
+            lineCount: 1
+        )
+
+        view.applyColors(
+            primaryColor: .labelColor,
+            trailingColor: .secondaryLabelColor,
+            isShimmering: true,
+            shimmerColor: .controlAccentColor,
+            reducedMotion: false,
+            animatesLocalCodexSpinner: false
+        )
+
+        XCTAssertFalse(view.animatesBrailleSpinnerForTesting)
+        XCTAssertFalse(view.baseLabelIsHiddenForTesting)
+        XCTAssertEqual(view.renderedPrimaryTextColorForTesting, .labelColor)
+    }
+
+    func test_stopping_local_spinner_restores_static_base_label_color() {
+        let view = SidebarPanePrimaryRowView()
+        view.configure(
+            primaryText: "Working ⠋ zentty",
+            trailingText: nil,
+            presentationMode: .inline,
+            lineCount: 1
+        )
+        view.applyColors(
+            primaryColor: .labelColor,
+            trailingColor: .secondaryLabelColor,
+            isShimmering: true,
+            shimmerColor: .controlAccentColor,
+            reducedMotion: false,
+            animatesLocalCodexSpinner: true
+        )
+
+        view.applyColors(
+            primaryColor: .systemPink,
+            trailingColor: .secondaryLabelColor,
+            isShimmering: false,
+            shimmerColor: .controlAccentColor,
+            reducedMotion: false
+        )
+
+        XCTAssertFalse(view.animatesBrailleSpinnerForTesting)
+        XCTAssertFalse(view.baseLabelIsHiddenForTesting)
+        XCTAssertEqual(view.renderedPrimaryTextColorForTesting, .systemPink)
     }
 }

--- a/ZenttyLogicTests/SidebarShimmerCoordinatorTests.swift
+++ b/ZenttyLogicTests/SidebarShimmerCoordinatorTests.swift
@@ -7,4 +7,36 @@ final class SidebarShimmerCoordinatorTests: XCTestCase {
         XCTAssertEqual(SidebarShimmerCoordinator.pauseRangeForTesting.lowerBound, 2.5)
         XCTAssertEqual(SidebarShimmerCoordinator.pauseRangeForTesting.upperBound, 4.0)
     }
+
+    func test_braille_spinner_advances_without_mutating_source_title() {
+        let view = SidebarShimmerTextView()
+        view.stringValue = "Working ⠹ zentty"
+        view.animatesBrailleSpinner = true
+        view.isShimmering = true
+        view.isVisibleForSharedAnimation = true
+
+        XCTAssertEqual(view.displayedStringValueForTesting, "Working ⠋ zentty")
+
+        for _ in 0..<SidebarShimmerTextView.spinnerTicksPerFrameForTesting {
+            view.applySharedShimmerState(phase: 0, inSweep: false)
+        }
+
+        XCTAssertEqual(view.displayedStringValueForTesting, "Working ⠙ zentty")
+        XCTAssertEqual(view.stringValue, "Working ⠹ zentty")
+    }
+
+    func test_braille_spinner_respects_reduced_motion() {
+        let view = SidebarShimmerTextView()
+        view.stringValue = "Working ⠹ zentty"
+        view.animatesBrailleSpinner = true
+        view.isShimmering = true
+        view.isVisibleForSharedAnimation = true
+        view.reducedMotion = true
+
+        for _ in 0..<(SidebarShimmerTextView.spinnerTicksPerFrameForTesting * 2) {
+            view.applySharedShimmerState(phase: 0, inSweep: false)
+        }
+
+        XCTAssertEqual(view.displayedStringValueForTesting, "Working ⠋ zentty")
+    }
 }

--- a/ZenttyLogicTests/SidebarShimmerCoordinatorTests.swift
+++ b/ZenttyLogicTests/SidebarShimmerCoordinatorTests.swift
@@ -39,4 +39,20 @@ final class SidebarShimmerCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(view.displayedStringValueForTesting, "Working ⠋ zentty")
     }
+
+    func test_braille_in_a_regular_title_is_never_rewritten() {
+        let view = SidebarShimmerTextView()
+        view.stringValue = "Working on ⠹ literal braille"
+        view.animatesBrailleSpinner = true
+
+        XCTAssertEqual(view.displayedStringValueForTesting, "Working on ⠹ literal braille")
+    }
+
+    func test_codex_spinner_replacement_preserves_braille_in_the_subject() {
+        let view = SidebarShimmerTextView()
+        view.stringValue = "Working ⠹ review ⠸ accessibility"
+        view.animatesBrailleSpinner = true
+
+        XCTAssertEqual(view.displayedStringValueForTesting, "Working ⠋ review ⠸ accessibility")
+    }
 }

--- a/ZenttyLogicTests/SidebarViewRenderTests.swift
+++ b/ZenttyLogicTests/SidebarViewRenderTests.swift
@@ -4,6 +4,28 @@ import XCTest
 
 @MainActor
 final class SidebarViewRenderTests: AppKitTestCase {
+    func test_worklane_row_uses_the_default_arrow_cursor() throws {
+        let sidebar = makeSidebar()
+        sidebar.render(
+            summaries: [makeSummary(worklaneID: "main", primaryText: "demo")],
+            theme: ZenttyTheme.fallback(for: nil)
+        )
+        sidebar.layoutSubtreeIfNeeded()
+
+        let row = try XCTUnwrap(sidebarWorklaneButtons(in: sidebar).first)
+        row.updateTrackingAreas()
+        XCTAssertFalse(row.trackingAreas.contains { $0.options.contains(.cursorUpdate) })
+        XCTAssertFalse(row.trackingAreas.contains { $0.options.contains(.mouseMoved) })
+    }
+
+    func test_empty_sidebar_has_no_worklane_row_cursor_owner() throws {
+        let sidebar = makeSidebar()
+
+        sidebar.layoutSubtreeIfNeeded()
+
+        XCTAssertTrue(try sidebarWorklaneButtons(in: sidebar).isEmpty)
+    }
+
     func test_sidebar_toggle_tooltip_uses_configured_shortcut() {
         let button = SidebarToggleButton()
 
@@ -956,6 +978,22 @@ final class SidebarViewRenderTests: AppKitTestCase {
                 context: nil,
                 eventNumber: 1,
                 clickCount: 1,
+                pressure: 0
+            )
+        )
+    }
+
+    private func makeMouseMovedEvent() throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.mouseEvent(
+                with: .mouseMoved,
+                location: NSPoint(x: 12, y: 120),
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                eventNumber: 1,
+                clickCount: 0,
                 pressure: 0
             )
         )

--- a/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
+++ b/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
@@ -7,6 +7,47 @@ import XCTest
 final class SidebarWorklaneRowButtonTests: AppKitTestCase {
     private var rowWidthConstraints: [ObjectIdentifier: NSLayoutConstraint] = [:]
 
+    func test_working_braille_title_uses_local_spinner_renderer() {
+        let row = makeRow()
+
+        row.configure(
+            with: makeSummary(
+                primaryText: "Working ⠋ zentty",
+                statusText: "Running",
+                attentionState: .running,
+                isWorking: true
+            ),
+            theme: ZenttyTheme.fallback(for: nil),
+            animated: false
+        )
+
+        XCTAssertTrue(row.debugAccessForTesting.primaryLabel.animatesBrailleSpinner)
+        XCTAssertTrue(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+    }
+
+    func test_idle_braille_title_restores_static_base_label() {
+        let row = makeRow()
+        row.configure(
+            with: makeSummary(
+                primaryText: "Working ⠋ zentty",
+                statusText: "Running",
+                attentionState: .running,
+                isWorking: true
+            ),
+            theme: ZenttyTheme.fallback(for: nil),
+            animated: false
+        )
+
+        row.configure(
+            with: makeSummary(primaryText: "Ready · zentty"),
+            theme: ZenttyTheme.fallback(for: nil),
+            animated: false
+        )
+
+        XCTAssertFalse(row.debugAccessForTesting.primaryLabel.animatesBrailleSpinner)
+        XCTAssertFalse(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+    }
+
     func test_working_worklane_row_does_not_animate_until_it_is_hosted_in_a_visible_sidebar() {
         let row = makeRow()
 
@@ -2951,6 +2992,55 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         XCTAssertEqual(row.debugSnapshotForTesting.configureApplyCount, 2)
     }
 
+    func test_working_state_refresh_preserves_sidebar_view_hierarchy() throws {
+        let row = makeRow(width: 320, height: 120)
+        let theme = ZenttyTheme.fallback(for: nil)
+        let idlePaneRows = [
+            makePaneRow(
+                isFocused: true,
+                detailText: nil,
+                statusText: nil
+            )
+        ]
+
+        row.configure(
+            with: makeSummary(primaryText: "Claude Code", paneRows: idlePaneRows),
+            theme: theme,
+            animated: false
+        )
+        let paneButton = try XCTUnwrap(row.debugAccessForTesting.paneRowButtons.first)
+        let rowReplacementCount = row.contentStackReplacementCountForTesting
+        let paneReplacementCount = paneButton.contentStackReplacementCountForTesting
+
+        row.configure(
+            with: makeSummary(
+                primaryText: "Claude Code",
+                paneRows: [
+                    makePaneRow(
+                        isFocused: true,
+                        detailText: "…/zentty",
+                        statusText: "Working",
+                        isWorking: true
+                    )
+                ],
+                isWorking: true
+            ),
+            theme: theme,
+            animated: false
+        )
+
+        XCTAssertEqual(
+            row.contentStackReplacementCountForTesting,
+            rowReplacementCount,
+            "a content-only Working refresh must not rebuild the Worklane stack"
+        )
+        XCTAssertEqual(
+            paneButton.contentStackReplacementCountForTesting,
+            paneReplacementCount,
+            "a content-only Working refresh must not rebuild the pane stack"
+        )
+    }
+
     func test_configure_runsAgainWhenBoundsWidthChanges() {
         let row = makeRow(width: 220)
         let theme = ZenttyTheme.fallback(for: nil)
@@ -3046,17 +3136,20 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
 
     private func makePaneRow(
         paneID: String = "worklane-main-pane",
-        isFocused: Bool
+        isFocused: Bool,
+        detailText: String? = "…/zentty",
+        statusText: String? = "╰ Idle",
+        isWorking: Bool = false
     ) -> WorklaneSidebarPaneRow {
         WorklaneSidebarPaneRow(
             paneID: PaneID(paneID),
             primaryText: "Claude Code",
             trailingText: "main",
-            detailText: "…/zentty",
-            statusText: "╰ Idle",
+            detailText: detailText,
+            statusText: statusText,
             attentionState: nil,
             isFocused: isFocused,
-            isWorking: false
+            isWorking: isWorking
         )
     }
 

--- a/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
+++ b/ZenttyLogicTests/SidebarWorklaneRowButtonTests.swift
@@ -13,6 +13,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         row.configure(
             with: makeSummary(
                 primaryText: "Working ⠋ zentty",
+                primaryAnimatesLocalCodexSpinner: true,
                 statusText: "Running",
                 attentionState: .running,
                 isWorking: true
@@ -22,7 +23,8 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         )
 
         XCTAssertTrue(row.debugAccessForTesting.primaryLabel.animatesBrailleSpinner)
-        XCTAssertTrue(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+        XCTAssertFalse(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+        XCTAssertEqual(row.debugAccessForTesting.primaryBaseLabel.textColor, .clear)
     }
 
     func test_idle_braille_title_restores_static_base_label() {
@@ -30,6 +32,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
         row.configure(
             with: makeSummary(
                 primaryText: "Working ⠋ zentty",
+                primaryAnimatesLocalCodexSpinner: true,
                 statusText: "Running",
                 attentionState: .running,
                 isWorking: true
@@ -46,6 +49,26 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
 
         XCTAssertFalse(row.debugAccessForTesting.primaryLabel.animatesBrailleSpinner)
         XCTAssertFalse(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+        XCTAssertNotEqual(row.debugAccessForTesting.primaryBaseLabel.textColor, .clear)
+    }
+
+    func test_working_custom_braille_title_keeps_static_base_label() {
+        let row = makeRow()
+
+        row.configure(
+            with: makeSummary(
+                primaryText: "Working ⠋ literal custom title",
+                statusText: "Running",
+                attentionState: .running,
+                isWorking: true
+            ),
+            theme: ZenttyTheme.fallback(for: nil),
+            animated: false
+        )
+
+        XCTAssertFalse(row.debugAccessForTesting.primaryLabel.animatesBrailleSpinner)
+        XCTAssertFalse(row.debugAccessForTesting.primaryBaseLabel.isHidden)
+        XCTAssertNotEqual(row.debugAccessForTesting.primaryBaseLabel.textColor, .clear)
     }
 
     func test_working_worklane_row_does_not_animate_until_it_is_hosted_in_a_visible_sidebar() {
@@ -3082,6 +3105,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
     private func makeSummary(
         topLabel: String? = nil,
         primaryText: String,
+        primaryAnimatesLocalCodexSpinner: Bool = false,
         contextPrefixText: String? = nil,
         focusedPaneLineIndex: Int = 0,
         statusText: String? = nil,
@@ -3100,6 +3124,7 @@ final class SidebarWorklaneRowButtonTests: AppKitTestCase {
             badgeText: "1",
             topLabel: topLabel,
             primaryText: primaryText,
+            primaryAnimatesLocalCodexSpinner: primaryAnimatesLocalCodexSpinner,
             contextPrefixText: contextPrefixText,
             focusedPaneLineIndex: focusedPaneLineIndex,
             statusText: statusText,

--- a/ZenttyLogicTests/WindowChromeViewTests.swift
+++ b/ZenttyLogicTests/WindowChromeViewTests.swift
@@ -147,7 +147,7 @@ final class WindowChromeViewTests: AppKitTestCase {
         )
         view.render(summary: WorklaneChromeSummary(
             focusedLabel: "Working ⠂ linkedin-detox | Tasks 0/5",
-            focusedPaneIsWorking: true,
+            focusedLabelAnimatesLocalCodexSpinner: true,
             branch: "main",
             pullRequest: nil,
             reviewChips: []
@@ -163,14 +163,14 @@ final class WindowChromeViewTests: AppKitTestCase {
         XCTAssertEqual(view.focusedLabelText, "Working ⠂ linkedin-detox | Tasks 0/5")
     }
 
-    func test_idle_braille_title_stays_static_in_window_chrome() {
+    func test_custom_braille_title_stays_static_in_window_chrome() {
         let view = WindowChromeView(
             frame: NSRect(x: 0, y: 0, width: 720, height: WindowChromeView.preferredHeight),
             reducedMotionProvider: { false }
         )
         view.render(summary: WorklaneChromeSummary(
-            focusedLabel: "Ready ⠂ linkedin-detox",
-            focusedPaneIsWorking: false,
+            focusedLabel: "Working ⠂ literal custom title",
+            focusedLabelAnimatesLocalCodexSpinner: false,
             branch: "main",
             pullRequest: nil,
             reviewChips: []
@@ -180,7 +180,7 @@ final class WindowChromeViewTests: AppKitTestCase {
         view.advanceFocusedBrailleSpinnerForTesting()
 
         XCTAssertFalse(view.focusedLabelUsesLocalBrailleAnimationForTesting)
-        XCTAssertEqual(view.focusedSpinnerDisplayedTextForTesting, "Ready ⠂ linkedin-detox")
+        XCTAssertEqual(view.focusedSpinnerDisplayedTextForTesting, "Working ⠂ literal custom title")
     }
 
     func test_window_chrome_braille_animation_respects_reduced_motion_and_theme_color() {
@@ -192,7 +192,7 @@ final class WindowChromeViewTests: AppKitTestCase {
         view.apply(theme: theme, animated: false)
         view.render(summary: WorklaneChromeSummary(
             focusedLabel: "Working ⠂ linkedin-detox",
-            focusedPaneIsWorking: true,
+            focusedLabelAnimatesLocalCodexSpinner: true,
             branch: "main",
             pullRequest: nil,
             reviewChips: []

--- a/ZenttyLogicTests/WindowChromeViewTests.swift
+++ b/ZenttyLogicTests/WindowChromeViewTests.swift
@@ -140,6 +140,74 @@ final class WindowChromeViewTests: AppKitTestCase {
         XCTAssertEqual(view.reviewChipTexts, ["Draft", "2 failing"])
     }
 
+    func test_working_braille_title_animates_locally_without_mutating_focused_label() {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 720, height: WindowChromeView.preferredHeight),
+            reducedMotionProvider: { false }
+        )
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Working ⠂ linkedin-detox | Tasks 0/5",
+            focusedPaneIsWorking: true,
+            branch: "main",
+            pullRequest: nil,
+            reviewChips: []
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        let initialRenderedText = view.focusedSpinnerDisplayedTextForTesting
+        view.advanceFocusedBrailleSpinnerForTesting()
+
+        XCTAssertTrue(view.focusedLabelUsesLocalBrailleAnimationForTesting)
+        XCTAssertTrue(view.focusedSpinnerIgnoresHitTestingForTesting)
+        XCTAssertNotEqual(view.focusedSpinnerDisplayedTextForTesting, initialRenderedText)
+        XCTAssertEqual(view.focusedLabelText, "Working ⠂ linkedin-detox | Tasks 0/5")
+    }
+
+    func test_idle_braille_title_stays_static_in_window_chrome() {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 720, height: WindowChromeView.preferredHeight),
+            reducedMotionProvider: { false }
+        )
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Ready ⠂ linkedin-detox",
+            focusedPaneIsWorking: false,
+            branch: "main",
+            pullRequest: nil,
+            reviewChips: []
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        view.advanceFocusedBrailleSpinnerForTesting()
+
+        XCTAssertFalse(view.focusedLabelUsesLocalBrailleAnimationForTesting)
+        XCTAssertEqual(view.focusedSpinnerDisplayedTextForTesting, "Ready ⠂ linkedin-detox")
+    }
+
+    func test_window_chrome_braille_animation_respects_reduced_motion_and_theme_color() {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 720, height: WindowChromeView.preferredHeight),
+            reducedMotionProvider: { true }
+        )
+        let theme = ZenttyTheme.fallback(for: NSAppearance(named: .darkAqua))
+        view.apply(theme: theme, animated: false)
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Working ⠂ linkedin-detox",
+            focusedPaneIsWorking: true,
+            branch: "main",
+            pullRequest: nil,
+            reviewChips: []
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        let initialRenderedText = view.focusedSpinnerDisplayedTextForTesting
+        view.advanceFocusedBrailleSpinnerForTesting()
+
+        XCTAssertTrue(view.focusedLabelUsesLocalBrailleAnimationForTesting)
+        XCTAssertTrue(view.focusedSpinnerReducedMotionForTesting)
+        XCTAssertEqual(view.focusedSpinnerDisplayedTextForTesting, initialRenderedText)
+        XCTAssertEqual(view.focusedSpinnerBaseColorForTesting, theme.secondaryText)
+    }
+
     func test_window_chrome_renders_branch_without_pr_and_hides_review_chips() {
         let view = WindowChromeView(
             frame: NSRect(x: 0, y: 0, width: 520, height: WindowChromeView.preferredHeight)

--- a/ZenttyLogicTests/WorklaneHeaderSummaryBuilderTests.swift
+++ b/ZenttyLogicTests/WorklaneHeaderSummaryBuilderTests.swift
@@ -312,6 +312,7 @@ final class WorklaneHeaderSummaryBuilderTests: XCTestCase {
         let summary = WorklaneHeaderSummaryBuilder.summary(for: worklane)
 
         XCTAssertEqual(summary.focusedLabel, "Thinking ✳ Investigate pane title updates")
+        XCTAssertTrue(summary.focusedPaneIsWorking)
     }
 
     func test_summary_omits_compacted_metadata_branch_when_review_state_is_unavailable() {

--- a/ZenttyLogicTests/WorklaneHeaderSummaryBuilderTests.swift
+++ b/ZenttyLogicTests/WorklaneHeaderSummaryBuilderTests.swift
@@ -312,7 +312,7 @@ final class WorklaneHeaderSummaryBuilderTests: XCTestCase {
         let summary = WorklaneHeaderSummaryBuilder.summary(for: worklane)
 
         XCTAssertEqual(summary.focusedLabel, "Thinking ✳ Investigate pane title updates")
-        XCTAssertTrue(summary.focusedPaneIsWorking)
+        XCTAssertFalse(summary.focusedLabelAnimatesLocalCodexSpinner)
     }
 
     func test_summary_omits_compacted_metadata_branch_when_review_state_is_unavailable() {
@@ -453,6 +453,31 @@ final class WorklaneHeaderSummaryBuilderTests: XCTestCase {
         let summary = WorklaneHeaderSummaryBuilder.summary(for: worklane)
 
         XCTAssertEqual(summary.focusedLabel, "/tmp/project")
+    }
+
+    func test_summary_marks_only_live_local_codex_spinner_title_for_animation() {
+        let paneID = PaneID("pane-codex")
+        let worklane = makeWorklane(
+            paneID: paneID,
+            metadata: TerminalMetadata(
+                title: "Working ⠋ preserve ⠸ subject",
+                currentWorkingDirectory: "/tmp/project",
+                processName: "codex",
+                gitBranch: "main"
+            ),
+            agentStatus: PaneAgentStatus(
+                tool: .codex,
+                state: .running,
+                text: nil,
+                artifactLink: nil,
+                updatedAt: Date(timeIntervalSince1970: 42)
+            )
+        )
+
+        let summary = WorklaneHeaderSummaryBuilder.summary(for: worklane)
+
+        XCTAssertEqual(summary.focusedLabel, "Working ⠋ preserve ⠸ subject")
+        XCTAssertTrue(summary.focusedLabelAnimatesLocalCodexSpinner)
     }
 
     func test_summary_surfaces_remote_context_without_reusing_local_cwd_path() {

--- a/ZenttyLogicTests/WorklaneSidebarSummaryTests.swift
+++ b/ZenttyLogicTests/WorklaneSidebarSummaryTests.swift
@@ -1860,6 +1860,8 @@ final class WorklaneSidebarSummaryTests: XCTestCase {
         XCTAssertEqual(paneRow.statusText, "Running")
         XCTAssertEqual(paneRow.attentionState, .running)
         XCTAssertTrue(paneRow.isWorking)
+        XCTAssertFalse(paneRow.animatesLocalCodexSpinner)
+        XCTAssertFalse(summary.primaryAnimatesLocalCodexSpinner)
     }
 
     func test_builder_uses_compacting_agent_status_text_while_remaining_running() {
@@ -1939,6 +1941,8 @@ final class WorklaneSidebarSummaryTests: XCTestCase {
         XCTAssertEqual(paneRow.statusText, "Running")
         XCTAssertEqual(paneRow.attentionState, .running)
         XCTAssertTrue(paneRow.isWorking)
+        XCTAssertTrue(paneRow.animatesLocalCodexSpinner)
+        XCTAssertTrue(summary.primaryAnimatesLocalCodexSpinner)
     }
 
     func test_builder_uses_exact_claude_status_title_as_primary_when_running() {

--- a/ZenttyLogicTests/WorklaneStoreMetadataVolatileFastPathTests.swift
+++ b/ZenttyLogicTests/WorklaneStoreMetadataVolatileFastPathTests.swift
@@ -658,7 +658,7 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
         )
     }
 
-    func test_volatileTitleTick_fires_volatileAgentTitleUpdated_not_auxiliaryStateUpdated() throws {
+    func test_codexVolatileTitleTick_updatesMetadata_withoutUIInvalidation() throws {
         let store = WorklaneStore(readyStatusDebounceInterval: 0)
         store.knownNonRepositoryPaths.insert("/tmp/project")
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
@@ -699,8 +699,12 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
             if case .auxiliaryStateUpdated = change { return true }
             return false
         }
-        XCTAssertEqual(volatileUpdates.count, 1, "expected one volatileAgentTitleUpdated")
+        XCTAssertEqual(volatileUpdates.count, 0, "spinner-only Codex ticks must not repaint AppKit UI")
         XCTAssertEqual(auxiliaryUpdates.count, 0, "slow path should not fire for volatile-only tick")
+        XCTAssertEqual(
+            store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.metadata?.title,
+            "Working ⠙ zentty"
+        )
     }
 
     func test_volatileTitleTick_updates_stored_metadata() throws {
@@ -1474,7 +1478,7 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
         XCTAssertNotEqual(auxiliaryState.presentation.statusText, "Stopped early")
     }
 
-    func test_hiddenWorklane_doesNotCoalesceVolatileNotifications() throws {
+    func test_hiddenWorklane_codexVolatileTicks_doNotEmitUIUpdates() throws {
         let store = WorklaneStore(readyStatusDebounceInterval: 0)
         store.knownNonRepositoryPaths.insert("/tmp/project")
         let activeWorklaneID = try XCTUnwrap(store.activeWorklane?.id)
@@ -1525,8 +1529,8 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
         }
         XCTAssertEqual(
             volatileUpdates.count,
-            3,
-            "hidden-worklane volatile ticks should stay realtime so background panes feel active"
+            0,
+            "hidden Codex spinner ticks must not repaint AppKit UI"
         )
 
         XCTAssertEqual(
@@ -1593,7 +1597,7 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
         )
     }
 
-    func test_activeWorklane_doesNotCoalesceVolatileNotifications() throws {
+    func test_activeWorklane_codexVolatileTicks_doNotEmitUIUpdates() throws {
         let store = WorklaneStore(readyStatusDebounceInterval: 0)
         store.knownNonRepositoryPaths.insert("/tmp/project")
         let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
@@ -1633,8 +1637,8 @@ final class WorklaneStoreMetadataVolatileFastPathTests: XCTestCase {
         }
         XCTAssertEqual(
             volatileUpdates.count,
-            3,
-            "active-worklane volatile ticks must not be throttled — they drive the realtime spinner"
+            0,
+            "active Codex spinner ticks must not repaint AppKit UI"
         )
     }
 


### PR DESCRIPTION
## Summary

- keep terminal cursor ownership stable while output, scrolling, and layout updates change the viewport beneath a stationary pointer
- retain the cursor that is actually displayed during programmatic viewport changes, then resume semantic terminal cursor updates after genuine pointer movement
- prevent volatile Codex Braille title ticks from repeatedly repainting AppKit sidebar and window-chrome labels
- animate the visible Worklane and title-bar activity glyphs locally with one shared per-window animation clock, the resolved theme color, and reduced-motion support
- remove competing cursor updates from background panes, sidebar rows, controls, and chrome regions
- add regression coverage for cursor retention, tracking ownership, scrolling, sidebar and window-chrome rendering, and volatile metadata updates

## Root cause

Several independent AppKit paths could recalculate or write the application-wide cursor while the pointer itself had not moved. Terminal output and momentum scrolling changed viewport geometry, background terminal surfaces invalidated cursor state, and high-frequency Codex title updates repeatedly repainted sidebar rows. On affected macOS builds, those updates could briefly expose different cursor regions under the same stationary pointer, producing rapid pointer/I-beam flicker across panes and sidebar content.

Suppressing volatile Braille-only metadata renders fixed that repaint source, but initially left the custom window-chrome activity glyph frozen because it still relied on metadata updates to advance its frame.

## Fix

The terminal now separates pointer tracking from cursor ownership and only applies Ghostty cursor shapes when hit-testing confirms that the terminal is topmost under the pointer. During programmatic viewport growth, it retains the cursor currently shown by AppKit until real pointer movement makes a semantic cursor refresh appropriate. Scroll and lifecycle transitions no longer perform repeated global cursor writes.

For the sidebar and window chrome, volatile Braille-only title changes still update stored metadata but skip unnecessary UI invalidation. The visible activity glyphs advance locally through `SidebarShimmerTextView` using the same per-window coordinator. The CoreText path uses the resolved Worklane theme color, respects reduced motion, and the window-chrome overlay ignores hit testing so it does not become a new cursor or drag-region owner.

Fixes #66

## Validation

- 515 focused logic and detached AppKit tests passed with 0 failures for the cursor-flicker change set
- 62 focused window-chrome and header-summary tests passed with 0 failures after adding title-bar animation coverage
- full signed macOS Debug build succeeded and passed strict code-signature verification
- live validation covered active Codex output, programmatic terminal scrolling, smooth and momentum scrolling, multiple panes, Worklane rows, sidebar controls, pane headers, and window chrome
- confirmed stable cursor behavior plus smooth, correctly colored Worklane and title-bar activity animation in the installed build

I have read CLA.md and agree to its terms.
