### PR TITLE
Fix custom chrome window drag regions

### DIFF
--- a/Zentty/UI/Chrome/WindowChromeView.swift
+++ b/Zentty/UI/Chrome/WindowChromeView.swift
@@ -60,7 +60,7 @@ final class WindowChromeView: NSView {
         }
     }
 
-    private let rowContainerView = NSView()
+    private let rowContainerView = WindowChromeDragRegionView()
     private let focusedProxyIconView = WindowChromeProxyIconView()
     private let serverContainerView = NSView()
     private let serverPrimaryBackgroundView = NSView()
@@ -181,6 +181,10 @@ final class WindowChromeView: NSView {
     func animateNextRowLayoutForSidebarTransition() {
         animatesNextRowLayout = true
         needsLayout = true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 
     private func setup() {
@@ -1280,7 +1284,7 @@ final class WindowChromeView: NSView {
         font: NSFont,
         lineBreakMode: NSLineBreakMode
     ) -> NSTextField {
-        let label = NSTextField(labelWithString: text)
+        let label = WindowChromeDragLabel(labelWithString: text)
         label.font = font
         label.textColor = color
         label.lineBreakMode = lineBreakMode
@@ -1522,6 +1526,17 @@ final class WindowChromeView: NSView {
         focusedProxyIconView.setDragSessionActiveForTesting(active)
     }
 
+    func acceptsWindowDragForTesting(at point: NSPoint) -> Bool {
+        guard let hitView = hitTest(point) else {
+            return false
+        }
+
+        return hitView === self ||
+            hitView === rowContainerView ||
+            hitView is WindowChromeDragLabel ||
+            hitView is WindowChromeReviewChipView
+    }
+
     private static func contextMenuEventForTesting() -> NSEvent? {
         NSEvent.mouseEvent(
             with: .rightMouseDown,
@@ -1534,6 +1549,33 @@ final class WindowChromeView: NSView {
             clickCount: 1,
             pressure: 0
         )
+    }
+}
+
+private final class WindowChromeDragRegionView: NSView {
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
+    }
+}
+
+private final class WindowChromeDragLabel: NSTextField {
+    init(labelWithString stringValue: String) {
+        super.init(frame: .zero)
+        self.stringValue = stringValue
+        isEditable = false
+        isSelectable = false
+        isBordered = false
+        drawsBackground = false
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 }
 
@@ -2439,7 +2481,7 @@ private final class WindowChromeBranchLabel: NSTextField {
 }
 
 private final class WindowChromeReviewChipView: NSView {
-    private let label = NSTextField(labelWithString: "")
+    private let label = WindowChromePassiveLabel(labelWithString: "")
     private let chip: WorklaneReviewChip
 
     init(chip: WorklaneReviewChip) {
@@ -2475,6 +2517,10 @@ private final class WindowChromeReviewChipView: NSView {
             width: max(0, bounds.width - 20),
             height: labelHeight
         )
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 
     func apply(theme: ZenttyTheme, animated: Bool) {
@@ -2533,5 +2579,26 @@ private final class WindowChromeReviewChipView: NSView {
         label.usesSingleLineMode = true
         label.cell?.wraps = false
         return ceil(max(label.fittingSize.width, label.intrinsicContentSize.width)) + 20
+    }
+}
+
+private final class WindowChromePassiveLabel: NSTextField {
+    init(labelWithString stringValue: String) {
+        super.init(frame: .zero)
+        self.stringValue = stringValue
+        isEditable = false
+        isSelectable = false
+        isBordered = false
+        drawsBackground = false
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
     }
 }

--- a/Zentty/UI/Chrome/WindowChromeView.swift
+++ b/Zentty/UI/Chrome/WindowChromeView.swift
@@ -183,6 +183,10 @@ final class WindowChromeView: NSView {
         needsLayout = true
     }
 
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
     override func mouseDown(with event: NSEvent) {
         window?.performDrag(with: event)
     }
@@ -1553,6 +1557,10 @@ final class WindowChromeView: NSView {
 }
 
 private final class WindowChromeDragRegionView: NSView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
     override func mouseDown(with event: NSEvent) {
         window?.performDrag(with: event)
     }
@@ -2517,6 +2525,10 @@ private final class WindowChromeReviewChipView: NSView {
             width: max(0, bounds.width - 20),
             height: labelHeight
         )
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/ZenttyLogicTests/WindowChromeViewTests.swift
+++ b/ZenttyLogicTests/WindowChromeViewTests.swift
@@ -1195,6 +1195,65 @@ final class WindowChromeViewTests: AppKitTestCase {
         XCTAssertTrue(pullRequestButton.acceptsFirstMouse(for: nil))
     }
 
+    func test_window_chrome_accepts_window_drag_from_empty_header_and_status_text() throws {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 900, height: WindowChromeView.preferredHeight)
+        )
+
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Claude Code",
+            remoteContextLabel: "remote ~/zentty",
+            branch: "main",
+            pullRequest: WorklanePullRequestSummary(
+                number: 1413,
+                url: URL(string: "https://example.com/pr/1413"),
+                state: .open
+            ),
+            reviewChips: []
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        let focusedLabel = try XCTUnwrap(findLabel(in: view, withText: "Claude Code"))
+        let remoteLabel = try XCTUnwrap(findLabel(in: view, withText: "remote ~/zentty"))
+        let contentFrames = view.rowContentFramesForTesting
+        let contentMinX = try XCTUnwrap(contentFrames.map(\.minX).min())
+        let contentMaxX = try XCTUnwrap(contentFrames.map(\.maxX).max())
+        XCTAssertGreaterThan(contentMinX - view.rowFrame.minX, 4)
+        XCTAssertGreaterThan(view.rowFrame.maxX - contentMaxX, 4)
+
+        XCTAssertTrue(view.acceptsWindowDragForTesting(at: focusedLabel.convert(center(of: focusedLabel.bounds), to: view)))
+        XCTAssertTrue(view.acceptsWindowDragForTesting(at: remoteLabel.convert(center(of: remoteLabel.bounds), to: view)))
+        XCTAssertTrue(view.acceptsWindowDragForTesting(at: NSPoint(x: view.rowFrame.minX + 2, y: view.rowFrame.midY)))
+        XCTAssertTrue(view.acceptsWindowDragForTesting(at: NSPoint(x: view.rowFrame.maxX - 2, y: view.rowFrame.midY)))
+    }
+
+    func test_window_chrome_keeps_interactive_items_out_of_window_drag_region() throws {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 760, height: WindowChromeView.preferredHeight)
+        )
+
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Claude Code",
+            cwdPath: "/tmp/project",
+            branch: "main",
+            branchURL: URL(string: "https://example.com/branch/main"),
+            pullRequest: WorklanePullRequestSummary(
+                number: 1413,
+                url: URL(string: "https://example.com/pr/1413"),
+                state: .open
+            ),
+            reviewChips: []
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        let branchLabel = try XCTUnwrap(findLabel(in: view, withText: "main"))
+        let pullRequestButton = try XCTUnwrap(findButton(in: view, withTitle: "PR #1413"))
+
+        XCTAssertFalse(view.acceptsWindowDragForTesting(at: branchLabel.convert(center(of: branchLabel.bounds), to: view)))
+        XCTAssertFalse(view.acceptsWindowDragForTesting(at: pullRequestButton.convert(center(of: pullRequestButton.bounds), to: view)))
+        XCTAssertFalse(view.acceptsWindowDragForTesting(at: center(of: view.focusedProxyIconFrame)))
+    }
+
     func test_window_chrome_disables_pull_request_click_affordance_when_url_is_missing() {
         let view = WindowChromeView(
             frame: NSRect(x: 0, y: 0, width: 760, height: WindowChromeView.preferredHeight)
@@ -1369,6 +1428,10 @@ final class WindowChromeViewTests: AppKitTestCase {
         }
 
         return nil
+    }
+
+    private func center(of rect: NSRect) -> NSPoint {
+        NSPoint(x: rect.midX, y: rect.midY)
     }
 
     func test_apply_panes_propagates_show_project_icons_toggle() throws {

--- a/ZenttyLogicTests/WindowChromeViewTests.swift
+++ b/ZenttyLogicTests/WindowChromeViewTests.swift
@@ -1227,6 +1227,42 @@ final class WindowChromeViewTests: AppKitTestCase {
         XCTAssertTrue(view.acceptsWindowDragForTesting(at: NSPoint(x: view.rowFrame.maxX - 2, y: view.rowFrame.midY)))
     }
 
+    func test_window_chrome_drag_targets_accept_first_mouse_for_inactive_window() throws {
+        let view = WindowChromeView(
+            frame: NSRect(x: 0, y: 0, width: 900, height: WindowChromeView.preferredHeight)
+        )
+
+        view.render(summary: WorklaneChromeSummary(
+            focusedLabel: "Claude Code",
+            remoteContextLabel: "remote ~/zentty",
+            branch: "main",
+            pullRequest: WorklanePullRequestSummary(
+                number: 1413,
+                url: URL(string: "https://example.com/pr/1413"),
+                state: .open
+            ),
+            reviewChips: [WorklaneReviewChip(text: "1 failing", style: .danger)]
+        ))
+        view.layoutSubtreeIfNeeded()
+
+        let focusedLabel = try XCTUnwrap(findLabel(in: view, withText: "Claude Code"))
+        let remoteLabel = try XCTUnwrap(findLabel(in: view, withText: "remote ~/zentty"))
+        let reviewChipLabel = try XCTUnwrap(findLabel(in: view, withText: "1 failing"))
+        let points = [
+            ("empty header space", NSPoint(x: view.bounds.minX + 2, y: view.bounds.minY + 2)),
+            ("row padding", NSPoint(x: view.rowFrame.minX + 2, y: view.rowFrame.midY)),
+            ("focused passive label", focusedLabel.convert(center(of: focusedLabel.bounds), to: view)),
+            ("remote passive label", remoteLabel.convert(center(of: remoteLabel.bounds), to: view)),
+            ("review chip", reviewChipLabel.convert(center(of: reviewChipLabel.bounds), to: view)),
+        ]
+
+        for (target, point) in points {
+            XCTAssertTrue(view.acceptsWindowDragForTesting(at: point), "\(target) should accept window dragging")
+            let hitView = try XCTUnwrap(view.hitTest(point), "\(target) should hit a view")
+            XCTAssertTrue(hitView.acceptsFirstMouse(for: nil), "\(target) should accept first mouse")
+        }
+    }
+
     func test_window_chrome_keeps_interactive_items_out_of_window_drag_region() throws {
         let view = WindowChromeView(
             frame: NSRect(x: 0, y: 0, width: 760, height: WindowChromeView.preferredHeight)


### PR DESCRIPTION
## Summary
- Make the custom window chrome explicitly drag the window from empty header/background areas.
- Allow non-interactive chrome text and review chips to start window drags.
- Keep interactive chrome controls such as branch, PR, proxy icon, and split buttons out of the drag region.

## Verification
- Built GhosttyKit locally with `./scripts/build_ghosttykit.sh`.
- `xcodebuild -project Zentty.xcodeproj -scheme Zentty -destination 'platform=macOS' -configuration Debug -derivedDataPath /private/tmp/zentty-derived CODE_SIGNING_ALLOWED=NO build` passed.
- `xcodebuild -project Zentty.xcodeproj -scheme Zentty -destination 'platform=macOS' -configuration Debug -derivedDataPath /private/tmp/zentty-derived CODE_SIGNING_ALLOWED=NO -only-testing:ZenttyLogicTests/WindowChromeViewTests test` passed: 60 tests, 0 failures.

## Notes
A full `xcodebuild ... test` run completed compilation and integration tests, but had unrelated existing/environment failures outside this change area, including path-shortening expectations, programmatic resize layout assertions, a shortcuts preview key-recording assertion, and an OpenCode theme sync assertion. `WindowChromeViewTests` passed in the full run and in the focused rerun.