### PR TITLE
fix: never free ghostty surfaces on the main thread (app-wide deadlock)

### DIFF
--- a/Zentty/Terminal/LibghosttySurface.swift
+++ b/Zentty/Terminal/LibghosttySurface.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon.HIToolbox
+import os
 import GhosttyKit
 
 struct LibghosttySurfaceScrollbarUpdate: Equatable, Sendable {
@@ -144,6 +145,8 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     private weak var hostView: LibghosttyView?
     private(set) var hasScrollback = false
     private var hasEmittedShellReady = false
+    nonisolated(unsafe) private var isCloseRequested = false
+    private let pendingFree = OSAllocatedUnfairLock<ghostty_surface_t?>(initialState: nil)
     var searchDidChange: ((TerminalSearchEvent) -> Void)?
 
     var mouseCaptured: Bool {
@@ -267,15 +270,32 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     }
 
     func close() {
+        // Thread-safety: never free a ghostty surface on the main thread.
+        // ghostty's teardown may join its io/renderer threads; when one of
+        // those is blocked (e.g. after a pane stream stall), the join never
+        // returns and the whole app freezes (dedene/zentty#67).
+        // The surface pointer is handed off to `pendingFree` and freed only
+        // from ghostty's close callback (freeSurface) or deinit, off-main.
+        guard !isCloseRequested else { return }
+        isCloseRequested = true
         guard let surface else { return }
-        ghostty_surface_request_close(surface)
-        ghostty_surface_free(surface)
+        // Stop further ghostty calls through the property synchronously on
+        // the main thread; the raw pointer below is what teardown needs.
         self.surface = nil
+        ghostty_surface_request_close(surface)
+        pendingFree.withLock { $0 = surface }
     }
 
     deinit {
-        if let surface {
-            ghostty_surface_free(surface)
+        let pending = pendingFree.withLock { ptr -> ghostty_surface_t? in
+            let p = ptr
+            ptr = nil
+            return p
+        }
+        if let pending {
+            DispatchQueue.global(qos: .utility).async {
+                ghostty_surface_free(pending)
+            }
         }
     }
 
@@ -775,8 +795,30 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     }
 
     nonisolated func notifySurfaceClosed() {
+        // Invoked by ghostty from its own thread once the surface close has
+        // completed — the safe point to free, since ghostty no longer owns
+        // the io/renderer threads that a main-thread free could join forever
+        // (dedene/zentty#67).
+        freeSurface()
         DispatchQueue.main.async { [weak self] in
             self?.eventDidOccur(.surfaceClosed)
+        }
+    }
+
+    private nonisolated func freeSurface() {
+        let pending = pendingFree.withLock { ptr -> ghostty_surface_t? in
+            let p = ptr
+            ptr = nil
+            return p
+        }
+        guard let pending else { return }
+        if Thread.isMainThread {
+            // Defensive bounce: teardown must never run on the main thread.
+            DispatchQueue.global(qos: .utility).async {
+                ghostty_surface_free(pending)
+            }
+        } else {
+            ghostty_surface_free(pending)
         }
     }
 

--- a/Zentty/Terminal/LibghosttySurface.swift
+++ b/Zentty/Terminal/LibghosttySurface.swift
@@ -145,8 +145,14 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     private weak var hostView: LibghosttyView?
     private(set) var hasScrollback = false
     private var hasEmittedShellReady = false
-    nonisolated(unsafe) private var isCloseRequested = false
-    private let pendingFree = OSAllocatedUnfairLock<ghostty_surface_t?>(initialState: nil)
+    private enum TeardownState {
+        case live(ghostty_surface_t)
+        case closing(ghostty_surface_t)
+        case freed
+    }
+    private var isCloseRequested = false
+    private let teardownState = OSAllocatedUnfairLock<TeardownState>(initialState: .freed)
+    private var closeRetain: LibghosttySurface?
     var searchDidChange: ((TerminalSearchEvent) -> Void)?
 
     var mouseCaptured: Bool {
@@ -252,6 +258,11 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
         }
 
         self.surface = surface
+        // Single owner of the raw pointer for teardown (state machine, armed
+        // once here). Transitioned atomically by close(), the close callback
+        // (freeSurface), and deinit — no unlocked gap between a liveness
+        // check and an action on the pointer.
+        teardownState.withLock { $0 = .live(surface) }
         self.hostView = hostView
         metadata.currentWorkingDirectory = request.workingDirectory
         let initialViewportSize = hostView.normalizedBackingViewportSize
@@ -270,27 +281,56 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     }
 
     func close() {
+        dispatchPrecondition(condition: .onQueue(.main))
         // Thread-safety: never free a ghostty surface on the main thread.
         // ghostty's teardown may join its io/renderer threads; when one of
         // those is blocked (e.g. after a pane stream stall), the join never
         // returns and the whole app freezes (dedene/zentty#67).
-        // The surface pointer is handed off to `pendingFree` and freed only
-        // from ghostty's close callback (freeSurface) or deinit, off-main.
         guard !isCloseRequested else { return }
         isCloseRequested = true
-        guard let surface else { return }
+        // Atomic live -> closing transition. The returned pointer is safe to
+        // request_close on: the callback can only fire after the request is
+        // processed, and either way the pointer is never freed twice.
+        let target = teardownState.withLock { state -> ghostty_surface_t? in
+            guard case .live(let ptr) = state else { return nil }
+            state = .closing(ptr)
+            return ptr
+        }
+        guard let target else {
+            // Already closed or freed by another path (e.g. shell exit).
+            self.surface = nil
+            return
+        }
+        // Strong self-bridge: keep the object alive until the close callback
+        // drains (cleared in freeSurface), so deinit can never free a pointer
+        // ghostty still owns in the .closing state.
+        closeRetain = self
         // Stop further ghostty calls through the property synchronously on
-        // the main thread; the raw pointer below is what teardown needs.
+        // the main thread; ownership of the pointer stays in teardownState.
         self.surface = nil
-        ghostty_surface_request_close(surface)
-        pendingFree.withLock { $0 = surface }
+        ghostty_surface_request_close(target)
+        // Deliberate trade-off: if ghostty never fires the close callback (a
+        // stalled pane), closeRetain keeps this object — and its surface —
+        // alive indefinitely. That leak is accepted: freeing while ghostty
+        // may still be closing is a guaranteed use-after-free, and the leak
+        // is bounded to stalled panes.
     }
 
     deinit {
-        let pending = pendingFree.withLock { ptr -> ghostty_surface_t? in
-            let p = ptr
-            ptr = nil
-            return p
+        // Last-resort safety net: frees a pointer neither the close callback
+        // nor the close() watchdog got to. .live here is a contract violation
+        // worth shouting about in debug; .closing is possible only if the
+        // watchdog fired and the object was retained past it.
+        let pending = teardownState.withLock { state -> ghostty_surface_t? in
+            defer { state = .freed }
+            if case .live = state {
+                assertionFailure("LibghosttySurface deallocated in .live state")
+            }
+            switch state {
+            case .live(let ptr): return ptr
+            case .closing(let ptr): return ptr
+            case .freed: return nil
+            }
         }
         if let pending {
             DispatchQueue.global(qos: .utility).async {
@@ -795,10 +835,9 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     }
 
     nonisolated func notifySurfaceClosed() {
-        // Invoked by ghostty from its own thread once the surface close has
-        // completed — the safe point to free, since ghostty no longer owns
-        // the io/renderer threads that a main-thread free could join forever
-        // (dedene/zentty#67).
+        // The close callback is ghostty ASKING the embedder to release the
+        // surface — the designated safe point to free, in both the
+        // shell-exit (.live) and app-initiated (.closing) paths.
         freeSurface()
         DispatchQueue.main.async { [weak self] in
             self?.eventDidOccur(.surfaceClosed)
@@ -806,19 +845,32 @@ final class LibghosttySurface: LibghosttySurfaceControlling, LibghosttySurfaceTe
     }
 
     private nonisolated func freeSurface() {
-        let pending = pendingFree.withLock { ptr -> ghostty_surface_t? in
-            let p = ptr
-            ptr = nil
-            return p
+        let pending = teardownState.withLock { state -> ghostty_surface_t? in
+            switch state {
+            case .live(let ptr):
+                state = .freed
+                return ptr
+            case .closing(let ptr):
+                state = .freed
+                return ptr
+            case .freed:
+                return nil
+            }
         }
         guard let pending else { return }
-        if Thread.isMainThread {
-            // Defensive bounce: teardown must never run on the main thread.
+        let owner = self
+        // Nil the property and release the close-bridge on the main thread
+        // BEFORE dispatching the free, so main-thread property reads stop
+        // before the pointer dies; the free itself stays off-main, and the
+        // object stays alive through it via the owner capture. (Reads from
+        // ghostty's own callback threads are pre-existing and out of scope.)
+        DispatchQueue.main.async { [weak self] in
+            self?.surface = nil
+            self?.closeRetain = nil
             DispatchQueue.global(qos: .utility).async {
                 ghostty_surface_free(pending)
+                withExtendedLifetime(owner) {}
             }
-        } else {
-            ghostty_surface_free(pending)
         }
     }
 


### PR DESCRIPTION
## What this fixes

Zentty freezes completely (no window switching, no input) every few days of uptime. Process samples show the main thread pinned forever in `_pthread_join → __ulock_wait`, reached through an AppKit text-change notification observer. The join is inside ghostty surface teardown: `ghostty_surface_free` can join the surface's io/renderer threads, and when one of those threads is blocked (observed after per-pane stream stalls), the join never returns. Reproduced 2026-07-27, 2026-08-05, 2026-08-10; upstream reference: #67.

## The change (one file, LibghosttySurface.swift)

Never free a ghostty surface on the main thread. A single-owner teardown state machine (`.live/.closing/.freed`, OSAllocatedUnfairLock, armed at init) is transitioned atomically by close(), the close callback (ghostty's safe-to-free signal), and deinit. close() keeps a strong self-bridge so deinit can never free a pointer ghostty still owns; the free always runs off-main after the property is nil'd on the main thread, keeping the Swift object alive through teardown (`withExtendedLifetime`).

Deliberate trade-off: a stalled pane whose close callback never fires leaks its surface (bounded to stalled panes) — freeing while ghostty may still be closing is a guaranteed use-after-free.

## Verification

- `swiftc -frontend -parse` passes.
- 9 adversarial opposite-vendor review rounds (strategy + patch + every amendment), all findings incorporated: join-inversion diagnosis, lock-guarded pointer handoff, no off-main property writes, TOCTOU-atomic state machine, nil-before-free ordering, closeRetain bridge, watchdog rejected (UAF risk) in favor of the bounded-leak trade-off. Review record in commit `288c45b`.
- Full build requires GhosttyKit.xcframework (`scripts/build_ghosttykit.sh`) — not available here; the change is one file, no new APIs. Maintainers should confirm the close callback fires for app-initiated closes on the normal path (worst case there is the documented deinit net).

## What this does not fix

The underlying ghostty behavior (joining a blocked io/renderer thread from teardown) is upstream; this removes the main-thread exposure so a stalled pane can no longer freeze the whole app.

I have read CLA.md and agree to its terms.