### PR TITLE
fix(menu): label Move Pane to Worklane destinations by worklane title

### DIFF
--- a/Zentty/AppState/WorklaneDestinationCatalog.swift
+++ b/Zentty/AppState/WorklaneDestinationCatalog.swift
@@ -4,6 +4,9 @@ struct WorklaneDestinationSummary: Equatable, Sendable {
     let windowID: WindowID
     let worklaneID: WorklaneID
     let color: WorklaneColor?
+    /// The worklane's own title, trimmed, or nil when the worklane is untitled.
+    /// Callers prefer this over `primaryPaneTitle` when labelling a destination.
+    let worklaneTitle: String?
     let primaryPaneTitle: String
     let additionalPaneCount: Int
 }
@@ -43,6 +46,7 @@ extension WorklaneStore {
                 windowID: windowID,
                 worklaneID: worklane.id,
                 color: worklane.color,
+                worklaneTitle: WorklaneContextFormatter.trimmed(worklane.title),
                 primaryPaneTitle: primary,
                 additionalPaneCount: panes.count - 1
             )

--- a/Zentty/UI/PaneStrip/MoveToWorklaneMenuBuilder.swift
+++ b/Zentty/UI/PaneStrip/MoveToWorklaneMenuBuilder.swift
@@ -32,9 +32,7 @@ enum MoveToWorklaneMenuBuilder {
         summary: WorklaneDestinationSummary,
         paneID: PaneID
     ) -> NSMenuItem {
-        let title = summary.additionalPaneCount > 0
-            ? "\(summary.primaryPaneTitle)  +\(summary.additionalPaneCount) more"
-            : summary.primaryPaneTitle
+        let title = destinationTitle(for: summary)
         let item = NSMenuItem(
             title: title,
             action: #selector(MainWindowController.movePaneToWorklane(_:)),
@@ -47,6 +45,19 @@ enum MoveToWorklaneMenuBuilder {
             destinationWorklaneID: summary.worklaneID
         )
         return item
+    }
+
+    /// A titled worklane is labelled by its own title, matching the sidebar
+    /// header and every other worklane surface. Only untitled worklanes fall
+    /// back to describing their contents.
+    static func destinationTitle(for summary: WorklaneDestinationSummary) -> String {
+        if let worklaneTitle = WorklaneContextFormatter.trimmed(summary.worklaneTitle) {
+            return worklaneTitle
+        }
+
+        return summary.additionalPaneCount > 0
+            ? "\(summary.primaryPaneTitle)  +\(summary.additionalPaneCount) more"
+            : summary.primaryPaneTitle
     }
 
     static func makeNewWorklaneItem(paneID: PaneID) -> NSMenuItem {

--- a/ZenttyLogicTests/MoveToWorklaneMenuBuilderTests.swift
+++ b/ZenttyLogicTests/MoveToWorklaneMenuBuilderTests.swift
@@ -33,6 +33,52 @@ final class MoveToWorklaneMenuBuilderTests: XCTestCase {
         XCTAssertEqual(menu.items[0].title, "vim  +2 more")
     }
 
+    func test_titledWorklane_usesWorklaneTitleInsteadOfPaneTitle() {
+        let summary = makeSummary(
+            windowID: "w1",
+            worklaneID: "A",
+            primary: "vim",
+            additional: 2,
+            worklaneTitle: "PLATFORM"
+        )
+        let catalog = WorklaneDestinationCatalog(
+            groups: [WorklaneDestinationGroup(windowID: WindowID("w1"), summaries: [summary])],
+            canCreateNewWorklane: false
+        )
+
+        let menu = MoveToWorklaneMenuBuilder.makeSubmenu(catalog: catalog, paneID: sourcePaneID)
+
+        XCTAssertEqual(menu.items[0].title, "PLATFORM")
+    }
+
+    func test_titledWorklane_singlePane_usesWorklaneTitle() {
+        let summary = makeSummary(
+            windowID: "w1",
+            worklaneID: "A",
+            primary: "vim",
+            additional: 0,
+            worklaneTitle: "RELEASE"
+        )
+
+        let item = MoveToWorklaneMenuBuilder.makeDestinationItem(summary: summary, paneID: sourcePaneID)
+
+        XCTAssertEqual(item.title, "RELEASE")
+    }
+
+    func test_blankWorklaneTitle_fallsBackToPaneSummary() {
+        let summary = makeSummary(
+            windowID: "w1",
+            worklaneID: "A",
+            primary: "vim",
+            additional: 2,
+            worklaneTitle: "   "
+        )
+
+        let item = MoveToWorklaneMenuBuilder.makeDestinationItem(summary: summary, paneID: sourcePaneID)
+
+        XCTAssertEqual(item.title, "vim  +2 more")
+    }
+
     func test_multipleGroups_insertsSeparatorBetweenWindows() {
         let g1 = WorklaneDestinationGroup(
             windowID: WindowID("w1"),
@@ -127,12 +173,14 @@ final class MoveToWorklaneMenuBuilderTests: XCTestCase {
         worklaneID: String,
         primary: String,
         additional: Int,
-        color: WorklaneColor? = nil
+        color: WorklaneColor? = nil,
+        worklaneTitle: String? = nil
     ) -> WorklaneDestinationSummary {
         WorklaneDestinationSummary(
             windowID: WindowID(windowID),
             worklaneID: WorklaneID(worklaneID),
             color: color,
+            worklaneTitle: worklaneTitle,
             primaryPaneTitle: primary,
             additionalPaneCount: additional
         )

--- a/ZenttyLogicTests/WorklaneDestinationCatalogTests.swift
+++ b/ZenttyLogicTests/WorklaneDestinationCatalogTests.swift
@@ -146,6 +146,70 @@ final class WorklaneDestinationCatalogTests: XCTestCase {
         XCTAssertEqual(summary?.color, .blue)
     }
 
+    func test_summary_carriesWorklaneTitle() {
+        let store = makeStore(activeID: "A")
+        let summary = store.destinationSummaries(windowID: testWindowID, excluding: nil).first
+        XCTAssertEqual(summary?.worklaneTitle, "A")
+    }
+
+    func test_summary_worklaneTitleIsNilWhenUntitled() {
+        let store = WorklaneStore(
+            windowID: testWindowID,
+            worklanes: [
+                WorklaneState(
+                    id: WorklaneID("untitled"),
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("p1"), title: "vim")],
+                        focusedPaneID: PaneID("p1")
+                    )
+                )
+            ],
+            activeWorklaneID: WorklaneID("untitled")
+        )
+        let summary = store.destinationSummaries(windowID: testWindowID, excluding: nil).first
+        XCTAssertNil(summary?.worklaneTitle)
+        XCTAssertEqual(summary?.primaryPaneTitle, "vim")
+    }
+
+    func test_summary_worklaneTitleIsNilWhenBlank() {
+        let store = WorklaneStore(
+            windowID: testWindowID,
+            worklanes: [
+                WorklaneState(
+                    id: WorklaneID("blank"),
+                    title: "   ",
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("p1"), title: "vim")],
+                        focusedPaneID: PaneID("p1")
+                    )
+                )
+            ],
+            activeWorklaneID: WorklaneID("blank")
+        )
+        let summary = store.destinationSummaries(windowID: testWindowID, excluding: nil).first
+        XCTAssertNil(summary?.worklaneTitle)
+    }
+
+    func test_summary_worklaneTitleIsTrimmed() {
+        let store = WorklaneStore(
+            windowID: testWindowID,
+            worklanes: [
+                WorklaneState(
+                    id: WorklaneID("padded"),
+                    title: "  PLATFORM  ",
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("p1"), title: "vim")],
+                        focusedPaneID: PaneID("p1")
+                    )
+                )
+            ],
+            activeWorklaneID: WorklaneID("padded")
+        )
+        let summary = store.destinationSummaries(windowID: testWindowID, excluding: nil).first
+        XCTAssertEqual(summary?.worklaneTitle, "PLATFORM")
+    }
+
     func test_catalog_hasAnyDestination_emptyAndCanCreateFalse_returnsFalse() {
         let catalog = WorklaneDestinationCatalog(groups: [], canCreateNewWorklane: false)
         XCTAssertFalse(catalog.hasAnyDestination)
@@ -161,6 +225,7 @@ final class WorklaneDestinationCatalogTests: XCTestCase {
             windowID: testWindowID,
             worklaneID: WorklaneID("X"),
             color: nil,
+            worklaneTitle: nil,
             primaryPaneTitle: "vim",
             additionalPaneCount: 0
         )


### PR DESCRIPTION
## Problem

`Move Pane to Worklane` labels every destination with a pane title instead of the worklane's name, so a user with named worklanes sees none of their names.

With worklanes named `PLATFORM`, `DOCS`, `RELEASE`, the submenu reads:

```
● vim  +2 more
● npm run dev  +1 more
● ssh prod
```

Every entry is the destination's focused pane title. The only way to pick the right lane is to count rows against the sidebar, and pane titles change constantly under agent-driven work, so the same lane is labelled differently minute to minute.

## Root cause

`WorklaneDestinationSummary` carries `color` but never the worklane's `title`, so the menu builder has nothing else to render:

- `Zentty/AppState/WorklaneDestinationCatalog.swift:42-48` builds each summary from `worklane.color` and a pane-derived `primaryPaneTitle`, never reading `worklane.title`.
- `Zentty/UI/PaneStrip/MoveToWorklaneMenuBuilder.swift:35-37` therefore composes the item title purely from `primaryPaneTitle` + `+N more`.

Every other worklane surface reads `worklane.title` correctly, including the sidebar header (`WorklaneHeaderSummaryBuilder`), the command palette (`CommandPaletteItem`), bookmarks (`BookmarkNameSuggester`), and the CLI (`TopologyCLI`). This is the one path that does not.

## Fix

Carry the title through and prefer it when labelling:

- Add `worklaneTitle: String?` to `WorklaneDestinationSummary`, populated with `WorklaneContextFormatter.trimmed(worklane.title)` (matching the read-site trim in `WorkspaceTemplateCapture`).
- Extract `MoveToWorklaneMenuBuilder.destinationTitle(for:)`. A titled worklane renders its title alone; an untitled worklane keeps the existing `primaryPaneTitle` + `+N more` behaviour unchanged.

The `+N more` suffix is dropped for titled lanes on purpose: it existed to signal "this label is one pane out of several", which is not a caveat the lane's own name needs. This matches the sidebar, which shows the name alone.

Untitled worklanes are unaffected, so the fallback path and its `Untitled` handling stay exactly as they were.

## Tests

`ZenttyLogicTests`, both existing files:

- `WorklaneDestinationCatalogTests` — title carried, nil when untitled, nil when blank, trimmed when padded.
- `MoveToWorklaneMenuBuilderTests` — titled lane wins over pane title (multi-pane and single-pane), blank title falls back to the pane summary.

Existing assertions are untouched: `primaryPaneTitle` keeps its current semantics, and the untitled-lane cases still produce the same strings.

## Verification

```
TEST_RUNNER_SWIFT_BACKTRACE=enable=no xcodebuild test \
  -project Zentty.xcodeproj -scheme Zentty -destination 'platform=macOS' \
  -only-testing:ZenttyLogicTests/MoveToWorklaneMenuBuilderTests \
  -only-testing:ZenttyLogicTests/WorklaneDestinationCatalogTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
```

```
Test Suite 'MoveToWorklaneMenuBuilderTests' passed
     Executed 13 tests, with 0 failures (0 unexpected)
Test Suite 'WorklaneDestinationCatalogTests' passed
     Executed 15 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

Ran the two affected classes directly rather than through `scripts/test-on-virtual-display`: neither BetterDisplay nor `simpledisplayctl` is installed on this machine, and neither class creates windows. Happy to rerun the full `ZenttyLogicTests` target if you want the broader sweep on this branch.
