### PR TITLE
Fix tmux teammate launch handshake

### DIFF
--- a/Zentty/AppState/Agent/TmuxCompatIPCHandler.swift
+++ b/Zentty/AppState/Agent/TmuxCompatIPCHandler.swift
@@ -4,6 +4,28 @@ import OSLog
 
 private let tmuxLogger = Logger(subsystem: "be.zenjoy.zentty", category: "tmux-compat")
 
+struct RespawnPaneLaunchRequest: Equatable {
+    let paneID: PaneID
+    let nativeCommand: String
+}
+
+enum TmuxCompatIPCError: LocalizedError {
+    case invalidRespawnPane
+    case targetNotDeferred(PaneID)
+    case targetUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRespawnPane:
+            "Unsupported respawn-pane arguments; expected -k -t <pane> -- <command>."
+        case let .targetNotDeferred(paneID):
+            "Cannot respawn pane %\(paneID.rawValue): it is not awaiting a launch command."
+        case .targetUnavailable:
+            "Cannot route tmux command: the target Zentty worklane or pane is no longer available."
+        }
+    }
+}
+
 /// Translates the small subset of tmux subcommands that Claude Code's
 /// experimental agent-teams mode emits (split-window, send-keys, list-panes,
 /// kill-pane, etc.) into Zentty's existing window-controller and worklane
@@ -73,18 +95,15 @@ enum TmuxCompatIPCHandler {
         target: AgentIPCTarget
     ) throws -> AgentIPCResponseResult {
         guard let appDelegate = NSApp.delegate as? AppDelegate else {
-            return AgentIPCResponseResult()
+            return try unresolvedTargetResult(for: subcommand)
         }
-        guard let windowController = target.windowID
-            .flatMap(appDelegate.windowController(with:))
-            ?? appDelegate.windowController(containingWorklane: target.worklaneID)
-        else {
-            return AgentIPCResponseResult()
+        guard let windowController = resolveWindowController(for: target, appDelegate: appDelegate) else {
+            return try unresolvedTargetResult(for: subcommand)
         }
 
         switch subcommand {
         case "split-window", "splitw":
-            return handleSplitWindow(arguments: arguments, target: target, windowController: windowController)
+            return try handleSplitWindow(arguments: arguments, target: target, windowController: windowController)
         case "send-keys", "send":
             return handleSendKeys(
                 arguments: arguments,
@@ -92,6 +111,11 @@ enum TmuxCompatIPCHandler {
                 target: target,
                 windowController: windowController
             )
+        case "set-option", "set":
+            // Claude uses pane options for styling and remain-on-exit; Zentty owns presentation/session retention, so this acknowledgment is intentional.
+            return AgentIPCResponseResult()
+        case "respawn-pane", "respawnp":
+            return try handleRespawnPane(arguments: arguments, target: target, windowController: windowController)
         case "select-pane", "selectp":
             return handleSelectPane(arguments: arguments, target: target, windowController: windowController)
         case "select-window", "selectw":
@@ -145,6 +169,33 @@ enum TmuxCompatIPCHandler {
         }
     }
 
+    static func unresolvedTargetResult(for subcommand: String) throws -> AgentIPCResponseResult {
+        switch subcommand {
+        case "split-window", "splitw", "respawn-pane", "respawnp":
+            throw TmuxCompatIPCError.targetUnavailable
+        default:
+            return AgentIPCResponseResult()
+        }
+    }
+
+    @MainActor
+    static func resolveWindowController(
+        for target: AgentIPCTarget,
+        appDelegate: AppDelegate
+    ) -> MainWindowController? {
+        let exactController = target.windowID
+            .flatMap(appDelegate.windowController(with:))
+            .flatMap { controller in
+                controller.containsPane(worklaneID: target.worklaneID, paneID: target.paneID) ? controller : nil
+            }
+        let paneOwner = appDelegate.orderedWindowControllersForDiscovery().first { controller in
+            controller.containsPane(worklaneID: target.worklaneID, paneID: target.paneID)
+        }
+        return exactController
+            ?? paneOwner
+            ?? appDelegate.windowController(containingWorklane: target.worklaneID)
+    }
+
     // MARK: - split-window
 
     @MainActor
@@ -152,15 +203,19 @@ enum TmuxCompatIPCHandler {
         arguments: [String],
         target: AgentIPCTarget,
         windowController: MainWindowController
-    ) -> AgentIPCResponseResult {
+    ) throws -> AgentIPCResponseResult {
         let parsed = TmuxCompatArguments.parse(
             arguments,
             valueFlags: ["-c", "-F", "-l", "-t"],
             boolFlags: ["-P", "-b", "-d", "-h", "-v"]
         )
+        try validateSplitTarget(
+            target.paneID,
+            paneEntries: windowController.paneListEntries(for: target.worklaneID)
+        )
         let key = target.worklaneID.rawValue
         let preExisting = TmuxCompatStoreIO.load().anchors[key]
-        let startupRequest = splitWindowStartupRequest(parsed: parsed)
+        let startupRequest = splitWindowStartupRequest(arguments: arguments, parsed: parsed)
         let newPaneID: String?
 
         // Snapshot the leader's column width BEFORE any split-window layout
@@ -176,6 +231,7 @@ enum TmuxCompatIPCHandler {
             // right of the leader at golden ratio while keeping the leader
             // visually anchored.
             newPaneID = windowController.splitWithLayout(
+                in: target.worklaneID,
                 placement: .afterFocused,
                 isHorizontal: true,
                 layout: .golden,
@@ -190,6 +246,7 @@ enum TmuxCompatIPCHandler {
             let targetPaneID = preExisting?.columnPaneIDs.last.map { PaneID($0) } ?? target.paneID
             let preservePaneID = PaneID(preExisting?.leaderPaneID ?? target.paneID.rawValue)
             newPaneID = windowController.splitWithLayout(
+                in: target.worklaneID,
                 placement: .afterFocused,
                 isHorizontal: false,
                 layout: .equal,
@@ -221,6 +278,7 @@ enum TmuxCompatIPCHandler {
             let leaderPaneID = preExisting?.leaderPaneID ?? target.paneID.rawValue
             windowController.resizeColumnContainingPane(
                 id: PaneID(leaderPaneID),
+                in: target.worklaneID,
                 toFraction: goldenWideFraction
             )
         }
@@ -249,6 +307,12 @@ enum TmuxCompatIPCHandler {
         )
     }
 
+    static func validateSplitTarget(_ paneID: PaneID, paneEntries: [PaneListEntry]) throws {
+        guard paneEntries.contains(where: { $0.id == paneID.rawValue }) else {
+            throw TmuxCompatIPCError.targetUnavailable
+        }
+    }
+
     // MARK: - send-keys
 
     @MainActor
@@ -258,18 +322,20 @@ enum TmuxCompatIPCHandler {
         target: AgentIPCTarget,
         windowController: MainWindowController
     ) -> AgentIPCResponseResult {
-        let resolvedPaneID = resolvedTargetPaneID(
+        guard let resolvedPaneID = sendKeysTargetPaneID(
             arguments: arguments,
-            target: target,
-            windowController: windowController
-        )
+            fallback: target.paneID,
+            paneEntries: windowController.paneListEntries(for: target.worklaneID)
+        ) else {
+            return AgentIPCResponseResult()
+        }
         let text = sendKeysText(arguments: arguments, standardInput: standardInput)
         guard !text.isEmpty else {
             return AgentIPCResponseResult()
         }
         if let launchCommand = launchCommandFromSendKeysText(text),
            let nativeCommand = shellWrappedGhosttyCommand(launchCommand),
-           windowController.launchDeferredPane(id: resolvedPaneID, nativeCommand: nativeCommand) {
+           windowController.launchDeferredPane(id: resolvedPaneID, in: target.worklaneID, nativeCommand: nativeCommand) {
             return AgentIPCResponseResult()
         }
         let delivered = windowController.sendText(text, to: resolvedPaneID)
@@ -277,6 +343,28 @@ enum TmuxCompatIPCHandler {
             tmuxLogger.warning(
                 "send-keys: no live runtime for pane \(resolvedPaneID.rawValue, privacy: .public)"
             )
+        }
+        return AgentIPCResponseResult()
+    }
+
+    @MainActor
+    private static func handleRespawnPane(
+        arguments: [String],
+        target: AgentIPCTarget,
+        windowController: MainWindowController
+    ) throws -> AgentIPCResponseResult {
+        guard let launchRequest = respawnPaneLaunchRequest(
+            arguments: arguments,
+            paneEntries: windowController.paneListEntries(for: target.worklaneID)
+        ) else {
+            throw TmuxCompatIPCError.invalidRespawnPane
+        }
+        guard windowController.launchDeferredPane(
+            id: launchRequest.paneID,
+            in: target.worklaneID,
+            nativeCommand: launchRequest.nativeCommand
+        ) else {
+            throw TmuxCompatIPCError.targetNotDeferred(launchRequest.paneID)
         }
         return AgentIPCResponseResult()
     }
@@ -342,14 +430,76 @@ enum TmuxCompatIPCHandler {
         return "sh -c \(shellQuote(trimmed))"
     }
 
+    static func respawnPaneLaunchRequest(
+        arguments: [String],
+        paneEntries: [PaneListEntry],
+        loginShellPath: String? = ProcessInfo.processInfo.environment["SHELL"]
+    ) -> RespawnPaneLaunchRequest? {
+        guard arguments.count == 5,
+              arguments[0] == "-k",
+              arguments[1] == "-t",
+              !arguments[2].isEmpty,
+              arguments[3] == "--"
+        else {
+            return nil
+        }
+        guard let separatorIndex = arguments.firstIndex(of: "--") else {
+            return nil
+        }
+        let suffix = Array(arguments[arguments.index(after: separatorIndex)...])
+        guard suffix.count == 1 else {
+            return nil
+        }
+
+        let parsed = TmuxCompatArguments.parse(
+            arguments,
+            valueFlags: ["-t"],
+            boolFlags: ["-k"]
+        )
+        guard parsed.hasFlag("-k"),
+              parsed.value("-t") != nil,
+              parsed.positionals == suffix,
+              let paneID = explicitTargetPaneID(arguments: arguments, paneEntries: paneEntries),
+              let nativeCommand = shellWrappedGhosttyCommand(suffix[0], loginShellPath: loginShellPath)
+        else {
+            return nil
+        }
+        return RespawnPaneLaunchRequest(paneID: paneID, nativeCommand: nativeCommand)
+    }
+
     private static func isLoginShellSupported(_ shellPath: String) -> Bool {
         let shellName = URL(fileURLWithPath: shellPath).lastPathComponent
         return shellName == "zsh" || shellName == "bash" || shellName == "fish"
     }
 
-    private static func splitWindowStartupRequest(parsed: TmuxCompatArguments) -> TerminalSessionRequest {
+    static func isClaudeBootstrapSplit(arguments: [String], parsed: TmuxCompatArguments) -> Bool {
+        guard let separatorIndex = arguments.firstIndex(of: "--"),
+              Array(arguments[arguments.index(after: separatorIndex)...]) == ["cat"],
+              parsed.positionals == ["cat"],
+              parsed.hasFlag("-d"),
+              parsed.hasFlag("-P"),
+              parsed.value("-t") != nil,
+              parsed.formatTemplate == "#{pane_id}"
+        else {
+            return false
+        }
+        return true
+    }
+
+    static func splitWindowStartupRequest(
+        arguments: [String],
+        parsed: TmuxCompatArguments,
+        loginShellPath: String? = ProcessInfo.processInfo.environment["SHELL"]
+    ) -> TerminalSessionRequest {
+        if isClaudeBootstrapSplit(arguments: arguments, parsed: parsed) {
+            return TerminalSessionRequest(
+                workingDirectory: parsed.value("-c"),
+                isLaunchDeferred: true
+            )
+        }
+
         let commandText = parsed.positionals.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        if let nativeCommand = shellWrappedGhosttyCommand(commandText) {
+        if let nativeCommand = shellWrappedGhosttyCommand(commandText, loginShellPath: loginShellPath) {
             return TerminalSessionRequest(
                 workingDirectory: parsed.value("-c"),
                 nativeCommand: nativeCommand,
@@ -907,6 +1057,22 @@ enum TmuxCompatIPCHandler {
         paneEntries: [PaneListEntry]
     ) -> PaneID {
         explicitTargetPaneID(arguments: arguments, paneEntries: paneEntries) ?? fallback
+    }
+
+    static func sendKeysTargetPaneID(
+        arguments: [String],
+        fallback: PaneID,
+        paneEntries: [PaneListEntry]
+    ) -> PaneID? {
+        let parsed = TmuxCompatArguments.parse(
+            arguments,
+            valueFlags: ["-t"],
+            boolFlags: []
+        )
+        if arguments.contains("-t") || parsed.value("-t") != nil {
+            return explicitTargetPaneID(arguments: arguments, paneEntries: paneEntries)
+        }
+        return fallback
     }
 
     static func explicitTargetPaneID(

--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -1045,11 +1045,46 @@ final class WorklaneStore {
         preserveFocusPaneID: PaneID? = nil,
         sessionRequest: TerminalSessionRequest? = nil
     ) -> PaneID? {
-        guard var worklane = activeWorklane else {
+        splitWithLayout(
+            in: activeWorklaneID,
+            placement: placement,
+            isHorizontal: isHorizontal,
+            layout: layout,
+            availableWidth: availableWidth,
+            leadingVisibleInset: leadingVisibleInset,
+            availableSize: availableSize,
+            minimumSizeByPaneID: minimumSizeByPaneID,
+            targetPaneID: targetPaneID,
+            preserveFocusPaneID: preserveFocusPaneID,
+            sessionRequest: sessionRequest
+        )
+    }
+
+    @discardableResult
+    func splitWithLayout(
+        in worklaneID: WorklaneID,
+        placement: PanePlacement,
+        isHorizontal: Bool,
+        layout: SplitLayoutAction,
+        availableWidth: CGFloat,
+        leadingVisibleInset: CGFloat,
+        availableSize: CGSize,
+        minimumSizeByPaneID: [PaneID: PaneMinimumSize],
+        targetPaneID: PaneID? = nil,
+        preserveFocusPaneID: PaneID? = nil,
+        sessionRequest: TerminalSessionRequest? = nil
+    ) -> PaneID? {
+        guard let worklaneIndex = worklanes.firstIndex(where: { $0.id == worklaneID }) else {
+            return nil
+        }
+        var worklane = worklanes[worklaneIndex]
+        if let targetPaneID,
+           !worklane.paneStripState.panes.contains(where: { $0.id == targetPaneID }) {
             return nil
         }
 
-        let previousPaneRef = currentPaneReference
+        let isActiveWorklane = worklaneID == activeWorklaneID
+        let previousPaneRef = isActiveWorklane ? currentPaneReference : nil
         if let targetPaneID {
             worklane.paneStripState.focusPane(id: targetPaneID)
         }
@@ -1104,15 +1139,17 @@ final class WorklaneStore {
             worklane.paneStripState.focusPane(id: preserveFocusPaneID)
         }
 
-        activeWorklane = worklane
+        worklanes[worklaneIndex] = worklane
 
-        let newPaneRef = currentPaneReference
-        if previousPaneRef != newPaneRef {
-            recordFocusTransition(from: previousPaneRef)
+        if isActiveWorklane {
+            let newPaneRef = currentPaneReference
+            if previousPaneRef != newPaneRef {
+                recordFocusTransition(from: previousPaneRef)
+            }
+
+            refreshLastFocusedLocalWorkingDirectory()
         }
-
-        refreshLastFocusedLocalWorkingDirectory()
-        notify(.paneStructure(activeWorklaneID))
+        notify(.paneStructure(worklaneID))
         return newPaneID
     }
 
@@ -1316,9 +1353,15 @@ final class WorklaneStore {
 
     @discardableResult
     func launchDeferredPane(id paneID: PaneID, nativeCommand: String) -> Bool {
-        guard var worklane = activeWorklane else {
+        launchDeferredPane(id: paneID, in: activeWorklaneID, nativeCommand: nativeCommand)
+    }
+
+    @discardableResult
+    func launchDeferredPane(id paneID: PaneID, in worklaneID: WorklaneID, nativeCommand: String) -> Bool {
+        guard let worklaneIndex = worklanes.firstIndex(where: { $0.id == worklaneID }) else {
             return false
         }
+        var worklane = worklanes[worklaneIndex]
         let trimmedCommand = nativeCommand.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedCommand.isEmpty else {
             return false
@@ -1336,8 +1379,8 @@ final class WorklaneStore {
             worklane.paneStripState.columns[columnIndex].panes[paneIndex].sessionRequest.nativeCommand = trimmedCommand
             worklane.paneStripState.columns[columnIndex].panes[paneIndex].sessionRequest.waitAfterNativeCommand = true
             worklane.paneStripState.columns[columnIndex].panes[paneIndex].sessionRequest.isLaunchDeferred = false
-            activeWorklane = worklane
-            notify(.paneStructure(activeWorklaneID))
+            worklanes[worklaneIndex] = worklane
+            notify(.paneStructure(worklaneID))
             return true
         }
 
@@ -1447,7 +1490,29 @@ final class WorklaneStore {
         leadingVisibleInset: CGFloat = 0,
         minimumSizeByPaneID: [PaneID: PaneMinimumSize]
     ) {
-        guard var worklane = activeWorklane else {
+        resizeColumnContainingPane(
+            id: paneID,
+            in: activeWorklaneID,
+            toFraction: fraction,
+            availableWidth: availableWidth,
+            leadingVisibleInset: leadingVisibleInset,
+            minimumSizeByPaneID: minimumSizeByPaneID
+        )
+    }
+
+    func resizeColumnContainingPane(
+        id paneID: PaneID,
+        in worklaneID: WorklaneID,
+        toFraction fraction: CGFloat,
+        availableWidth: CGFloat,
+        leadingVisibleInset: CGFloat = 0,
+        minimumSizeByPaneID: [PaneID: PaneMinimumSize]
+    ) {
+        guard let worklaneIndex = worklanes.firstIndex(where: { $0.id == worklaneID }) else {
+            return
+        }
+        var worklane = worklanes[worklaneIndex]
+        guard worklane.paneStripState.panes.contains(where: { $0.id == paneID }) else {
             return
         }
 
@@ -1481,15 +1546,15 @@ final class WorklaneStore {
             if let previousPaneID {
                 worklane.paneStripState.focusPane(id: previousPaneID)
             }
-            activeWorklane = worklane
+            worklanes[worklaneIndex] = worklane
             return
         }
         if let previousPaneID {
             worklane.paneStripState.focusPane(id: previousPaneID)
         }
 
-        activeWorklane = worklane
-        notifyLayoutResized(animation: .splitCurve)
+        worklanes[worklaneIndex] = worklane
+        notify(.layoutResized(worklaneID, animation: .splitCurve))
     }
 
     /// Read the absolute pixel width of the column containing `paneID` in

--- a/Zentty/MainWindowController.swift
+++ b/Zentty/MainWindowController.swift
@@ -1053,6 +1053,27 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     }
 
     @discardableResult
+    func splitWithLayout(
+        in worklaneID: WorklaneID,
+        placement: PanePlacement,
+        isHorizontal: Bool,
+        layout: SplitLayoutAction,
+        targetPaneID: PaneID? = nil,
+        preserveFocusPaneID: PaneID? = nil,
+        sessionRequest: TerminalSessionRequest? = nil
+    ) -> PaneID? {
+        rootViewController.paneCommands.splitWithLayout(
+            in: worklaneID,
+            placement: placement,
+            isHorizontal: isHorizontal,
+            layout: layout,
+            targetPaneID: targetPaneID,
+            preserveFocusPaneID: preserveFocusPaneID,
+            sessionRequest: sessionRequest
+        )
+    }
+
+    @discardableResult
     func applyGrid(
         sourcePaneID: PaneID,
         rows: Int,
@@ -1093,6 +1114,11 @@ final class MainWindowController: NSObject, NSWindowDelegate {
     @discardableResult
     func launchDeferredPane(id paneID: PaneID, nativeCommand: String) -> Bool {
         rootViewController.paneCommands.launchDeferredPane(id: paneID, nativeCommand: nativeCommand)
+    }
+
+    @discardableResult
+    func launchDeferredPane(id paneID: PaneID, in worklaneID: WorklaneID, nativeCommand: String) -> Bool {
+        rootViewController.paneCommands.launchDeferredPane(id: paneID, in: worklaneID, nativeCommand: nativeCommand)
     }
 
     @discardableResult
@@ -1200,6 +1226,14 @@ final class MainWindowController: NSObject, NSWindowDelegate {
 
     func resizeColumnContainingPane(id paneID: PaneID, toFraction fraction: CGFloat) {
         rootViewController.paneCommands.resizeColumnContainingPane(id: paneID, toFraction: fraction)
+    }
+
+    func resizeColumnContainingPane(id paneID: PaneID, in worklaneID: WorklaneID, toFraction fraction: CGFloat) {
+        rootViewController.paneCommands.resizeColumnContainingPane(
+            id: paneID,
+            in: worklaneID,
+            toFraction: fraction
+        )
     }
 
     func columnWidthForPane(id paneID: PaneID, in worklaneID: WorklaneID) -> CGFloat? {

--- a/Zentty/UI/PaneCommandExecutor.swift
+++ b/Zentty/UI/PaneCommandExecutor.swift
@@ -241,7 +241,11 @@ final class PaneCommandExecutor {
     }
 
     func paneMinimumSizesByPaneID() -> [PaneID: PaneMinimumSize] {
-        guard let worklane = worklaneStore.activeWorklane else {
+        paneMinimumSizesByPaneID(in: worklaneStore.activeWorklaneID)
+    }
+
+    private func paneMinimumSizesByPaneID(in worklaneID: WorklaneID) -> [PaneID: PaneMinimumSize] {
+        guard let worklane = worklaneStore.worklanes.first(where: { $0.id == worklaneID }) else {
             return [:]
         }
 
@@ -284,6 +288,32 @@ final class PaneCommandExecutor {
             leadingVisibleInset: canvas.leadingVisibleInset,
             availableSize: canvas.boundsSize,
             minimumSizeByPaneID: paneMinimumSizesByPaneID(),
+            targetPaneID: targetPaneID,
+            preserveFocusPaneID: preserveFocusPaneID,
+            sessionRequest: sessionRequest
+        )
+    }
+
+    @discardableResult
+    func splitWithLayout(
+        in worklaneID: WorklaneID,
+        placement: PanePlacement,
+        isHorizontal: Bool,
+        layout: SplitLayoutAction,
+        targetPaneID: PaneID? = nil,
+        preserveFocusPaneID: PaneID? = nil,
+        sessionRequest: TerminalSessionRequest? = nil
+    ) -> PaneID? {
+        canvas.settlePaneStripPresentationNow()
+        return worklaneStore.splitWithLayout(
+            in: worklaneID,
+            placement: placement,
+            isHorizontal: isHorizontal,
+            layout: layout,
+            availableWidth: canvas.boundsSize.width,
+            leadingVisibleInset: canvas.leadingVisibleInset,
+            availableSize: canvas.boundsSize,
+            minimumSizeByPaneID: paneMinimumSizesByPaneID(in: worklaneID),
             targetPaneID: targetPaneID,
             preserveFocusPaneID: preserveFocusPaneID,
             sessionRequest: sessionRequest
@@ -336,6 +366,11 @@ final class PaneCommandExecutor {
     }
 
     @discardableResult
+    func launchDeferredPane(id paneID: PaneID, in worklaneID: WorklaneID, nativeCommand: String) -> Bool {
+        worklaneStore.launchDeferredPane(id: paneID, in: worklaneID, nativeCommand: nativeCommand)
+    }
+
+    @discardableResult
     func setPaneTitle(id paneID: PaneID, title: String) -> Bool {
         worklaneStore.setPaneTitle(id: paneID, title: title)
     }
@@ -373,6 +408,18 @@ final class PaneCommandExecutor {
             availableWidth: canvas.boundsSize.width,
             leadingVisibleInset: canvas.leadingVisibleInset,
             minimumSizeByPaneID: paneMinimumSizesByPaneID()
+        )
+    }
+
+    func resizeColumnContainingPane(id paneID: PaneID, in worklaneID: WorklaneID, toFraction fraction: CGFloat) {
+        canvas.settlePaneStripPresentationNow()
+        worklaneStore.resizeColumnContainingPane(
+            id: paneID,
+            in: worklaneID,
+            toFraction: fraction,
+            availableWidth: canvas.boundsSize.width,
+            leadingVisibleInset: canvas.leadingVisibleInset,
+            minimumSizeByPaneID: paneMinimumSizesByPaneID(in: worklaneID)
         )
     }
 

--- a/ZenttyLogicTests/PaneStripStoreTests.swift
+++ b/ZenttyLogicTests/PaneStripStoreTests.swift
@@ -2712,6 +2712,104 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertEqual(columns[1].panes[0].sessionRequest.isLaunchDeferred, true)
     }
 
+    func test_splitWithLayoutInInactiveWorklaneOnlyMutatesAndNotifiesRoutedWorklane() throws {
+        let teamWorklaneID = WorklaneID("team")
+        let otherWorklaneID = WorklaneID("other")
+        let layoutContext = PaneLayoutContext(
+            displayClass: .largeDisplay,
+            preset: .balanced,
+            viewportWidth: 1200,
+            leadingVisibleInset: 0,
+            sizing: .balanced
+        )
+        let otherWorklane = WorklaneState(
+            id: otherWorklaneID,
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: PaneID("other-pane"), title: "other")],
+                focusedPaneID: PaneID("other-pane")
+            )
+        )
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: teamWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("leader"), title: "leader", width: 1194)],
+                        focusedPaneID: PaneID("leader")
+                    )
+                ),
+                otherWorklane,
+            ],
+            layoutContext: layoutContext,
+            activeWorklaneID: otherWorklaneID
+        )
+        let originalOtherWorklane = store.worklanes.first(where: { $0.id == otherWorklaneID })
+        var changes: [WorklaneChange] = []
+        store.subscribe { changes.append($0) }
+
+        let newPaneID = store.splitWithLayout(
+            in: teamWorklaneID,
+            placement: .afterFocused,
+            isHorizontal: true,
+            layout: .golden,
+            availableWidth: layoutContext.viewportWidth,
+            leadingVisibleInset: layoutContext.leadingVisibleInset,
+            availableSize: CGSize(width: layoutContext.viewportWidth, height: 800),
+            minimumSizeByPaneID: [:],
+            targetPaneID: PaneID("leader"),
+            preserveFocusPaneID: PaneID("leader"),
+            sessionRequest: TerminalSessionRequest(isLaunchDeferred: true)
+        )
+
+        let teamWorklane = try XCTUnwrap(store.worklanes.first(where: { $0.id == teamWorklaneID }))
+        let createdPaneID = try XCTUnwrap(newPaneID)
+        XCTAssertEqual(store.activeWorklaneID, otherWorklaneID)
+        XCTAssertEqual(store.worklanes.first(where: { $0.id == otherWorklaneID }), originalOtherWorklane)
+        XCTAssertEqual(teamWorklane.paneStripState.focusedPaneID, PaneID("leader"))
+        XCTAssertEqual(teamWorklane.paneStripState.columns.count, 2)
+        XCTAssertEqual(teamWorklane.paneStripState.columns[1].panes.map(\.id), [createdPaneID])
+        XCTAssertTrue(teamWorklane.paneStripState.columns[1].panes[0].sessionRequest.isLaunchDeferred)
+        XCTAssertEqual(changes, [.paneStructure(teamWorklaneID)])
+    }
+
+    func test_splitWithLayoutInWorklaneRefusesMissingTargetPane() {
+        let teamWorklaneID = WorklaneID("team")
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: teamWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("leader"), title: "leader")],
+                        focusedPaneID: PaneID("leader")
+                    )
+                )
+            ],
+            activeWorklaneID: teamWorklaneID
+        )
+        let originalWorklanes = store.worklanes
+        var changes: [WorklaneChange] = []
+        store.subscribe { changes.append($0) }
+
+        let newPaneID = store.splitWithLayout(
+            in: teamWorklaneID,
+            placement: .afterFocused,
+            isHorizontal: true,
+            layout: .equal,
+            availableWidth: 1200,
+            leadingVisibleInset: 0,
+            availableSize: CGSize(width: 1200, height: 800),
+            minimumSizeByPaneID: [:],
+            targetPaneID: PaneID("missing")
+        )
+
+        XCTAssertNil(newPaneID)
+        XCTAssertEqual(store.worklanes, originalWorklanes)
+        XCTAssertTrue(changes.isEmpty)
+    }
+
     func test_launchDeferredPaneStoresNativeCommandWithoutChangingFocus() throws {
         let store = WorklaneStore(
             worklanes: [
@@ -2760,6 +2858,71 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertEqual(store.activeWorklane?.paneStripState.focusedPaneID, PaneID("master"))
         XCTAssertFalse(agentPane.sessionRequest.isLaunchDeferred)
         XCTAssertEqual(agentPane.sessionRequest.nativeCommand, "cd /tmp/project && env CLAUDECODE=1 claude")
+        XCTAssertTrue(agentPane.sessionRequest.waitAfterNativeCommand)
+        XCTAssertNil(agentPane.sessionRequest.command)
+    }
+
+    func test_launchDeferredPaneInSpecifiedWorklaneDoesNotChangeActiveWorklaneOrFocus() throws {
+        let teamWorklaneID = WorklaneID("team")
+        let otherWorklaneID = WorklaneID("other")
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: teamWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        columns: [
+                            PaneColumnState(
+                                id: PaneColumnID("leader-column"),
+                                panes: [PaneState(id: PaneID("leader"), title: "leader")],
+                                width: 400,
+                                focusedPaneID: PaneID("leader"),
+                                lastFocusedPaneID: PaneID("leader")
+                            ),
+                            PaneColumnState(
+                                id: PaneColumnID("agent-column"),
+                                panes: [
+                                    PaneState(
+                                        id: PaneID("agent"),
+                                        title: "agent",
+                                        sessionRequest: TerminalSessionRequest(isLaunchDeferred: true)
+                                    )
+                                ],
+                                width: 700,
+                                focusedPaneID: PaneID("agent"),
+                                lastFocusedPaneID: PaneID("agent")
+                            ),
+                        ],
+                        focusedColumnID: PaneColumnID("leader-column")
+                    )
+                ),
+                WorklaneState(
+                    id: otherWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: PaneID("other-pane"), title: "other")],
+                        focusedPaneID: PaneID("other-pane")
+                    )
+                ),
+            ],
+            activeWorklaneID: otherWorklaneID
+        )
+
+        let didLaunch = store.launchDeferredPane(
+            id: PaneID("agent"),
+            in: teamWorklaneID,
+            nativeCommand: "'/bin/zsh' -lic 'claude --agent-id teammate'"
+        )
+
+        let teamWorklane = try XCTUnwrap(store.worklanes.first(where: { $0.id == teamWorklaneID }))
+        let agentPane = try XCTUnwrap(
+            teamWorklane.paneStripState.panes.first(where: { $0.id == PaneID("agent") })
+        )
+        XCTAssertTrue(didLaunch)
+        XCTAssertEqual(store.activeWorklaneID, otherWorklaneID)
+        XCTAssertEqual(teamWorklane.paneStripState.focusedPaneID, PaneID("leader"))
+        XCTAssertFalse(agentPane.sessionRequest.isLaunchDeferred)
+        XCTAssertEqual(agentPane.sessionRequest.nativeCommand, "'/bin/zsh' -lic 'claude --agent-id teammate'")
         XCTAssertTrue(agentPane.sessionRequest.waitAfterNativeCommand)
         XCTAssertNil(agentPane.sessionRequest.command)
     }
@@ -2817,6 +2980,76 @@ final class PaneStripStoreTests: XCTestCase {
         XCTAssertEqual(store.activeWorklane?.paneStripState.focusedPaneID, PaneID("agent"))
         XCTAssertEqual(columns[0].width, pairUsableWidth * leaderFraction, accuracy: 0.01)
         XCTAssertEqual(columns[1].width, pairUsableWidth * (1 - leaderFraction), accuracy: 0.01)
+    }
+
+    func test_resizeColumnContainingPaneInInactiveWorklaneOnlyMutatesAndNotifiesRoutedWorklane() throws {
+        let teamWorklaneID = WorklaneID("team")
+        let otherWorklaneID = WorklaneID("other")
+        let layoutContext = PaneLayoutContext(
+            displayClass: .largeDisplay,
+            preset: .balanced,
+            viewportWidth: 1200,
+            leadingVisibleInset: 0,
+            sizing: .balanced
+        )
+        let otherWorklane = WorklaneState(
+            id: otherWorklaneID,
+            title: nil,
+            paneStripState: PaneStripState(
+                panes: [PaneState(id: PaneID("other-pane"), title: "other")],
+                focusedPaneID: PaneID("other-pane")
+            )
+        )
+        let store = WorklaneStore(
+            worklanes: [
+                WorklaneState(
+                    id: teamWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        columns: [
+                            PaneColumnState(
+                                id: PaneColumnID("leader-column"),
+                                panes: [PaneState(id: PaneID("leader"), title: "leader")],
+                                width: 400,
+                                focusedPaneID: PaneID("leader")
+                            ),
+                            PaneColumnState(
+                                id: PaneColumnID("agent-column"),
+                                panes: [PaneState(id: PaneID("agent"), title: "agent")],
+                                width: 788,
+                                focusedPaneID: PaneID("agent")
+                            ),
+                        ],
+                        focusedColumnID: PaneColumnID("agent-column")
+                    )
+                ),
+                otherWorklane,
+            ],
+            layoutContext: layoutContext,
+            activeWorklaneID: otherWorklaneID
+        )
+        let originalOtherWorklane = store.worklanes.first(where: { $0.id == otherWorklaneID })
+        var changes: [WorklaneChange] = []
+        store.subscribe { changes.append($0) }
+        let phi: CGFloat = (1 + sqrt(5)) / 2
+        let leaderFraction = phi / (1 + phi)
+
+        store.resizeColumnContainingPane(
+            id: PaneID("leader"),
+            in: teamWorklaneID,
+            toFraction: leaderFraction,
+            availableWidth: layoutContext.viewportWidth,
+            leadingVisibleInset: layoutContext.leadingVisibleInset,
+            minimumSizeByPaneID: [:]
+        )
+
+        let teamWorklane = try XCTUnwrap(store.worklanes.first(where: { $0.id == teamWorklaneID }))
+        let pairUsableWidth = layoutContext.availableWidth - layoutContext.sizing.interPaneSpacing
+        XCTAssertEqual(store.activeWorklaneID, otherWorklaneID)
+        XCTAssertEqual(store.worklanes.first(where: { $0.id == otherWorklaneID }), originalOtherWorklane)
+        XCTAssertEqual(teamWorklane.paneStripState.focusedPaneID, PaneID("agent"))
+        XCTAssertEqual(teamWorklane.paneStripState.columns[0].width, pairUsableWidth * leaderFraction, accuracy: 0.01)
+        XCTAssertEqual(changes, [.layoutResized(teamWorklaneID, animation: .splitCurve)])
     }
 
     func test_golden_width_arrange_emits_split_curve_layout_resize_change() {

--- a/ZenttyLogicTests/TmuxCompatArgumentsTests.swift
+++ b/ZenttyLogicTests/TmuxCompatArgumentsTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import Zentty
 
 final class TmuxCompatArgumentsTests: XCTestCase {
+    private func paneEntry(id: String, isFocused: Bool) -> PaneListEntry {
+        PaneListEntry(
+            index: 0,
+            id: id,
+            column: 0,
+            title: id,
+            workingDirectory: nil,
+            isFocused: isFocused,
+            agentTool: nil,
+            agentStatus: nil
+        )
+    }
+
     func test_displayTemplateUsesPositionalFormatAfterPrintFlag() {
         let parsed = TmuxCompatArguments.parse(
             ["-t", "%pn_leader", "-p", "#{session_name}:#{window_index}"],
@@ -100,6 +113,152 @@ final class TmuxCompatArgumentsTests: XCTestCase {
         XCTAssertEqual(parsed.positionals, ["-c", "value"])
     }
 
+    func test_splitWindowStartupRequestDefersExactClaudeBootstrap() {
+        let arguments = [
+            "-d", "-t", "%leader", "-h", "-l", "70%", "-P", "-F", "#{pane_id}", "--", "cat"
+        ]
+        let parsed = TmuxCompatArguments.parse(
+            arguments,
+            valueFlags: ["-c", "-F", "-l", "-t"],
+            boolFlags: ["-P", "-b", "-d", "-h", "-v"]
+        )
+
+        let request = TmuxCompatIPCHandler.splitWindowStartupRequest(
+            arguments: arguments,
+            parsed: parsed,
+            loginShellPath: "/bin/zsh"
+        )
+
+        XCTAssertTrue(request.isLaunchDeferred)
+        XCTAssertNil(request.command)
+        XCTAssertNil(request.nativeCommand)
+    }
+
+    func test_splitWindowStartupRequestKeepsOrdinaryCatImmediate() {
+        let arguments = ["--", "cat"]
+        let parsed = TmuxCompatArguments.parse(
+            arguments,
+            valueFlags: ["-c", "-F", "-l", "-t"],
+            boolFlags: ["-P", "-b", "-d", "-h", "-v"]
+        )
+
+        let request = TmuxCompatIPCHandler.splitWindowStartupRequest(
+            arguments: arguments,
+            parsed: parsed,
+            loginShellPath: "/bin/zsh"
+        )
+
+        XCTAssertFalse(request.isLaunchDeferred)
+        XCTAssertEqual(request.nativeCommand, "'/bin/zsh' -lic 'cat'")
+    }
+
+    func test_splitWindowStartupRequestKeepsNonPlaceholderCommandImmediate() {
+        let arguments = [
+            "-d", "-t", "%leader", "-h", "-l", "70%", "-P", "-F", "#{pane_id}", "--", "cat", "README.md"
+        ]
+        let parsed = TmuxCompatArguments.parse(
+            arguments,
+            valueFlags: ["-c", "-F", "-l", "-t"],
+            boolFlags: ["-P", "-b", "-d", "-h", "-v"]
+        )
+
+        let request = TmuxCompatIPCHandler.splitWindowStartupRequest(
+            arguments: arguments,
+            parsed: parsed,
+            loginShellPath: "/bin/zsh"
+        )
+
+        XCTAssertFalse(request.isLaunchDeferred)
+        XCTAssertEqual(request.nativeCommand, "'/bin/zsh' -lic 'cat README.md'")
+    }
+
+    func test_respawnPaneLaunchRequestPreservesClaudeCompoundCommand() {
+        let leader = paneEntry(id: "leader", isFocused: true)
+        let agent = paneEntry(id: "agent", isFocused: false)
+        let command = "cd /tmp/project && env CLAUDECODE=1 claude --agent-id teammate"
+
+        let request = TmuxCompatIPCHandler.respawnPaneLaunchRequest(
+            arguments: ["-k", "-t", "%agent", "--", command],
+            paneEntries: [leader, agent],
+            loginShellPath: "/bin/zsh"
+        )
+
+        XCTAssertEqual(request?.paneID, PaneID("agent"))
+        XCTAssertEqual(
+            request?.nativeCommand,
+            "'/bin/zsh' -lic 'cd /tmp/project && env CLAUDECODE=1 claude --agent-id teammate'"
+        )
+    }
+
+    func test_respawnPaneLaunchRequestRejectsUnsupportedOrUnsafeShapes() {
+        let leader = paneEntry(id: "leader", isFocused: true)
+        let agent = paneEntry(id: "agent", isFocused: false)
+        let command = "cd /tmp/project && env CLAUDECODE=1 claude --agent-id teammate"
+        let cases: [[String]] = [
+            ["-t", "%agent", "--", command],
+            ["-k", "--", command],
+            ["-k", "-t", "%agent", command],
+            ["-k", "-t", "%agent", "--"],
+            ["-k", "-t", "%agent", "--", command, "extra"],
+            ["-k", "-t", "%missing", "--", command],
+            ["-k", "-k", "-t", "%agent", "--", command],
+            ["-t", "%agent", "-k", "--", command],
+            ["-k", "-t", "%leader", "-t", "%agent", "--", command],
+            ["-k", "-t%agent", "--", command],
+            ["-k", "-x", "-t", "%agent", "--", command],
+        ]
+
+        for arguments in cases {
+            XCTAssertNil(
+                TmuxCompatIPCHandler.respawnPaneLaunchRequest(
+                    arguments: arguments,
+                    paneEntries: [leader, agent],
+                    loginShellPath: "/bin/zsh"
+                ),
+                "Expected nil for arguments: \(arguments)"
+            )
+        }
+    }
+
+    func test_unresolvedTargetResultRejectsTargetDependentLaunchCommands() {
+        for subcommand in ["split-window", "splitw", "respawn-pane", "respawnp"] {
+            XCTAssertThrowsError(try TmuxCompatIPCHandler.unresolvedTargetResult(for: subcommand)) { error in
+                guard let tmuxError = error as? TmuxCompatIPCError else {
+                    return XCTFail("Expected TmuxCompatIPCError, got \(error)")
+                }
+                guard case .targetUnavailable = tmuxError else {
+                    return XCTFail("Expected targetUnavailable, got \(tmuxError)")
+                }
+                XCTAssertEqual(
+                    tmuxError.localizedDescription,
+                    "Cannot route tmux command: the target Zentty worklane or pane is no longer available."
+                )
+            }
+        }
+    }
+
+    func test_validateSplitTargetRejectsMissingLeaderPane() {
+        XCTAssertThrowsError(
+            try TmuxCompatIPCHandler.validateSplitTarget(
+                PaneID("gone"),
+                paneEntries: [paneEntry(id: "other", isFocused: true)]
+            )
+        ) { error in
+            guard let tmuxError = error as? TmuxCompatIPCError else {
+                return XCTFail("Expected TmuxCompatIPCError, got \(error)")
+            }
+            guard case .targetUnavailable = tmuxError else {
+                return XCTFail("Expected targetUnavailable, got \(tmuxError)")
+            }
+        }
+    }
+
+    func test_unresolvedTargetResultAcknowledgesSetOption() throws {
+        let result = try TmuxCompatIPCHandler.unresolvedTargetResult(for: "set-option")
+
+        XCTAssertNil(result.stdout)
+    }
+
     func test_sendKeysTranslatesEnterToCarriageReturn() {
         XCTAssertEqual(
             TmuxCompatIPCHandler.sendKeysText(arguments: ["-t", "%pane", "claude", "Enter"], standardInput: nil),
@@ -170,6 +329,35 @@ final class TmuxCompatArgumentsTests: XCTestCase {
                 paneEntries: panes
             ),
             PaneID("agent")
+        )
+    }
+
+    func test_sendKeysTargetPaneIDDoesNotFallbackWhenExplicitTargetIsMissing() {
+        let panes = [paneEntry(id: "leader", isFocused: true)]
+
+        for arguments in [
+            ["-t", "%gone", "echo", "hello"],
+            ["-t%gone", "echo", "hello"],
+        ] {
+            XCTAssertNil(
+                TmuxCompatIPCHandler.sendKeysTargetPaneID(
+                    arguments: arguments,
+                    fallback: PaneID("leader"),
+                    paneEntries: panes
+                ),
+                "Expected no fallback for arguments: \(arguments)"
+            )
+        }
+    }
+
+    func test_sendKeysTargetPaneIDUsesFallbackWhenTargetFlagIsAbsent() {
+        XCTAssertEqual(
+            TmuxCompatIPCHandler.sendKeysTargetPaneID(
+                arguments: ["echo", "hello"],
+                fallback: PaneID("leader"),
+                paneEntries: []
+            ),
+            PaneID("leader")
         )
     }
 

--- a/ZenttyTests/AppDelegateTests.swift
+++ b/ZenttyTests/AppDelegateTests.swift
@@ -757,6 +757,174 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertNil(controllers[0].lastNavigateRequestPaneIDForTesting)
     }
 
+    func test_tmux_routing_prefers_matching_windowIDAndFallsBackWhenThatWindowNoLongerOwnsWorklane() throws {
+        NSApp.mainMenu = nil
+
+        let delegate = AppDelegate(
+            runtimeRegistryFactory: { PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() }) }
+        )
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+        delegate.newWindow(nil)
+        waitForAppWindows()
+
+        let controllers = delegate.windowControllersForTesting
+        XCTAssertEqual(controllers.count, 2)
+        let sharedWorklaneID = WorklaneID("shared")
+        for (index, controller) in controllers.enumerated() {
+            let paneID = PaneID("pane-\(index)")
+            controller.rootViewControllerForTesting.replaceWorklanes([
+                WorklaneState(
+                    id: sharedWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: paneID, title: "shell")],
+                        focusedPaneID: paneID
+                    )
+                )
+            ], activeWorklaneID: sharedWorklaneID)
+        }
+
+        let target = AgentIPCTarget(
+            windowID: controllers[1].windowIDForTesting,
+            worklaneID: sharedWorklaneID,
+            paneID: PaneID("pane-1")
+        )
+        XCTAssertTrue(
+            TmuxCompatIPCHandler.resolveWindowController(for: target, appDelegate: delegate) === controllers[1]
+        )
+
+        let replacementWorklaneID = WorklaneID("replacement")
+        let replacementPaneID = PaneID("replacement-pane")
+        controllers[1].rootViewControllerForTesting.replaceWorklanes([
+            WorklaneState(
+                id: replacementWorklaneID,
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: replacementPaneID, title: "shell")],
+                    focusedPaneID: replacementPaneID
+                )
+            )
+        ], activeWorklaneID: replacementWorklaneID)
+
+        XCTAssertTrue(
+            TmuxCompatIPCHandler.resolveWindowController(for: target, appDelegate: delegate) === controllers[0]
+        )
+    }
+
+    func test_tmux_routing_followsPaneWhenOriginalWindowRetainsDuplicatedWorklane() throws {
+        NSApp.mainMenu = nil
+
+        let delegate = AppDelegate(
+            runtimeRegistryFactory: { PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() }) }
+        )
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+        delegate.newWindow(nil)
+        waitForAppWindows()
+
+        let controllers = delegate.windowControllersForTesting
+        XCTAssertEqual(controllers.count, 2)
+        let sharedWorklaneID = WorklaneID("shared")
+        let originalPaneID = PaneID("original-pane")
+        controllers[0].rootViewControllerForTesting.replaceWorklanes([
+            WorklaneState(
+                id: sharedWorklaneID,
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: originalPaneID, title: "shell")],
+                    focusedPaneID: originalPaneID
+                )
+            )
+        ], activeWorklaneID: sharedWorklaneID)
+
+        let movedPaneID = PaneID("moved-pane")
+        controllers[1].rootViewControllerForTesting.replaceWorklanes([
+            WorklaneState(
+                id: sharedWorklaneID,
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: movedPaneID, title: "shell")],
+                    focusedPaneID: movedPaneID
+                )
+            )
+        ], activeWorklaneID: sharedWorklaneID)
+
+        let target = AgentIPCTarget(
+            windowID: controllers[0].windowIDForTesting,
+            worklaneID: sharedWorklaneID,
+            paneID: movedPaneID
+        )
+
+        XCTAssertTrue(
+            TmuxCompatIPCHandler.resolveWindowController(for: target, appDelegate: delegate) === controllers[1]
+        )
+    }
+
+    func test_tmux_routing_usesPaneMembershipToDisambiguateDuplicatedWorklanesAfterStaleWindowID() throws {
+        NSApp.mainMenu = nil
+
+        let delegate = AppDelegate(
+            runtimeRegistryFactory: { PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() }) }
+        )
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+        delegate.newWindow(nil)
+        delegate.newWindow(nil)
+        waitForAppWindows()
+
+        let controllers = delegate.windowControllersForTesting
+        XCTAssertEqual(controllers.count, 3)
+        let sharedWorklaneID = WorklaneID("shared")
+        for (index, controller) in controllers.prefix(2).enumerated() {
+            let paneID = PaneID("wrong-pane-\(index)")
+            controller.rootViewControllerForTesting.replaceWorklanes([
+                WorklaneState(
+                    id: sharedWorklaneID,
+                    title: nil,
+                    paneStripState: PaneStripState(
+                        panes: [PaneState(id: paneID, title: "shell")],
+                        focusedPaneID: paneID
+                    )
+                )
+            ], activeWorklaneID: sharedWorklaneID)
+        }
+
+        let worklaneOnlyMatch = try XCTUnwrap(delegate.windowController(containingWorklane: sharedWorklaneID))
+        let paneMatch = try XCTUnwrap(controllers.prefix(2).first { $0 !== worklaneOnlyMatch })
+        let targetPaneID = PaneID("target-pane")
+        paneMatch.rootViewControllerForTesting.replaceWorklanes([
+            WorklaneState(
+                id: sharedWorklaneID,
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: targetPaneID, title: "shell")],
+                    focusedPaneID: targetPaneID
+                )
+            )
+        ], activeWorklaneID: sharedWorklaneID)
+
+        let staleWorklaneID = WorklaneID("stale-window-worklane")
+        let stalePaneID = PaneID("stale-window-pane")
+        controllers[2].rootViewControllerForTesting.replaceWorklanes([
+            WorklaneState(
+                id: staleWorklaneID,
+                title: nil,
+                paneStripState: PaneStripState(
+                    panes: [PaneState(id: stalePaneID, title: "shell")],
+                    focusedPaneID: stalePaneID
+                )
+            )
+        ], activeWorklaneID: staleWorklaneID)
+
+        let target = AgentIPCTarget(
+            windowID: controllers[2].windowIDForTesting,
+            worklaneID: sharedWorklaneID,
+            paneID: targetPaneID
+        )
+
+        XCTAssertTrue(
+            TmuxCompatIPCHandler.resolveWindowController(for: target, appDelegate: delegate) === paneMatch
+        )
+    }
+
     func test_restore_launch_uses_legacy_autosaved_frame_as_layout_seed_when_recipe_has_no_frame() throws {
         NSApp.mainMenu = nil
         let directoryURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

- Defer the exact `split-window ... -- cat` placeholder emitted by current Claude Code, then promote that same pane when `respawn-pane` arrives.
- Keep split, resize, launch, and historical `send-keys` routing tied to the originating pane and worklane, including moved panes and duplicate worklane IDs.
- Return readable failures for stale or malformed targets instead of silently routing to the wrong pane.

## Test plan

- [x] 3,716 ZenttyLogicTests
- [x] 3 hosted multi-window routing tests
- [x] 8 TmuxCompatCLITests
- [x] Debug build
- [x] Live `split-window -> set-option -> respawn-pane` smoke test produced `ZENTTY_HANDSHAKE_OK` with no IPC or CLI errors

Closes #58