### PR TITLE
fix(terminal): preserve text during IME backspace

### DIFF
--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -2280,14 +2280,22 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
             }
         }
 
+        // An IME may clear marked text while consuming this event (for example,
+        // Backspace cancelling a candidate). Preserve the state the event began in.
+        let wasComposing = hasMarkedText()
         keyTextAccumulator = ""
         interpretKeyEvents([translatedEvent])
-        let keyText = keyTextAccumulator.isEmpty ? fallbackText(for: translatedEvent) : keyTextAccumulator
+        let committedText = keyTextAccumulator.isEmpty ? nil : keyTextAccumulator
+        let keyText = committedText ?? fallbackText(for: translatedEvent)
         _ = surfaceController.sendKey(
             event: event,
             action: event.isARepeat ? .repeatPress : .press,
             text: keyText,
-            composing: hasMarkedText()
+            composing: Self.shouldSendKeyAsComposing(
+                wasComposing: wasComposing,
+                isComposing: hasMarkedText(),
+                committedText: committedText
+            )
         )
         if shouldEmitUserSubmittedInput {
             onLocalEventDidOccur?(.userSubmittedInput)
@@ -2768,6 +2776,14 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
 
     private func fallbackText(for event: NSEvent) -> String? {
         LibghosttySurface.textForKeyEvent(event)
+    }
+
+    static func shouldSendKeyAsComposing(
+        wasComposing: Bool,
+        isComposing: Bool,
+        committedText: String?
+    ) -> Bool {
+        committedText == nil && (wasComposing || isComposing)
     }
 
     private static func sanitizedInputText(_ text: String) -> String? {

--- a/ZenttyLogicTests/LibghosttyViewIMETests.swift
+++ b/ZenttyLogicTests/LibghosttyViewIMETests.swift
@@ -112,6 +112,49 @@ final class LibghosttyViewIMETests: AppKitTestCase {
     }
 }
 
+@MainActor
+final class LibghosttyViewIMEKeyRoutingTests: XCTestCase {
+    func test_key_ending_composition_without_committed_text_stays_composing() {
+        XCTAssertTrue(
+            LibghosttyView.shouldSendKeyAsComposing(
+                wasComposing: true,
+                isComposing: false,
+                committedText: nil
+            )
+        )
+    }
+
+    func test_key_during_active_composition_is_composing() {
+        XCTAssertTrue(
+            LibghosttyView.shouldSendKeyAsComposing(
+                wasComposing: false,
+                isComposing: true,
+                committedText: nil
+            )
+        )
+    }
+
+    func test_key_without_composition_is_not_composing() {
+        XCTAssertFalse(
+            LibghosttyView.shouldSendKeyAsComposing(
+                wasComposing: false,
+                isComposing: false,
+                committedText: nil
+            )
+        )
+    }
+
+    func test_key_committing_composed_text_is_not_composing() {
+        XCTAssertFalse(
+            LibghosttyView.shouldSendKeyAsComposing(
+                wasComposing: true,
+                isComposing: false,
+                committedText: "好"
+            )
+        )
+    }
+}
+
 // `ghostty_surface_ime_point` hands back x/y/height in points but width in device
 // pixels (upstream leaves the width divide out on purpose), so `imeRect()` has to
 // normalise width itself or the caret rect is twice as wide on Retina and the


### PR DESCRIPTION
## Summary

- Preserve the composition state that existed before AppKit handles an IME key event, so a candidate-cancelling Backspace does not reach the terminal.
- Send committed IME text normally and cover both paths with regression tests.

## Testing

- `ZENTTY_TEST_DISPLAY_PROVIDER=betterdisplay scripts/test-on-virtual-display -only-testing:ZenttyLogicTests/LibghosttyViewIMETests -only-testing:ZenttyLogicTests/LibghosttyViewIMEKeyRoutingTests`
- Full `ZenttyLogicTests` suite: 3,764 tests passed

Closes #71