### PR TITLE
build: update libghostty to current tip

### DIFF
--- a/docs/ghosttykit-setup.md
+++ b/docs/ghosttykit-setup.md
@@ -35,13 +35,13 @@ xcodebuild -project Zentty.xcodeproj -scheme Zentty -destination 'platform=macOS
 
 ## Recovery Steps
 
-If the locked Zig version is missing:
+If the locked Zig version is missing (currently `0.16.0`):
 
 ```bash
-brew install zig@0.15
+brew install zig
 ```
 
-`zig@0.15` is keg-only. You do not need to relink Homebrew's default `zig`; `scripts/build_ghosttykit.sh` resolves the locked version directly.
+You do not need to relink a versioned Homebrew formula; `scripts/build_ghosttykit.sh` resolves the locked version directly.
 
 If `gettext` is missing:
 

--- a/scripts/build_ghosttykit.sh
+++ b/scripts/build_ghosttykit.sh
@@ -41,6 +41,7 @@ if ! command -v brew >/dev/null 2>&1 && ! command -v port >/dev/null 2>&1; then
   exit 1
 fi
 require_command xcode-select "Install full Xcode."
+require_command xcodebuild "Install full Xcode."
 require_command xcrun "Install full Xcode."
 
 resolve_zig_command() {
@@ -79,7 +80,7 @@ resolve_zig_command() {
   fi
 
   echo "Missing required Zig version ${zig_version}." >&2
-  echo "Install it with: brew install ${formula} OR sudo port install zig" >&2
+  echo "Install it with: brew install zig OR sudo port install zig" >&2
   exit 1
 }
 
@@ -90,6 +91,29 @@ if [[ "${XCODE_PATH}" != */Xcode*.app/Contents/Developer ]]; then
   echo "Full Xcode is not selected. Current developer dir: ${XCODE_PATH}" >&2
   echo "Select full Xcode with: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
   exit 1
+fi
+
+# Newer Xcode releases ship the Metal compiler as a separately installed
+# toolchain. Select it explicitly when available; otherwise xcrun may resolve
+# the XcodeDefault shim, which reports that the installed toolchain is missing.
+METAL_TOOLCHAINS="${TOOLCHAINS:-}"
+if METAL_COMPONENT_INFO="$(xcodebuild -showComponent MetalToolchain 2>/dev/null)"; then
+  METAL_TOOLCHAIN_ID=""
+  while IFS= read -r line; do
+    if [[ "${line}" == "Toolchain Identifier: "* ]]; then
+      METAL_TOOLCHAIN_ID="${line#Toolchain Identifier: }"
+      break
+    fi
+  done <<< "${METAL_COMPONENT_INFO}"
+
+  if [[ -n "${METAL_TOOLCHAIN_ID}" ]]; then
+    METAL_TOOLCHAINS="${METAL_TOOLCHAIN_ID}${METAL_TOOLCHAINS:+ ${METAL_TOOLCHAINS}}"
+  fi
+fi
+
+BUILD_ENV=()
+if [[ -n "${METAL_TOOLCHAINS}" ]]; then
+  BUILD_ENV=(env "TOOLCHAINS=${METAL_TOOLCHAINS}")
 fi
 
 has_gettext=0
@@ -106,7 +130,7 @@ if [[ "$has_gettext" -eq 0 ]]; then
   exit 1
 fi
 
-if ! xcrun --find metal >/dev/null 2>&1; then
+if ! "${BUILD_ENV[@]}" xcrun --find metal >/dev/null 2>&1; then
   echo "Missing Metal Toolchain. Install with: xcodebuild -downloadComponent MetalToolchain" >&2
   exit 1
 fi
@@ -136,7 +160,7 @@ fi
 
 (
   cd "${SOURCE_DIR}"
-  "${ZIG_COMMAND}" build -Doptimize=ReleaseFast -Demit-macos-app=false -Dxcframework-target="${build_target}"
+  "${BUILD_ENV[@]}" "${ZIG_COMMAND}" build -Doptimize=ReleaseFast -Demit-macos-app=false -Dxcframework-target="${build_target}"
 )
 
 if [[ ! -d "${ARTIFACT_SOURCE}" ]]; then

--- a/scripts/ghosttykit.lock
+++ b/scripts/ghosttykit.lock
@@ -1,7 +1,7 @@
 repo=https://github.com/dedene/ghostty.git
-revision=4e9fe4bb5adbd0140b0a94133bd39672076cb6de
+revision=bee61930c43ea94ccb372fb14f02f81c01ec73b9
 upstream_repo=https://github.com/ghostty-org/ghostty.git
-upstream_revision=19e20f7664dc7a755d2d7a16ab545b2503f26caf
+upstream_revision=9f0e1719dc918368367d368bfe300f59bb68b5a4
 patch_branch=zentty/smooth-scroll
 build_target=universal
-zig_version=0.15.2
+zig_version=0.16.0


### PR DESCRIPTION
## What changed

Updates libghostty from the May snapshot to Ghostty 9f0e171, with Zentty’s smooth-scroll patches rebased on top at bee61930. This includes Ghostty’s renderer mutex handoff fix and libghostty mode 5522 support while preserving the scrolling behavior Zentty depends on.

The build helper now detects Xcode’s separately installed Metal toolchain and selects it through TOOLCHAINS when needed. The setup notes now match the Zig 0.16 toolchain used by this build.

## Verification

- Ghostty smooth-scroll tests passed
- Ghostty mode 5522 tests passed
- 207 focused libghostty logic tests passed
- 16 hosted TerminalPaneHostView tests passed
- Release app build passed
- Peter’s manual OMP close smoke test passed

The full ZenttyLogicTests run passed 3,763 of 3,764 tests. The remaining failure is the current-main AppKitTestDisplay test: the locally registered BetterDisplay display was not visible through NSScreen.