### PR TITLE
Add Ghostty-compatible shortcuts

### DIFF
--- a/Zentty/AppDelegate.swift
+++ b/Zentty/AppDelegate.swift
@@ -245,6 +245,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc
+    func toggleMainWindowFullScreen(_ sender: Any?) {
+        windowControllers.values
+            .first(where: { $0.window.isKeyWindow })?
+            .window.toggleFullScreen(sender)
+    }
+
+    @objc
     func focusNextWaitingAgentPane(_ sender: Any?) {
         _ = menuBarStatusController?.focusNextWaitingPane()
     }
@@ -993,6 +1000,16 @@ extension AppDelegate: NSMenuItemValidation {
 
         if menuItem.action == #selector(toggleTerminalFrameMeter(_:)) {
             menuItem.state = TerminalFrameMeter.shared.isEnabled ? .on : .off
+            return true
+        }
+
+        if menuItem.action == #selector(toggleMainWindowFullScreen(_:)) {
+            guard let controller = windowControllers.values.first(where: { $0.window.isKeyWindow }) else {
+                return false
+            }
+            menuItem.title = controller.window.styleMask.contains(.fullScreen)
+                ? "Exit Full Screen"
+                : "Enter Full Screen"
             return true
         }
 

--- a/Zentty/AppMenuBuilder.swift
+++ b/Zentty/AppMenuBuilder.swift
@@ -175,7 +175,23 @@ enum AppMenuBuilder {
     }
 
     private static func makeViewMenuItem(shortcutManager: ShortcutManager) -> NSMenuItem {
-        makeSectionMenuItem(section: .view, shortcutManager: shortcutManager)
+        let menuItem = makeSectionMenuItem(section: .view, shortcutManager: shortcutManager)
+        guard let menu = menuItem.submenu else {
+            return menuItem
+        }
+
+        menu.addItem(makeSeparatorItem())
+        let fullScreenItem = makeStandardMenuActionItem(
+            title: "Enter Full Screen",
+            action: #selector(AppDelegate.toggleMainWindowFullScreen(_:)),
+            keyEquivalent: "f",
+            modifierMask: [.command, .control]
+        )
+        // AppKit hides this item when it synthesizes the native full-screen
+        // menu entry. Keep the alternate ⌃⌘F equivalent active while hidden.
+        fullScreenItem.allowsKeyEquivalentWhenHidden = true
+        menu.addItem(fullScreenItem)
+        return menuItem
     }
 
     private static func makeWindowMenuItem(shortcutManager: ShortcutManager) -> NSMenuItem {
@@ -246,10 +262,11 @@ enum AppMenuBuilder {
     private static func makeStandardMenuActionItem(
         title: String,
         action: Selector,
-        keyEquivalent: String
+        keyEquivalent: String,
+        modifierMask: NSEvent.ModifierFlags? = nil
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
-        item.keyEquivalentModifierMask = keyEquivalent.isEmpty ? [] : [.command]
+        item.keyEquivalentModifierMask = modifierMask ?? (keyEquivalent.isEmpty ? [] : [.command])
         return item
     }
 
@@ -377,7 +394,13 @@ enum AppMenuBuilder {
             hasRequiredStructure(expectedEntries(for: .navigation), in: navigationMenu)
         let hasViewItems =
             viewMenu?.title == AppMenuSection.view.rawValue &&
-            hasRequiredStructure(expectedEntries(for: .view), in: viewMenu)
+            hasRequiredStructure(expectedEntries(for: .view), in: viewMenu) &&
+            viewMenu?.items.contains(where: {
+                $0.action == #selector(AppDelegate.toggleMainWindowFullScreen(_:)) &&
+                $0.keyEquivalent == "f" &&
+                $0.keyEquivalentModifierMask == [.command, .control] &&
+                $0.allowsKeyEquivalentWhenHidden
+            }) == true
         let hasWindowItems =
             windowMenu?.title == "Window" &&
             hasRequiredItems([

--- a/Zentty/Input/ShortcutPreset.swift
+++ b/Zentty/Input/ShortcutPreset.swift
@@ -3,6 +3,7 @@ import Carbon.HIToolbox
 enum ShortcutPreset: String, CaseIterable, Sendable {
     case leftHand
     case rightHand
+    case ghosttyCompatible
 
     var title: String {
         switch self {
@@ -10,6 +11,8 @@ enum ShortcutPreset: String, CaseIterable, Sendable {
             "Left-Hand Preset"
         case .rightHand:
             "Right-Hand Preset"
+        case .ghosttyCompatible:
+            "Ghostty-Compatible Preset"
         }
     }
 
@@ -23,6 +26,8 @@ enum ShortcutPreset: String, CaseIterable, Sendable {
             "This will replace all current shortcut bindings with shortcuts optimized for left-hand use, based on your current keyboard layout."
         case .rightHand:
             "This will replace all current shortcut bindings with shortcuts optimized for right-hand use, based on your current keyboard layout."
+        case .ghosttyCompatible:
+            "This replaces your current shortcut bindings with Ghostty-compatible macOS shortcuts while keeping non-conflicting Zentty shortcuts."
         }
     }
 }
@@ -77,7 +82,19 @@ struct ShortcutPresetResolver {
     }
 
     private func resolveKey(for entry: ShortcutPresetEntry) -> KeyboardShortcutKey? {
-        switch entry.keyKind {
+        switch entry.key {
+        case .logical(let key):
+            return key
+        case .physical(let keyCode, let keyKind):
+            return resolvePhysicalKey(keyCode: keyCode, keyKind: keyKind)
+        }
+    }
+
+    private func resolvePhysicalKey(
+        keyCode: UInt16,
+        keyKind: ShortcutPresetKeyKind
+    ) -> KeyboardShortcutKey? {
+        switch keyKind {
         case .tab:
             return .tab
         case .leftArrow:
@@ -89,10 +106,10 @@ struct ShortcutPresetResolver {
         case .downArrow:
             return .downArrow
         case .character:
-            if isNumberRowKeyCode(entry.keyCode) {
-                return resolveNumberRowKey(for: entry)
+            if isNumberRowKeyCode(keyCode) {
+                return resolveNumberRowKey(keyCode: keyCode)
             }
-            guard let character = sourceProvider.output(for: entry.keyCode, modifiers: []) else {
+            guard let character = sourceProvider.output(for: keyCode, modifiers: []) else {
                 return nil
             }
             return .character(character.lowercased())
@@ -100,10 +117,11 @@ struct ShortcutPresetResolver {
     }
 
     private func resolveModifiers(for entry: ShortcutPresetEntry) -> Set<KeyboardModifier> {
-        guard entry.keyKind == .character, isNumberRowKeyCode(entry.keyCode) else {
+        guard case .physical(let keyCode, .character) = entry.key,
+              isNumberRowKeyCode(keyCode) else {
             return entry.modifiers
         }
-        guard let unshifted = sourceProvider.output(for: entry.keyCode, modifiers: []) else {
+        guard let unshifted = sourceProvider.output(for: keyCode, modifiers: []) else {
             return entry.modifiers
         }
         let isDigitByDefault = unshifted.count == 1 && unshifted.first?.isNumber == true
@@ -113,12 +131,12 @@ struct ShortcutPresetResolver {
         return entry.modifiers.union([.shift])
     }
 
-    private func resolveNumberRowKey(for entry: ShortcutPresetEntry) -> KeyboardShortcutKey? {
-        if let unshifted = sourceProvider.output(for: entry.keyCode, modifiers: []),
+    private func resolveNumberRowKey(keyCode: UInt16) -> KeyboardShortcutKey? {
+        if let unshifted = sourceProvider.output(for: keyCode, modifiers: []),
            unshifted.count == 1, unshifted.first?.isNumber == true {
             return .character(unshifted)
         }
-        if let shifted = sourceProvider.output(for: entry.keyCode, modifiers: [.shift]),
+        if let shifted = sourceProvider.output(for: keyCode, modifiers: [.shift]),
            shifted.count == 1, shifted.first?.isNumber == true {
             return .character(shifted)
         }
@@ -145,11 +163,36 @@ enum ShortcutPresetKeyKind {
     case downArrow
 }
 
+enum ShortcutPresetEntryKey {
+    case physical(keyCode: UInt16, kind: ShortcutPresetKeyKind)
+    case logical(KeyboardShortcutKey)
+}
+
 struct ShortcutPresetEntry {
     let commandID: AppCommandID
-    let keyCode: UInt16
-    let keyKind: ShortcutPresetKeyKind
+    let key: ShortcutPresetEntryKey
     let modifiers: Set<KeyboardModifier>
+
+    init(
+        commandID: AppCommandID,
+        keyCode: UInt16,
+        keyKind: ShortcutPresetKeyKind,
+        modifiers: Set<KeyboardModifier>
+    ) {
+        self.commandID = commandID
+        key = .physical(keyCode: keyCode, kind: keyKind)
+        self.modifiers = modifiers
+    }
+
+    init(
+        commandID: AppCommandID,
+        key: KeyboardShortcutKey,
+        modifiers: Set<KeyboardModifier>
+    ) {
+        self.commandID = commandID
+        self.key = .logical(key)
+        self.modifiers = modifiers
+    }
 }
 
 extension ShortcutPreset {
@@ -159,6 +202,8 @@ extension ShortcutPreset {
             Self.leftHandEntries
         case .rightHand:
             Self.rightHandEntries
+        case .ghosttyCompatible:
+            Self.ghosttyCompatibleEntries
         }
     }
 
@@ -270,5 +315,63 @@ extension ShortcutPreset {
         .init(commandID: .copyFocusedPanePath, keyCode: UInt16(kVK_ANSI_L), keyKind: .character, modifiers: [.command, .shift]),
         .init(commandID: .jumpToLatestNotification, keyCode: UInt16(kVK_ANSI_Semicolon), keyKind: .character, modifiers: [.command, .shift]),
         .init(commandID: .openSettings, keyCode: UInt16(kVK_ANSI_O), keyKind: .character, modifiers: [.command]),
+    ]
+
+    // MARK: - Ghostty-Compatible Preset
+    // Curated against Ghostty's macOS defaults at scripts/ghosttykit.lock.
+    // Logical keys match Ghostty's character-based bindings on non-US layouts.
+
+    private static let ghosttyCompatibleEntries: [ShortcutPresetEntry] = [
+        // Windows and worklanes (Ghostty windows and tabs)
+        .init(commandID: .newWindow, key: .character("n"), modifiers: [.command]),
+        .init(commandID: .closeWindow, key: .character("w"), modifiers: [.command, .shift]),
+        .init(commandID: .newWorklane, key: .character("t"), modifiers: [.command]),
+        .init(commandID: .nextWorklane, key: .tab, modifiers: [.control]),
+        .init(commandID: .previousWorklane, key: .tab, modifiers: [.control, .shift]),
+
+        // Panes (Ghostty surfaces and splits)
+        .init(commandID: .closeFocusedPane, key: .character("w"), modifiers: [.command]),
+        .init(commandID: .restoreClosedPane, key: .character("t"), modifiers: [.command, .shift]),
+        .init(commandID: .splitHorizontally, key: .character("d"), modifiers: [.command]),
+        .init(commandID: .splitVertically, key: .character("d"), modifiers: [.command, .shift]),
+        .init(commandID: .focusPreviousPane, key: .character("["), modifiers: [.command]),
+        .init(commandID: .focusNextPane, key: .character("]"), modifiers: [.command]),
+        .init(commandID: .focusLeftPane, key: .leftArrow, modifiers: [.command, .option]),
+        .init(commandID: .focusRightPane, key: .rightArrow, modifiers: [.command, .option]),
+        .init(commandID: .focusUpInColumn, key: .upArrow, modifiers: [.command, .option]),
+        .init(commandID: .focusDownInColumn, key: .downArrow, modifiers: [.command, .option]),
+        .init(commandID: .resizePaneLeft, key: .leftArrow, modifiers: [.command, .control]),
+        .init(commandID: .resizePaneRight, key: .rightArrow, modifiers: [.command, .control]),
+        .init(commandID: .resizePaneUp, key: .upArrow, modifiers: [.command, .control]),
+        .init(commandID: .resizePaneDown, key: .downArrow, modifiers: [.command, .control]),
+
+        // Search and configuration
+        .init(commandID: .find, key: .character("f"), modifiers: [.command]),
+        .init(commandID: .useSelectionForFind, key: .character("e"), modifiers: [.command]),
+        .init(commandID: .findNext, key: .character("g"), modifiers: [.command]),
+        .init(commandID: .findPrevious, key: .character("g"), modifiers: [.command, .shift]),
+        .init(commandID: .showCommandPalette, key: .character("p"), modifiers: [.command, .shift]),
+        .init(commandID: .openSettings, key: .character(","), modifiers: [.command]),
+        .init(commandID: .reloadConfig, key: .character(","), modifiers: [.command, .shift]),
+
+        // Non-conflicting Zentty shortcuts
+        .init(commandID: .toggleSidebar, key: .character("s"), modifiers: [.command]),
+        .init(commandID: .copyFocusedPanePath, key: .character("c"), modifiers: [.command, .shift]),
+        .init(commandID: .cleanCopy, key: .character("c"), modifiers: [.command, .control]),
+        .init(commandID: .jumpToLatestNotification, key: .character("u"), modifiers: [.command, .shift]),
+        .init(commandID: .arrangeHeightFull, key: .character("1"), modifiers: [.command, .option]),
+        .init(commandID: .arrangeHeightTwoPerColumn, key: .character("2"), modifiers: [.command, .option]),
+        .init(commandID: .arrangeHeightThreePerColumn, key: .character("3"), modifiers: [.command, .option]),
+        .init(commandID: .arrangeHeightFourPerColumn, key: .character("4"), modifiers: [.command, .option]),
+        .init(commandID: .arrangeWidthGoldenFocusWide, key: .character("g"), modifiers: [.command, .control]),
+        .init(commandID: .arrangeWidthGoldenFocusNarrow, key: .character("g"), modifiers: [.command, .control, .option]),
+        .init(commandID: .arrangeHeightGoldenFocusTall, key: .character("g"), modifiers: [.command, .control, .shift]),
+        .init(commandID: .arrangeHeightGoldenFocusShort, key: .character("g"), modifiers: [.command, .control, .option, .shift]),
+        .init(commandID: .movePaneLeft, key: .leftArrow, modifiers: [.command, .control, .option]),
+        .init(commandID: .movePaneRight, key: .rightArrow, modifiers: [.command, .control, .option]),
+        .init(commandID: .movePaneUp, key: .upArrow, modifiers: [.command, .control, .option]),
+        .init(commandID: .movePaneDown, key: .downArrow, modifiers: [.command, .control, .option]),
+        .init(commandID: .resetPaneLayout, key: .character("0"), modifiers: [.command, .control, .option]),
+        .init(commandID: .openBookmarksPopover, key: .character("b"), modifiers: [.command, .shift]),
     ]
 }

--- a/Zentty/UI/Settings/SettingsWindowController.swift
+++ b/Zentty/UI/Settings/SettingsWindowController.swift
@@ -767,13 +767,23 @@ final class SettingsViewController: NSSplitViewController, SettingsSidebarViewCo
     }
 }
 
-/// Settings window. Intercepts the back/forward key equivalents (⌘[ / ⌘])
-/// before the responder chain, so the shortcuts work regardless of which
-/// control holds first responder.
+/// Settings window. Intercepts window-scoped key equivalents before the
+/// responder chain, so closing and back/forward navigation work regardless
+/// of which control holds first responder.
 private final class SettingsWindow: NSWindow {
     var keyEquivalentHandler: ((NSEvent) -> Bool)?
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting(.capsLock)
+        if event.type == .keyDown,
+           modifiers == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "w" {
+            performClose(nil)
+            return true
+        }
+
         if keyEquivalentHandler?(event) == true {
             return true
         }

--- a/ZenttyLogicTests/AppMenuBuilderTests.swift
+++ b/ZenttyLogicTests/AppMenuBuilderTests.swift
@@ -33,6 +33,24 @@ final class AppMenuBuilderTests: XCTestCase {
         XCTAssertFalse(AppMenuBuilder.hasRequiredMenuItems(in: menuWithoutMarkdown, appName: "Zentty", config: config))
     }
 
+    func test_main_menu_exposes_native_full_screen_for_main_windows() throws {
+        let mainMenu = AppMenuBuilder.makeMainMenu(appName: "Zentty")
+        let fullScreenItem = try XCTUnwrap(
+            menuItem(for: #selector(AppDelegate.toggleMainWindowFullScreen(_:)), in: mainMenu)
+        )
+
+        XCTAssertEqual(fullScreenItem.title, "Enter Full Screen")
+        XCTAssertNil(fullScreenItem.target)
+        XCTAssertEqual(fullScreenItem.keyEquivalent, "f")
+        XCTAssertEqual(fullScreenItem.keyEquivalentModifierMask, [.command, .control])
+        XCTAssertTrue(fullScreenItem.allowsKeyEquivalentWhenHidden)
+        XCTAssertTrue(AppMenuBuilder.hasRequiredMenuItems(in: mainMenu, appName: "Zentty"))
+
+        fullScreenItem.menu?.removeItem(fullScreenItem)
+
+        XCTAssertFalse(AppMenuBuilder.hasRequiredMenuItems(in: mainMenu, appName: "Zentty"))
+    }
+
     private func menuItem(for action: Selector, in mainMenu: NSMenu) -> NSMenuItem? {
         for rootItem in mainMenu.items {
             if let found = menuItem(for: action, in: rootItem.submenu) {

--- a/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
+++ b/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
@@ -690,6 +690,89 @@ final class KeyboardShortcutResolverTests: XCTestCase {
         XCTAssertEqual(manager.shortcut(for: .findPrevious), .init(key: .character("g"), modifiers: [.command, .shift]))
     }
 
+    func test_ghostty_compatible_preset_maps_host_actions_and_preserves_safe_zentty_shortcuts() throws {
+        let preset = try XCTUnwrap(ShortcutPreset(rawValue: "ghosttyCompatible"))
+        let presetBindings = ShortcutPresetResolver().resolve(preset)
+        let manager = ShortcutManager(shortcuts: .init(bindings: presetBindings))
+
+        let expected: [AppCommandID: KeyboardShortcut] = [
+            .newWindow: .init(key: .character("n"), modifiers: [.command]),
+            .closeWindow: .init(key: .character("w"), modifiers: [.command, .shift]),
+            .newWorklane: .init(key: .character("t"), modifiers: [.command]),
+            .nextWorklane: .init(key: .tab, modifiers: [.control]),
+            .previousWorklane: .init(key: .tab, modifiers: [.control, .shift]),
+            .closeFocusedPane: .init(key: .character("w"), modifiers: [.command]),
+            .restoreClosedPane: .init(key: .character("t"), modifiers: [.command, .shift]),
+            .splitHorizontally: .init(key: .character("d"), modifiers: [.command]),
+            .splitVertically: .init(key: .character("d"), modifiers: [.command, .shift]),
+            .focusPreviousPane: .init(key: .character("["), modifiers: [.command]),
+            .focusNextPane: .init(key: .character("]"), modifiers: [.command]),
+            .focusLeftPane: .init(key: .leftArrow, modifiers: [.command, .option]),
+            .focusRightPane: .init(key: .rightArrow, modifiers: [.command, .option]),
+            .focusUpInColumn: .init(key: .upArrow, modifiers: [.command, .option]),
+            .focusDownInColumn: .init(key: .downArrow, modifiers: [.command, .option]),
+            .resizePaneLeft: .init(key: .leftArrow, modifiers: [.command, .control]),
+            .resizePaneRight: .init(key: .rightArrow, modifiers: [.command, .control]),
+            .resizePaneUp: .init(key: .upArrow, modifiers: [.command, .control]),
+            .resizePaneDown: .init(key: .downArrow, modifiers: [.command, .control]),
+            .find: .init(key: .character("f"), modifiers: [.command]),
+            .useSelectionForFind: .init(key: .character("e"), modifiers: [.command]),
+            .findNext: .init(key: .character("g"), modifiers: [.command]),
+            .findPrevious: .init(key: .character("g"), modifiers: [.command, .shift]),
+            .showCommandPalette: .init(key: .character("p"), modifiers: [.command, .shift]),
+            .openSettings: .init(key: .character(","), modifiers: [.command]),
+            .reloadConfig: .init(key: .character(","), modifiers: [.command, .shift]),
+            .toggleSidebar: .init(key: .character("s"), modifiers: [.command]),
+            .copyFocusedPanePath: .init(key: .character("c"), modifiers: [.command, .shift]),
+            .cleanCopy: .init(key: .character("c"), modifiers: [.command, .control]),
+            .jumpToLatestNotification: .init(key: .character("u"), modifiers: [.command, .shift]),
+            .arrangeHeightFull: .init(key: .character("1"), modifiers: [.command, .option]),
+            .arrangeHeightTwoPerColumn: .init(key: .character("2"), modifiers: [.command, .option]),
+            .arrangeHeightThreePerColumn: .init(key: .character("3"), modifiers: [.command, .option]),
+            .arrangeHeightFourPerColumn: .init(key: .character("4"), modifiers: [.command, .option]),
+            .arrangeWidthGoldenFocusWide: .init(key: .character("g"), modifiers: [.command, .control]),
+            .arrangeWidthGoldenFocusNarrow: .init(key: .character("g"), modifiers: [.command, .control, .option]),
+            .arrangeHeightGoldenFocusTall: .init(key: .character("g"), modifiers: [.command, .control, .shift]),
+            .arrangeHeightGoldenFocusShort: .init(key: .character("g"), modifiers: [.command, .control, .option, .shift]),
+            .movePaneLeft: .init(key: .leftArrow, modifiers: [.command, .control, .option]),
+            .movePaneRight: .init(key: .rightArrow, modifiers: [.command, .control, .option]),
+            .movePaneUp: .init(key: .upArrow, modifiers: [.command, .control, .option]),
+            .movePaneDown: .init(key: .downArrow, modifiers: [.command, .control, .option]),
+            .resetPaneLayout: .init(key: .character("0"), modifiers: [.command, .control, .option]),
+            .openBookmarksPopover: .init(key: .character("b"), modifiers: [.command, .shift]),
+        ]
+
+        for (commandID, shortcut) in expected {
+            XCTAssertEqual(manager.shortcut(for: commandID), shortcut, "Unexpected shortcut for \(commandID)")
+        }
+
+        for definition in AppCommandRegistry.definitions where expected[definition.id] == nil {
+            XCTAssertNil(
+                manager.shortcut(for: definition.id),
+                "Expected unlisted command \(definition.id) to be unbound"
+            )
+        }
+    }
+
+    func test_ghostty_compatible_preset_uses_logical_characters_instead_of_physical_layout_output() throws {
+        let preset = try XCTUnwrap(ShortcutPreset(rawValue: "ghosttyCompatible"))
+        let presetBindings = ShortcutPresetResolver(
+            sourceProvider: StubKeyboardPreviewSourceProvider(
+                geometry: .iso,
+                outputs: [
+                    .init(keyCode: UInt16(kVK_ANSI_W), modifiers: [], value: "z"),
+                    .init(keyCode: UInt16(kVK_ANSI_LeftBracket), modifiers: [], value: "^"),
+                    .init(keyCode: UInt16(kVK_ANSI_RightBracket), modifiers: [], value: "$"),
+                ]
+            )
+        ).resolve(preset)
+        let manager = ShortcutManager(shortcuts: .init(bindings: presetBindings))
+
+        XCTAssertEqual(manager.shortcut(for: .closeFocusedPane), .init(key: .character("w"), modifiers: [.command]))
+        XCTAssertEqual(manager.shortcut(for: .focusPreviousPane), .init(key: .character("["), modifiers: [.command]))
+        XCTAssertEqual(manager.shortcut(for: .focusNextPane), .init(key: .character("]"), modifiers: [.command]))
+    }
+
     func test_preview_resolver_maps_option_modified_character_to_physical_key() {
         let resolver = KeyboardLayoutPreviewResolver(
             sourceProvider: StubKeyboardPreviewSourceProvider(

--- a/ZenttyTests/AppDelegateTests.swift
+++ b/ZenttyTests/AppDelegateTests.swift
@@ -209,6 +209,10 @@ final class AppDelegateTests: XCTestCase {
                 "Focus Right Pane",
                 "Focus Up In Column",
                 "Focus Down In Column",
+                "Move Pane Left",
+                "Move Pane Right",
+                "Move Pane Up",
+                "Move Pane Down",
             ]
         )
 
@@ -222,6 +226,10 @@ final class AppDelegateTests: XCTestCase {
             #selector(MainWindowController.focusRightPane(_:)),
             #selector(MainWindowController.focusUpInColumn(_:)),
             #selector(MainWindowController.focusDownInColumn(_:)),
+            #selector(MainWindowController.movePaneLeft(_:)),
+            #selector(MainWindowController.movePaneRight(_:)),
+            #selector(MainWindowController.movePaneUp(_:)),
+            #selector(MainWindowController.movePaneDown(_:)),
         ]
         for action in requiredActions {
             XCTAssertTrue(actions.contains(action), "Navigation menu should contain action \(action)")
@@ -261,7 +269,7 @@ final class AppDelegateTests: XCTestCase {
         delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
 
         let viewMenu = try XCTUnwrap(menu(named: "View"))
-        let actionItems = viewMenu.items.filter { !$0.isSeparatorItem }
+        let actionItems = viewMenu.items.filter { !$0.isSeparatorItem && !$0.isHidden }
 
         XCTAssertEqual(
             actionItems.map(\.title),
@@ -279,8 +287,19 @@ final class AppDelegateTests: XCTestCase {
                 "Resize Pane Up",
                 "Resize Pane Down",
                 "Reset Pane Layout",
+                "Enter Full Screen",
             ]
         )
+
+        let controlCommandFullScreenItem = try XCTUnwrap(
+            viewMenu.items.first(where: {
+                $0.action == #selector(AppDelegate.toggleMainWindowFullScreen(_:)) &&
+                $0.keyEquivalentModifierMask == [.command, .control]
+            })
+        )
+        XCTAssertNil(controlCommandFullScreenItem.target)
+        XCTAssertEqual(controlCommandFullScreenItem.keyEquivalent, "f")
+        XCTAssertTrue(controlCommandFullScreenItem.allowsKeyEquivalentWhenHidden)
 
         let arrangeWidthMenu = try XCTUnwrap(submenu(named: "Arrange Width", in: viewMenu))
         XCTAssertEqual(
@@ -310,6 +329,32 @@ final class AppDelegateTests: XCTestCase {
 
         let separatorCount = viewMenu.items.count(where: { $0.isSeparatorItem })
         XCTAssertGreaterThanOrEqual(separatorCount, 3, "View menu should have separator groups for visual structure")
+    }
+
+    func test_application_launch_routes_full_screen_menu_item_through_app_delegate() throws {
+        NSApp.mainMenu = nil
+
+        let delegate = AppDelegate(
+            runtimeRegistryFactory: { PaneRuntimeRegistry(adapterFactory: { _ in MockTerminalAdapter() }) }
+        )
+        delegate.applicationDidFinishLaunching(Notification(name: NSApplication.didFinishLaunchingNotification))
+
+        let settled = expectation(description: "window shown")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { settled.fulfill() }
+        wait(for: [settled], timeout: 2.0)
+
+        let viewMenu = try XCTUnwrap(menu(named: "View"))
+        let fullScreenItem = try XCTUnwrap(
+            viewMenu.items.first(where: {
+                $0.action == #selector(AppDelegate.toggleMainWindowFullScreen(_:)) &&
+                $0.keyEquivalentModifierMask == [.command, .control]
+            })
+        )
+        let action = try XCTUnwrap(fullScreenItem.action)
+        let target = NSApp.target(forAction: action, to: nil, from: fullScreenItem)
+
+        XCTAssertTrue(fullScreenItem.allowsKeyEquivalentWhenHidden)
+        XCTAssertTrue(target is AppDelegate)
     }
 
     func test_application_launch_applies_configured_shortcuts_to_menu_items() throws {

--- a/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
+++ b/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
@@ -643,6 +643,42 @@ final class SettingsWindowControllerTests: XCTestCase {
         XCTAssertEqual(shortcutsFrame.height, initialFrame.height, accuracy: 1.0)
     }
 
+    func test_command_w_closes_settings_window() throws {
+        let store = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
+        )
+        let controller = SettingsWindowController(configStore: store, initialSection: .general)
+        addTeardownBlock { controller.window?.close() }
+
+        controller.show(section: .general, sender: nil)
+        waitForLayout()
+
+        let window = try XCTUnwrap(controller.window)
+        window.makeKeyAndOrderFrontForHostedTesting(nil)
+        XCTAssertTrue(window.isVisible)
+
+        let shiftedEvent = try XCTUnwrap(
+            settingsKeyEvent("w", keyCode: UInt16(kVK_ANSI_W), modifiers: [.command, .shift])
+        )
+        XCTAssertFalse(window.performKeyEquivalent(with: shiftedEvent))
+        XCTAssertTrue(window.isVisible)
+
+        let commandW = try XCTUnwrap(
+            settingsKeyEvent("w", keyCode: UInt16(kVK_ANSI_W), modifiers: [.command])
+        )
+
+        XCTAssertTrue(window.performKeyEquivalent(with: commandW))
+        XCTAssertFalse(window.isVisible)
+
+        window.makeKeyAndOrderFrontForHostedTesting(nil)
+        let capsLockCommandW = try XCTUnwrap(
+            settingsKeyEvent("w", keyCode: UInt16(kVK_ANSI_W), modifiers: [.command, .capsLock])
+        )
+
+        XCTAssertTrue(window.performKeyEquivalent(with: capsLockCommandW))
+        XCTAssertFalse(window.isVisible)
+    }
+
     func test_settings_window_has_back_forward_navigation_control() throws {
         let store = AppConfigStore(
             fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
@@ -1280,10 +1316,11 @@ final class SettingsWindowControllerTests: XCTestCase {
         shortcutsController.beginRecordingSelectedCommandForTesting()
         shortcutsController.clickPreviewKeyForTesting(UInt16(kVK_Control))
         shortcutsController.clickPreviewKeyForTesting(UInt16(kVK_Option))
+        shortcutsController.clickPreviewKeyForTesting(UInt16(kVK_Shift))
         shortcutsController.clickPreviewKeyForTesting(UInt16(kVK_Command))
         shortcutsController.clickPreviewKeyForTesting(UInt16(kVK_UpArrow))
 
-        XCTAssertEqual(shortcutsController.displayString(for: .closeWindow), "⌃⌥⌘↑")
+        XCTAssertEqual(shortcutsController.displayString(for: .closeWindow), "⌃⌥⇧⌘↑")
         XCTAssertEqual(shortcutsController.previewPrimaryHighlightedKeyCodeForTesting, UInt16(kVK_UpArrow))
 
         shortcutsController.selectCommandForTesting(.reloadConfig)
@@ -2185,6 +2222,18 @@ private extension SettingsWindowControllerTests {
         _ character: String,
         modifiers: NSEvent.ModifierFlags
     ) -> NSEvent? {
+        settingsKeyEvent(
+            character,
+            keyCode: character == "[" ? UInt16(kVK_ANSI_LeftBracket) : UInt16(kVK_ANSI_RightBracket),
+            modifiers: modifiers
+        )
+    }
+
+    func settingsKeyEvent(
+        _ character: String,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags
+    ) -> NSEvent? {
         NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
@@ -2195,7 +2244,7 @@ private extension SettingsWindowControllerTests {
             characters: character,
             charactersIgnoringModifiers: character,
             isARepeat: false,
-            keyCode: character == "[" ? 33 : 30
+            keyCode: keyCode
         )
     }
 }


### PR DESCRIPTION
## Summary

- add a Ghostty-compatible shortcut preset based on Ghostty's pinned macOS defaults
- make Command-W close Settings and add native Control-Command-F fullscreen handling
- keep the hidden fullscreen accelerator active and refresh stale hosted-test expectations

## Test plan

- `ZENTTY_TEST_DISPLAY_PROVIDER=betterdisplay scripts/test-on-virtual-display -only-testing:ZenttyLogicTests/AppMenuBuilderTests -only-testing:ZenttyLogicTests/KeyboardShortcutResolverTests`
- `ZENTTY_TEST_DISPLAY_PROVIDER=betterdisplay scripts/test-hosted-on-virtual-display -only-testing:ZenttyTests/AppDelegateTests -only-testing:ZenttyTests/SettingsWindowControllerTests`