### PR TITLE
docs: add security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are made against the latest release and the `main` branch. Before reporting a problem, please confirm it is still present in the latest release when practical.
+
+## Reporting a vulnerability
+
+Do not report suspected vulnerabilities in a public GitHub issue.
+
+Use [GitHub private vulnerability reporting](https://github.com/dedene/zentty/security/advisories/new) to send the maintainers:
+
+- The affected Zentty version or commit.
+- The macOS version used for testing.
+- Reproduction steps or a minimal proof of concept.
+- The expected security impact.
+- Any suggested remediation, if available.
+
+If the private reporting form is unavailable, contact the repository owner through their GitHub profile and ask for a confidential reporting channel without including vulnerability details in the initial message.


### PR DESCRIPTION
## Summary

- Add a `SECURITY.md` for supported versions and vulnerability reports.
- Direct reporters to GitHub's private vulnerability reporting form.
- List the information that helps maintainers assess a report.

## Verification

- `vale SECURITY.md`: 0 errors, 0 warnings, 0 suggestions.
- `git diff --check`: passed.

## Maintainer action

Please enable private vulnerability reporting under **Settings > Code security and analysis** before merging so the reporting link is available.

Part of #77.
