### PR TITLE
Add user-configurable shortcuts for numbered worklanes

### DIFF
--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -1865,12 +1865,10 @@ final class WorklaneStore {
     }
 
     func selectWorklane(atPosition position: Int) {
-        guard position > 0, worklanes.isEmpty == false else {
+        guard worklanes.indices.contains(position - 1) else {
             return
         }
-
-        let index = min(position - 1, worklanes.count - 1)
-        selectWorklane(id: worklanes[index].id)
+        selectWorklane(id: worklanes[position - 1].id)
     }
 
     func selectNextWorklane() {

--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -1864,6 +1864,15 @@ final class WorklaneStore {
         notify(.activeWorklaneChanged)
     }
 
+    func selectWorklane(atPosition position: Int) {
+        guard position > 0, worklanes.isEmpty == false else {
+            return
+        }
+
+        let index = min(position - 1, worklanes.count - 1)
+        selectWorklane(id: worklanes[index].id)
+    }
+
     func selectNextWorklane() {
         guard worklanes.count > 1,
               let currentIndex = worklanes.firstIndex(where: { $0.id == activeWorklaneID }) else {

--- a/Zentty/Input/KeyboardShortcutResolver.swift
+++ b/Zentty/Input/KeyboardShortcutResolver.swift
@@ -27,6 +27,15 @@ enum AppCommandID: String, CaseIterable, Equatable, Hashable, Sendable {
     case renameCurrentPane = "pane.rename"
     case nextWorklane = "worklane.next"
     case previousWorklane = "worklane.previous"
+    case selectWorklane1 = "worklane.select_1"
+    case selectWorklane2 = "worklane.select_2"
+    case selectWorklane3 = "worklane.select_3"
+    case selectWorklane4 = "worklane.select_4"
+    case selectWorklane5 = "worklane.select_5"
+    case selectWorklane6 = "worklane.select_6"
+    case selectWorklane7 = "worklane.select_7"
+    case selectWorklane8 = "worklane.select_8"
+    case selectWorklane9 = "worklane.select_9"
     case worklaneMoveUp = "worklane.move_up"
     case worklaneMoveDown = "worklane.move_down"
     case find = "pane.search.find"
@@ -105,6 +114,7 @@ enum AppAction: Equatable, Sendable {
     case renameCurrentPane
     case nextWorklane
     case previousWorklane
+    case selectWorklane(position: Int)
     case moveWorklaneUp
     case moveWorklaneDown
     case find
@@ -277,6 +287,78 @@ enum AppCommandRegistry {
                 title: "Previous Worklane",
                 selector: #selector(MainWindowController.previousWorklane(_:))
             )
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane1,
+            title: "Switch to Worklane 1",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 1),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane2,
+            title: "Switch to Worklane 2",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 2),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane3,
+            title: "Switch to Worklane 3",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 3),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane4,
+            title: "Switch to Worklane 4",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 4),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane5,
+            title: "Switch to Worklane 5",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 5),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane6,
+            title: "Switch to Worklane 6",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 6),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane7,
+            title: "Switch to Worklane 7",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 7),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane8,
+            title: "Switch to Worklane 8",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 8),
+            menuItem: nil
+        ),
+        AppCommandDefinition(
+            id: .selectWorklane9,
+            title: "Switch to Worklane 9",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: 9),
+            menuItem: nil
         ),
         AppCommandDefinition(
             id: .worklaneMoveUp,
@@ -1083,6 +1165,10 @@ extension AppCommandDefinition {
             "Switch to the next worklane."
         case .previousWorklane:
             "Switch to the previous worklane."
+        case .selectWorklane1, .selectWorklane2, .selectWorklane3, .selectWorklane4,
+             .selectWorklane5, .selectWorklane6, .selectWorklane7, .selectWorklane8,
+             .selectWorklane9:
+            "Switch to this numbered worklane, or the last worklane if that position does not exist."
         case .worklaneMoveUp:
             "Move the active worklane up in the sidebar."
         case .worklaneMoveDown:

--- a/Zentty/Input/KeyboardShortcutResolver.swift
+++ b/Zentty/Input/KeyboardShortcutResolver.swift
@@ -100,6 +100,25 @@ enum AppCommandID: String, CaseIterable, Equatable, Hashable, Sendable {
     case copyMarkdown = "clipboard.copy_markdown"
     case reloadConfig = "app.reload_config"
     case openBookmarksPopover = "bookmarks.openPopover"
+
+    static let selectWorklaneIDs: [AppCommandID] = [
+        .selectWorklane1, .selectWorklane2, .selectWorklane3, .selectWorklane4, .selectWorklane5,
+        .selectWorklane6, .selectWorklane7, .selectWorklane8, .selectWorklane9,
+    ]
+
+    static func selectWorklaneID(position: Int) -> AppCommandID? {
+        guard selectWorklaneIDs.indices.contains(position - 1) else {
+            return nil
+        }
+        return selectWorklaneIDs[position - 1]
+    }
+
+    var selectWorklanePosition: Int? {
+        guard let index = Self.selectWorklaneIDs.firstIndex(of: self) else {
+            return nil
+        }
+        return index + 1
+    }
 }
 
 struct ShortcutBindingOverride: Equatable, Sendable {
@@ -188,6 +207,17 @@ struct AppCommandDefinition {
 }
 
 enum AppCommandRegistry {
+    private static let selectWorklaneDefinitions: [AppCommandDefinition] = AppCommandID.selectWorklaneIDs.enumerated().map { index, id in
+        AppCommandDefinition(
+            id: id,
+            title: "Switch to Worklane \(index + 1)",
+            category: .worklanes,
+            defaultShortcut: nil,
+            action: .selectWorklane(position: index + 1),
+            menuItem: nil
+        )
+    }
+
     static let definitions: [AppCommandDefinition] = [
         AppCommandDefinition(
             id: .toggleSidebar,
@@ -288,78 +318,7 @@ enum AppCommandRegistry {
                 selector: #selector(MainWindowController.previousWorklane(_:))
             )
         ),
-        AppCommandDefinition(
-            id: .selectWorklane1,
-            title: "Switch to Worklane 1",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 1),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane2,
-            title: "Switch to Worklane 2",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 2),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane3,
-            title: "Switch to Worklane 3",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 3),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane4,
-            title: "Switch to Worklane 4",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 4),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane5,
-            title: "Switch to Worklane 5",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 5),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane6,
-            title: "Switch to Worklane 6",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 6),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane7,
-            title: "Switch to Worklane 7",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 7),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane8,
-            title: "Switch to Worklane 8",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 8),
-            menuItem: nil
-        ),
-        AppCommandDefinition(
-            id: .selectWorklane9,
-            title: "Switch to Worklane 9",
-            category: .worklanes,
-            defaultShortcut: nil,
-            action: .selectWorklane(position: 9),
-            menuItem: nil
-        ),
+    ] + selectWorklaneDefinitions + [
         AppCommandDefinition(
             id: .worklaneMoveUp,
             title: "Move Worklane Up",
@@ -1168,7 +1127,7 @@ extension AppCommandDefinition {
         case .selectWorklane1, .selectWorklane2, .selectWorklane3, .selectWorklane4,
              .selectWorklane5, .selectWorklane6, .selectWorklane7, .selectWorklane8,
              .selectWorklane9:
-            "Switch to this numbered worklane, or the last worklane if that position does not exist."
+            "Switch to the worklane at this position in the sidebar."
         case .worklaneMoveUp:
             "Move the active worklane up in the sidebar."
         case .worklaneMoveDown:

--- a/Zentty/Input/ShortcutPreset.swift
+++ b/Zentty/Input/ShortcutPreset.swift
@@ -329,6 +329,18 @@ extension ShortcutPreset {
         .init(commandID: .nextWorklane, key: .tab, modifiers: [.control]),
         .init(commandID: .previousWorklane, key: .tab, modifiers: [.control, .shift]),
 
+        // Ghostty binds ⌘1–⌘8 to goto_tab and ⌘9 to last_tab; worklanes are Zentty's tabs.
+        // ⌘9 maps to worklane 9 (not "last") so every digit means the same thing.
+        .init(commandID: .selectWorklane1, key: .character("1"), modifiers: [.command]),
+        .init(commandID: .selectWorklane2, key: .character("2"), modifiers: [.command]),
+        .init(commandID: .selectWorklane3, key: .character("3"), modifiers: [.command]),
+        .init(commandID: .selectWorklane4, key: .character("4"), modifiers: [.command]),
+        .init(commandID: .selectWorklane5, key: .character("5"), modifiers: [.command]),
+        .init(commandID: .selectWorklane6, key: .character("6"), modifiers: [.command]),
+        .init(commandID: .selectWorklane7, key: .character("7"), modifiers: [.command]),
+        .init(commandID: .selectWorklane8, key: .character("8"), modifiers: [.command]),
+        .init(commandID: .selectWorklane9, key: .character("9"), modifiers: [.command]),
+
         // Panes (Ghostty surfaces and splits)
         .init(commandID: .closeFocusedPane, key: .character("w"), modifiers: [.command]),
         .init(commandID: .restoreClosedPane, key: .character("t"), modifiers: [.command, .shift]),

--- a/Zentty/UI/AppActionRouter.swift
+++ b/Zentty/UI/AppActionRouter.swift
@@ -11,6 +11,7 @@ protocol AppActionRouterEnvironment: AnyObject {
     func routeRenameCurrentPane()
     func routeNextWorklane()
     func routePreviousWorklane()
+    func routeSelectWorklane(position: Int)
     func routeMoveWorklaneUp()
     func routeMoveWorklaneDown()
     func routeFind()
@@ -62,6 +63,8 @@ struct AppActionRouter {
             environment.routeNextWorklane()
         case .previousWorklane:
             environment.routePreviousWorklane()
+        case .selectWorklane(let position):
+            environment.routeSelectWorklane(position: position)
         case .moveWorklaneUp:
             environment.routeMoveWorklaneUp()
         case .moveWorklaneDown:

--- a/Zentty/UI/CommandPalette/CommandAvailabilityResolver.swift
+++ b/Zentty/UI/CommandPalette/CommandAvailabilityResolver.swift
@@ -171,6 +171,13 @@ enum CommandAvailabilityResolver {
             // regardless of worklane count. The controller's instant-switch
             // path is a no-op when there's nothing to switch to.
             return true
+        case .selectWorklane1, .selectWorklane2, .selectWorklane3, .selectWorklane4,
+             .selectWorklane5, .selectWorklane6, .selectWorklane7, .selectWorklane8,
+             .selectWorklane9:
+            guard let position = commandID.selectWorklanePosition else {
+                return false
+            }
+            return context.worklaneCount >= position
         default:
             return true
         }

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -2108,8 +2108,8 @@ final class RootViewController: NSViewController {
 
     private func cancelPendingPaneStripScrollSwitchGestureIfNeeded(for action: AppAction) {
         switch action {
-        case .newWorklane, .nextWorklane, .previousWorklane, .navigateBack, .navigateForward,
-            .pane(_):
+        case .newWorklane, .nextWorklane, .previousWorklane, .selectWorklane,
+            .navigateBack, .navigateForward, .pane(_):
             appCanvasView.cancelPendingPaneStripScrollSwitchGesture()
         default:
             break
@@ -3023,6 +3023,10 @@ extension RootViewController: AppActionRouterEnvironment {
 
     func routePreviousWorklane() {
         peekController.handleTab(forward: false)
+    }
+
+    func routeSelectWorklane(position: Int) {
+        worklaneStore.selectWorklane(atPosition: position)
     }
 
     func routeMoveWorklaneUp() {

--- a/Zentty/UI/Settings/ShortcutsSettingsSectionViewController.swift
+++ b/Zentty/UI/Settings/ShortcutsSettingsSectionViewController.swift
@@ -23,6 +23,7 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
         static let shortcutControlHeight: CGFloat = 52
         static let shortcutControlInset: CGFloat = 12
         static let conflictSpacing: CGFloat = 6
+        static let conflictActionSpacing: CGFloat = 12
         static let previewHeight: CGFloat = 182
         static let keyboardPreviewLeadingBleed: CGFloat = 2
         static let headerRowHeight: CGFloat = max(searchHeight, headerActionSize)
@@ -36,7 +37,7 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
 
     private enum ShortcutIssue: Equatable {
         case message(String)
-        case conflict(AppCommandID)
+        case conflict(AppCommandID, pending: KeyboardShortcut)
     }
 
     private enum BrowserItem: Equatable {
@@ -68,7 +69,9 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
     private let errorLabel = NSTextField(labelWithString: "")
     private let conflictContainerView = NSStackView()
     private let conflictLabel = NSTextField(labelWithString: "This shortcut conflicts with another shortcut:")
+    private let conflictActionsView = NSStackView()
     private let conflictTargetButton = NSButton(title: "", target: nil, action: nil)
+    private let conflictReassignButton = NSButton(title: "Assign Anyway", target: nil, action: nil)
     private let keyboardPreviewContainerView = NSView()
     private let keyboardPreviewView = KeyboardShortcutPreviewView()
     private let layoutIndicatorLabel = NSTextField(labelWithString: "")
@@ -301,11 +304,15 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
 
     var conflictTargetTitleForTesting: String? {
         guard let selectedCommandID,
-              case let .conflict(conflictingCommandID) = issueByCommandID[selectedCommandID] else {
+              case let .conflict(conflictingCommandID, _) = issueByCommandID[selectedCommandID] else {
             return nil
         }
 
         return AppCommandRegistry.definition(for: conflictingCommandID).title
+    }
+
+    var showsConflictReassignActionForTesting: Bool {
+        conflictContainerView.isHidden == false && conflictReassignButton.isHidden == false
     }
 
     var showsKeyboardPreviewForTesting: Bool {
@@ -379,6 +386,10 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
 
     func activateConflictTargetForTesting() {
         handleConflictTargetClicked(nil)
+    }
+
+    func activateConflictReassignForTesting() {
+        handleConflictReassignClicked(nil)
     }
 
     func apply(shortcuts: AppConfig.Shortcuts) {
@@ -613,7 +624,24 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
         conflictTargetButton.font = .systemFont(ofSize: 13, weight: .medium)
         conflictTargetButton.target = self
         conflictTargetButton.action = #selector(handleConflictTargetClicked(_:))
-        conflictContainerView.addArrangedSubview(conflictTargetButton)
+
+        conflictReassignButton.bezelStyle = .inline
+        conflictReassignButton.isBordered = false
+        conflictReassignButton.contentTintColor = .controlAccentColor
+        conflictReassignButton.font = .systemFont(ofSize: 13, weight: .medium)
+        conflictReassignButton.target = self
+        conflictReassignButton.action = #selector(handleConflictReassignClicked(_:))
+        conflictReassignButton.setAccessibilityLabel(
+            "Assign shortcut to this command and unassign it from the conflicting command"
+        )
+
+        conflictActionsView.orientation = .horizontal
+        conflictActionsView.alignment = .firstBaseline
+        conflictActionsView.spacing = Layout.conflictActionSpacing
+        conflictActionsView.translatesAutoresizingMaskIntoConstraints = false
+        conflictActionsView.addArrangedSubview(conflictTargetButton)
+        conflictActionsView.addArrangedSubview(conflictReassignButton)
+        conflictContainerView.addArrangedSubview(conflictActionsView)
 
         stackView.addArrangedSubview(conflictContainerView)
         conflictContainerView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
@@ -772,10 +800,11 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
             errorLabel.stringValue = message
             errorLabel.isHidden = false
             conflictContainerView.isHidden = true
-        case let .conflict(conflictingCommandID):
+        case let .conflict(conflictingCommandID, _):
             errorLabel.stringValue = ""
             errorLabel.isHidden = true
             conflictTargetButton.title = "\(AppCommandRegistry.definition(for: conflictingCommandID).title) ↗"
+            conflictReassignButton.isHidden = false
             conflictContainerView.isHidden = false
         case nil:
             errorLabel.stringValue = ""
@@ -1106,7 +1135,7 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
         }
 
         if let conflict = shortcutManager.conflict(for: shortcut, assigningTo: commandID) {
-            issueByCommandID[commandID] = .conflict(conflict.commandID)
+            issueByCommandID[commandID] = .conflict(conflict.commandID, pending: shortcut)
             recordingCommandID = nil
             clearRecordingPreview()
             refreshVisibleState()
@@ -1238,10 +1267,28 @@ final class ShortcutsSettingsSectionViewController: SettingsScrollableSectionVie
         guard let selectedCommandID else {
             return
         }
-        guard case let .conflict(conflictingCommandID) = issueByCommandID[selectedCommandID] else {
+        guard case let .conflict(conflictingCommandID, _) = issueByCommandID[selectedCommandID] else {
             return
         }
         jumpToCommand(conflictingCommandID)
+    }
+
+    @objc
+    private func handleConflictReassignClicked(_ sender: Any?) {
+        guard let selectedCommandID,
+              case let .conflict(conflictingCommandID, pending) = issueByCommandID[selectedCommandID] else {
+            return
+        }
+
+        issueByCommandID[selectedCommandID] = nil
+        recordingCommandID = nil
+        clearRecordingPreview()
+        try? configStore.update { config in
+            config.shortcuts = config.shortcuts
+                .updating(commandID: conflictingCommandID, shortcut: nil)
+                .updating(commandID: selectedCommandID, shortcut: pending)
+        }
+        apply(shortcuts: configStore.current.shortcuts)
     }
 
     @objc

--- a/ZenttyLogicTests/AppActionRouterTests.swift
+++ b/ZenttyLogicTests/AppActionRouterTests.swift
@@ -15,6 +15,7 @@ final class AppActionRouterTests: XCTestCase {
             (.renameCurrentPane, "routeRenameCurrentPane"),
             (.nextWorklane, "routeNextWorklane"),
             (.previousWorklane, "routePreviousWorklane"),
+            (.selectWorklane(position: 7), "routeSelectWorklane"),
             (.moveWorklaneUp, "routeMoveWorklaneUp"),
             (.moveWorklaneDown, "routeMoveWorklaneDown"),
             (.find, "routeFind"),
@@ -52,6 +53,9 @@ final class AppActionRouterTests: XCTestCase {
             router.route(action)
 
             XCTAssertEqual(env.calls, [expected], "unexpected routing for \(action)")
+            if action == .selectWorklane(position: 7) {
+                XCTAssertEqual(env.lastSelectedWorklanePosition, 7)
+            }
         }
     }
 
@@ -81,6 +85,7 @@ private final class MockEnvironment: AppActionRouterEnvironment {
     private(set) var calls: [String] = []
     private(set) var lastPaneCommand: PaneCommand?
     private(set) var lastThemeMode: AppearanceThemeModeCommand?
+    private(set) var lastSelectedWorklanePosition: Int?
 
     func routeToggleSidebar() { calls.append("routeToggleSidebar") }
     func routeNewWorklane() { calls.append("routeNewWorklane") }
@@ -88,6 +93,10 @@ private final class MockEnvironment: AppActionRouterEnvironment {
     func routeRenameCurrentPane() { calls.append("routeRenameCurrentPane") }
     func routeNextWorklane() { calls.append("routeNextWorklane") }
     func routePreviousWorklane() { calls.append("routePreviousWorklane") }
+    func routeSelectWorklane(position: Int) {
+        calls.append("routeSelectWorklane")
+        lastSelectedWorklanePosition = position
+    }
     func routeMoveWorklaneUp() { calls.append("routeMoveWorklaneUp") }
     func routeMoveWorklaneDown() { calls.append("routeMoveWorklaneDown") }
     func routeFind() { calls.append("routeFind") }

--- a/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
+++ b/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
@@ -111,19 +111,7 @@ final class KeyboardShortcutResolverTests: XCTestCase {
     }
 
     func test_numbered_worklane_commands_are_registered_unbound_and_user_bindable() {
-        let commandIDs: [AppCommandID] = [
-            .selectWorklane1,
-            .selectWorklane2,
-            .selectWorklane3,
-            .selectWorklane4,
-            .selectWorklane5,
-            .selectWorklane6,
-            .selectWorklane7,
-            .selectWorklane8,
-            .selectWorklane9,
-        ]
-
-        for (index, commandID) in commandIDs.enumerated() {
+        for (index, commandID) in AppCommandID.selectWorklaneIDs.enumerated() {
             let position = index + 1
             let definition = AppCommandRegistry.definition(for: commandID)
 
@@ -133,21 +121,55 @@ final class KeyboardShortcutResolverTests: XCTestCase {
             XCTAssertEqual(definition.action, .selectWorklane(position: position))
             XCTAssertNil(definition.menuItem)
             XCTAssertFalse(definition.detailDescription.isEmpty)
+            XCTAssertEqual(commandID.selectWorklanePosition, position)
+            XCTAssertEqual(AppCommandID.selectWorklaneID(position: position), commandID)
         }
 
-        let shortcut = KeyboardShortcut(key: .character("4"), modifiers: [.command])
-        let manager = ShortcutManager(
+        XCTAssertNil(AppCommandID.selectWorklaneID(position: 0))
+        XCTAssertNil(AppCommandID.selectWorklaneID(position: 10))
+
+        // A free key binds directly.
+        let free = KeyboardShortcut(key: .character("5"), modifiers: [.command])
+        let freeManager = ShortcutManager(
             shortcuts: .init(bindings: [
-                ShortcutBindingOverride(commandID: .selectWorklane4, shortcut: shortcut),
+                ShortcutBindingOverride(commandID: .selectWorklane5, shortcut: free),
             ])
         )
-
-        XCTAssertEqual(manager.shortcut(for: .selectWorklane4), shortcut)
-        XCTAssertEqual(manager.commandID(for: shortcut), .selectWorklane4)
+        XCTAssertEqual(freeManager.shortcut(for: .selectWorklane5), free)
+        XCTAssertEqual(freeManager.commandID(for: free), .selectWorklane5)
         XCTAssertEqual(
-            KeyboardShortcutResolver.resolve(shortcut, shortcuts: .init(bindings: manager.bindings)),
-            .selectWorklane(position: 4)
+            KeyboardShortcutResolver.resolve(free, shortcuts: .init(bindings: freeManager.bindings)),
+            .selectWorklane(position: 5)
         )
+
+        // ⌘4 is the default for Arrange Width: Quarters; taking it over requires unbinding that command.
+        let taken = KeyboardShortcut(key: .character("4"), modifiers: [.command])
+        let takeoverManager = ShortcutManager(
+            shortcuts: .init(bindings: [
+                ShortcutBindingOverride(commandID: .arrangeWidthQuarters, shortcut: nil),
+                ShortcutBindingOverride(commandID: .selectWorklane4, shortcut: taken),
+            ])
+        )
+        XCTAssertNil(takeoverManager.shortcut(for: .arrangeWidthQuarters))
+        XCTAssertEqual(takeoverManager.shortcut(for: .selectWorklane4), taken)
+        XCTAssertEqual(takeoverManager.commandID(for: taken), .selectWorklane4)
+
+        // Without the unbind, the colliding override is dropped and the default wins.
+        let collidingManager = ShortcutManager(
+            shortcuts: .init(bindings: [
+                ShortcutBindingOverride(commandID: .selectWorklane4, shortcut: taken),
+            ])
+        )
+        XCTAssertNil(collidingManager.shortcut(for: .selectWorklane4))
+        XCTAssertEqual(collidingManager.commandID(for: taken), .arrangeWidthQuarters)
+    }
+
+    func test_every_command_id_has_exactly_one_registry_definition() {
+        let ids = AppCommandRegistry.definitions.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Duplicate definitions: \(ids)")
+        for commandID in AppCommandID.allCases {
+            XCTAssertTrue(ids.contains(commandID), "Missing definition for \(commandID)")
+        }
     }
 
     func test_numbered_worklane_shortcut_round_trips_through_toml() throws {
@@ -792,6 +814,15 @@ final class KeyboardShortcutResolverTests: XCTestCase {
             .movePaneDown: .init(key: .downArrow, modifiers: [.command, .control, .option]),
             .resetPaneLayout: .init(key: .character("0"), modifiers: [.command, .control, .option]),
             .openBookmarksPopover: .init(key: .character("b"), modifiers: [.command, .shift]),
+            .selectWorklane1: .init(key: .character("1"), modifiers: [.command]),
+            .selectWorklane2: .init(key: .character("2"), modifiers: [.command]),
+            .selectWorklane3: .init(key: .character("3"), modifiers: [.command]),
+            .selectWorklane4: .init(key: .character("4"), modifiers: [.command]),
+            .selectWorklane5: .init(key: .character("5"), modifiers: [.command]),
+            .selectWorklane6: .init(key: .character("6"), modifiers: [.command]),
+            .selectWorklane7: .init(key: .character("7"), modifiers: [.command]),
+            .selectWorklane8: .init(key: .character("8"), modifiers: [.command]),
+            .selectWorklane9: .init(key: .character("9"), modifiers: [.command]),
         ]
 
         for (commandID, shortcut) in expected {
@@ -804,6 +835,10 @@ final class KeyboardShortcutResolverTests: XCTestCase {
                 "Expected unlisted command \(definition.id) to be unbound"
             )
         }
+
+        // ⌘1–⌘4 are taken over by worklane selection, so the arrange-width commands
+        // that default to those digits must come out unbound.
+        XCTAssertNil(manager.shortcut(for: .arrangeWidthFull))
     }
 
     func test_ghostty_compatible_preset_uses_logical_characters_instead_of_physical_layout_output() throws {

--- a/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
+++ b/ZenttyLogicTests/KeyboardShortcutResolverTests.swift
@@ -110,6 +110,58 @@ final class KeyboardShortcutResolverTests: XCTestCase {
         )
     }
 
+    func test_numbered_worklane_commands_are_registered_unbound_and_user_bindable() {
+        let commandIDs: [AppCommandID] = [
+            .selectWorklane1,
+            .selectWorklane2,
+            .selectWorklane3,
+            .selectWorklane4,
+            .selectWorklane5,
+            .selectWorklane6,
+            .selectWorklane7,
+            .selectWorklane8,
+            .selectWorklane9,
+        ]
+
+        for (index, commandID) in commandIDs.enumerated() {
+            let position = index + 1
+            let definition = AppCommandRegistry.definition(for: commandID)
+
+            XCTAssertEqual(definition.title, "Switch to Worklane \(position)")
+            XCTAssertEqual(definition.category, .worklanes)
+            XCTAssertNil(definition.defaultShortcut)
+            XCTAssertEqual(definition.action, .selectWorklane(position: position))
+            XCTAssertNil(definition.menuItem)
+            XCTAssertFalse(definition.detailDescription.isEmpty)
+        }
+
+        let shortcut = KeyboardShortcut(key: .character("4"), modifiers: [.command])
+        let manager = ShortcutManager(
+            shortcuts: .init(bindings: [
+                ShortcutBindingOverride(commandID: .selectWorklane4, shortcut: shortcut),
+            ])
+        )
+
+        XCTAssertEqual(manager.shortcut(for: .selectWorklane4), shortcut)
+        XCTAssertEqual(manager.commandID(for: shortcut), .selectWorklane4)
+        XCTAssertEqual(
+            KeyboardShortcutResolver.resolve(shortcut, shortcuts: .init(bindings: manager.bindings)),
+            .selectWorklane(position: 4)
+        )
+    }
+
+    func test_numbered_worklane_shortcut_round_trips_through_toml() throws {
+        let binding = ShortcutBindingOverride(
+            commandID: .selectWorklane9,
+            shortcut: .init(key: .character("9"), modifiers: [.command])
+        )
+
+        let source = AppConfigTOML.encodeShortcuts([binding])
+        let decoded = try XCTUnwrap(AppConfigTOML.decodeShortcuts(source))
+
+        XCTAssertEqual(decoded, [binding])
+    }
+
     func test_registry_includes_find_commands_with_standard_shortcuts() {
         XCTAssertEqual(AppCommandRegistry.definition(for: .find).title, "Find")
         XCTAssertEqual(

--- a/ZenttyLogicTests/WorklaneStoreReorderingTests.swift
+++ b/ZenttyLogicTests/WorklaneStoreReorderingTests.swift
@@ -48,6 +48,28 @@ final class WorklaneStoreReorderingTests: XCTestCase {
         XCTAssertEqual(changes, [.worklaneListChanged])
     }
 
+    func test_selectWorklane_atPosition_usesCurrentOrderAndClampsToLast() {
+        let store = makeStore(activeID: "A")
+
+        store.selectWorklane(atPosition: 2)
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("B"))
+
+        XCTAssertTrue(store.reorderWorklanes(to: ids("C", "B", "A")))
+        store.selectWorklane(atPosition: 1)
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("C"))
+
+        store.selectWorklane(atPosition: 9)
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("A"))
+    }
+
+    func test_selectWorklane_atInvalidPosition_isANoOp() {
+        let store = makeStore(activeID: "B")
+
+        store.selectWorklane(atPosition: 0)
+
+        XCTAssertEqual(store.activeWorklaneID, WorklaneID("B"))
+    }
+
     private func makeStore(activeID: String) -> WorklaneStore {
         WorklaneStore(
             worklanes: [

--- a/ZenttyLogicTests/WorklaneStoreReorderingTests.swift
+++ b/ZenttyLogicTests/WorklaneStoreReorderingTests.swift
@@ -48,7 +48,7 @@ final class WorklaneStoreReorderingTests: XCTestCase {
         XCTAssertEqual(changes, [.worklaneListChanged])
     }
 
-    func test_selectWorklane_atPosition_usesCurrentOrderAndClampsToLast() {
+    func test_selectWorklane_atPosition_usesCurrentOrder() {
         let store = makeStore(activeID: "A")
 
         store.selectWorklane(atPosition: 2)
@@ -57,17 +57,21 @@ final class WorklaneStoreReorderingTests: XCTestCase {
         XCTAssertTrue(store.reorderWorklanes(to: ids("C", "B", "A")))
         store.selectWorklane(atPosition: 1)
         XCTAssertEqual(store.activeWorklaneID, WorklaneID("C"))
-
-        store.selectWorklane(atPosition: 9)
+        store.selectWorklane(atPosition: 3)
         XCTAssertEqual(store.activeWorklaneID, WorklaneID("A"))
     }
 
-    func test_selectWorklane_atInvalidPosition_isANoOp() {
+    func test_selectWorklane_atOutOfRangePosition_isANoOp() {
         let store = makeStore(activeID: "B")
+        var changes: [WorklaneChange] = []
+        store.subscribe { changes.append($0) }
 
         store.selectWorklane(atPosition: 0)
+        store.selectWorklane(atPosition: 4)
+        store.selectWorklane(atPosition: 9)
 
         XCTAssertEqual(store.activeWorklaneID, WorklaneID("B"))
+        XCTAssertTrue(changes.isEmpty)
     }
 
     private func makeStore(activeID: String) -> WorklaneStore {

--- a/ZenttyTests/CommandAvailabilityResolverTests.swift
+++ b/ZenttyTests/CommandAvailabilityResolverTests.swift
@@ -196,6 +196,18 @@ final class CommandAvailabilityResolverTests: XCTestCase {
         XCTAssertTrue(available.contains(.openBranchOnRemote))
     }
 
+    func testNumberedWorklaneCommandsRequireThatManyWorklanes() {
+        let available = CommandAvailabilityResolver.availableCommandIDs(
+            worklaneCount: 3,
+            activePaneCount: 1,
+            totalPaneCount: 3
+        )
+        XCTAssertTrue(available.contains(.selectWorklane1))
+        XCTAssertTrue(available.contains(.selectWorklane3))
+        XCTAssertFalse(available.contains(.selectWorklane4))
+        XCTAssertFalse(available.contains(.selectWorklane9))
+    }
+
     func testGlobalSearchRememberedStateEnablesSearchNavigation() {
         let available = CommandAvailabilityResolver.availableCommandIDs(
             worklaneCount: 1,

--- a/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
+++ b/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
@@ -395,6 +395,14 @@ final class SettingsWindowControllerTests: XCTestCase {
         XCTAssertNil(shortcutsController.selectedCommandDefaultShortcutForTesting)
         XCTAssertEqual(shortcutsController.displayString(for: .toggleSidebar), "⌘B")
         XCTAssertEqual(shortcutsController.displayString(for: .copyFocusedPanePath), "Unassigned")
+        for position in 1...9 {
+            XCTAssertTrue(
+                shortcutsController.visibleCommandTitles.contains("Switch to Worklane \(position)")
+            )
+        }
+        shortcutsController.selectCommandForTesting(.selectWorklane9)
+        XCTAssertEqual(shortcutsController.selectedCommandTitleForTesting, "Switch to Worklane 9")
+        XCTAssertEqual(shortcutsController.displayString(for: .selectWorklane9), "Unassigned")
     }
 
     func test_settings_window_can_present_appearance_section_when_requested() throws {

--- a/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
+++ b/ZenttyTests/PaneLayoutSettingsWindowControllerTests.swift
@@ -1209,6 +1209,50 @@ final class SettingsWindowControllerTests: XCTestCase {
         XCTAssertEqual(shortcutsController.selectedCommandTitleForTesting, "Toggle Sidebar")
     }
 
+    func test_shortcuts_conflict_can_be_reassigned_to_selected_command() throws {
+        let store = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")
+        )
+        let controller = SettingsWindowController(
+            configStore: store,
+            initialSection: .shortcuts
+        )
+        addTeardownBlock { controller.window?.close() }
+
+        controller.show(section: .shortcuts, sender: nil)
+        waitForLayout()
+
+        let contentController = try XCTUnwrap(
+            controller.window?.contentViewController as? SettingsViewController
+        )
+        let shortcutsController = try XCTUnwrap(
+            contentController.currentSectionViewController as? ShortcutsSettingsSectionViewController
+        )
+
+        let pending = KeyboardShortcut(key: .character("1"), modifiers: [.command])
+        shortcutsController.selectCommandForTesting(.selectWorklane1)
+        shortcutsController.attemptShortcutAssignmentForTesting(pending)
+
+        XCTAssertEqual(shortcutsController.conflictTargetTitleForTesting, "Arrange Width: Full Width")
+        XCTAssertTrue(shortcutsController.showsConflictReassignActionForTesting)
+
+        shortcutsController.activateConflictReassignForTesting()
+
+        XCTAssertNil(shortcutsController.conflictTargetTitleForTesting)
+        XCTAssertEqual(shortcutsController.displayString(for: .selectWorklane1), "\u{2318}1")
+        XCTAssertEqual(shortcutsController.displayString(for: .arrangeWidthFull), "Unassigned")
+
+        let bindings = store.current.shortcuts.bindings
+        XCTAssertTrue(
+            bindings.contains(ShortcutBindingOverride(commandID: .arrangeWidthFull, shortcut: nil)),
+            "Expected the conflicting command to be unbound: \(bindings)"
+        )
+        XCTAssertTrue(
+            bindings.contains(ShortcutBindingOverride(commandID: .selectWorklane1, shortcut: pending)),
+            "Expected the pending shortcut to be assigned: \(bindings)"
+        )
+    }
+
     func test_shortcuts_preview_updates_when_selected_command_changes() throws {
         let store = AppConfigStore(
             fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyTests.SettingsWindow")


### PR DESCRIPTION
## Summary

- Add “Switch to Worklane 1” through “Switch to Worklane 9” commands.
- Expose the commands under Settings → Shortcuts → Worklanes.
- Leave all numbered shortcuts unassigned by default so users can map them to ⌘1…⌘9 or other combinations.
- Select worklanes according to their current sidebar order.
- Clamp unavailable positions to the last worklane—for example, “Switch to Worklane 9” selects the last worklane when fewer than nine exist.
- Route numbered selection through the existing command and worklane-selection infrastructure.

This behavior matches the native macOS convention and Ghostty’s default terminal behavio

## Testing

- Add command registration and shortcut-resolution coverage.
- Test shortcut configuration TOML round-tripping.
- Test action routing and preservation of the requested position.
- Test positional selection, reordered worklanes, and clamping behavior.
- Verify all nine commands appear unassigned in Shortcut settings.