### PR TITLE
build: pin Swift package resolution and Sparkle tool revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ docs/superpowers/
 *.profraw
 *.xcuserstate
 xcuserdata/
-Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 FrameworksLocal
 tmp/
 .claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ Guidelines:
 - Do not add design docs, specs, or plans to git unless Peter explicitly asks.
 - It is fine to create them locally for discussion or planning, but keep them untracked and ignored by default.
 
+## Dependencies
+
+- `Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` is committed and is the source of truth for dependency versions. Commit it whenever a bump changes it; do not ignore it again.
+- Release builds pass `-disableAutomaticPackageResolution`, so a range change in `project.yml` without a matching resolved-file update fails the release instead of silently picking a new version.
+- The release lane builds `generate_appcast` from the Sparkle revision in `Package.resolved`, never from whatever checkout is newest in DerivedData.
+
 ## Project Generation
 
 - Treat `project.yml` as the source of truth for Xcode project structure and generated build scripts.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ If you need to regenerate the Xcode project from [`project.yml`](project.yml):
 bundle exec fastlane mac generate_project
 ```
 
+### Dependencies
+
+Swift package versions are pinned in `Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`, which is committed. The version ranges in `project.yml` say what is allowed; the resolved file says what actually ships. Release builds run with automatic package resolution disabled, so they fail rather than drift when the pins no longer satisfy the ranges.
+
+To bump a dependency, update the range in `project.yml` if needed, then resolve and commit the new pins:
+
+```bash
+xcodebuild -resolvePackageDependencies -project Zentty.xcodeproj -scheme Zentty
+git add Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+```
+
+The release lane builds Sparkle's `generate_appcast` from the pinned Sparkle revision. It reuses a checkout that already sits at that revision (the release build's `build/SourcePackages`, or Xcode's DerivedData) and otherwise clones it into `build/sparkle-tools`. `bundle exec fastlane mac build_generate_appcast` builds the tool on its own.
+
 More detail about the Ghostty bootstrap flow lives in [`docs/ghosttykit-setup.md`](docs/ghosttykit-setup.md).
 
 ## Test

--- a/Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Zentty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "182bc2bc94db6a5ce4016485ddc6fb32d0c4e1bcb352861d7b6dd59898b1dbd1",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "64c9c5cc401aefde0eda46a9192b36082533a79d",
+        "version" : "9.13.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,8 @@ PROJECT       = "Zentty.xcodeproj"
 PROJECT_SPEC  = "project.yml"
 APP_TARGET    = "Zentty"
 BUILD_DIR     = "build/release"
+SOURCE_PACKAGES_DIR = "build/SourcePackages"
+PACKAGE_RESOLVED = "#{PROJECT}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 APP_PATH      = "#{BUILD_DIR}/#{APP_NAME}.app"
 PROJECT_ROOT  = File.expand_path("..", __dir__)
 R2_CACHE_MAX  = "public, max-age=31536000, immutable"
@@ -216,6 +218,7 @@ end
 
 def ensure_release_tools_ready!
   hydrate_release_env_from_one_password!
+  sparkle_pin!
   capture_command!("gh", "auth", "status", "--hostname", "github.com", error_message: "gh is not authenticated")
   capture_command!("wrangler", "whoami", error_message: "wrangler is not authenticated")
   UI.user_error!("R2_PUBLIC_BASE_URL must be set") if r2_public_base_url.empty?
@@ -462,6 +465,8 @@ def archive_release!(version:)
     output_name: APP_NAME,
     export_method: "developer-id",
     export_options: "fastlane/ExportOptions.plist",
+    cloned_source_packages_path: project_root_path(SOURCE_PACKAGES_DIR),
+    disable_package_automatic_updates: true,
     xcargs: xcargs_for_release(version: version)
   )
 end
@@ -800,32 +805,72 @@ def stage_release_archive!(zip_path:)
   destination
 end
 
+def sparkle_pin!
+  @sparkle_pin ||= begin
+    resolved_path = project_root_path(PACKAGE_RESOLVED)
+    UI.user_error!("Missing #{PACKAGE_RESOLVED}; the pinned package resolution must be committed") unless File.file?(resolved_path)
+    pin = ReleaseAutomation.sparkle_pin(File.read(resolved_path))
+    UI.user_error!("#{PACKAGE_RESOLVED} does not pin Sparkle") unless pin
+    pin
+  end
+end
+
+def git_head_revision(path)
+  return nil unless File.directory?(path)
+
+  stdout, _, status = run_command("git", "-C", path, "rev-parse", "HEAD")
+  status.success? ? stdout.strip : nil
+end
+
 def sparkle_checkout_path!
+  pin = sparkle_pin!
+  pinned_label = "Sparkle #{pin[:version]} (#{pin[:revision]})"
+
   explicit_path = ENV["SPARKLE_PACKAGE_PATH"].to_s.strip
-  return explicit_path if !explicit_path.empty? && File.directory?(explicit_path)
+  unless explicit_path.empty?
+    head = git_head_revision(explicit_path)
+    UI.user_error!("SPARKLE_PACKAGE_PATH is at #{head || "an unknown revision"}, but #{PACKAGE_RESOLVED} pins #{pinned_label}") unless head == pin[:revision]
+    return explicit_path
+  end
 
-  candidates = Dir[File.join(Dir.home, "Library/Developer/Xcode/DerivedData", "*", "SourcePackages", "checkouts", "Sparkle")]
-  candidates += Dir["/tmp/zentty-agent-*/SourcePackages/checkouts/Sparkle"]
-  checkout = candidates
-    .select { |path| File.directory?(path) }
-    .max_by { |path| File.mtime(path) }
+  candidates = [project_root_path(SOURCE_PACKAGES_DIR, "checkouts", "Sparkle")]
+  candidates += Dir[File.join(Dir.home, "Library/Developer/Xcode/DerivedData", "*", "SourcePackages", "checkouts", "Sparkle")]
+  candidates = candidates.map { |path| { path: path, head: git_head_revision(path) } }
 
-  UI.user_error!("Could not locate Sparkle checkout. Set SPARKLE_PACKAGE_PATH if needed.") unless checkout
+  ReleaseAutomation.select_pinned_checkout(candidates, revision: pin[:revision]) || clone_pinned_sparkle_checkout!(pin)
+end
 
-  checkout
+def clone_pinned_sparkle_checkout!(pin)
+  destination = ReleaseAutomation.sparkle_clone_dir(project_root: PROJECT_ROOT, revision: pin[:revision])
+  return destination if git_head_revision(destination) == pin[:revision]
+
+  UI.user_error!("Package.resolved pins Sparkle without a location") if pin[:location].empty?
+  FileUtils.rm_rf(destination)
+  FileUtils.mkdir_p(File.dirname(destination))
+  UI.message("Cloning Sparkle #{pin[:version]} (#{pin[:revision]}) for generate_appcast...")
+  capture_command!(
+    "git", "clone", "--quiet", "--no-checkout", pin[:location], destination,
+    error_message: "Failed to clone Sparkle from #{pin[:location]}"
+  )
+  capture_command!(
+    "git", "-C", destination, "checkout", "--quiet", "--detach", pin[:revision],
+    error_message: "Failed to check out pinned Sparkle revision #{pin[:revision]}"
+  )
+  destination
 end
 
 def sparkle_generate_appcast_binary!
   explicit_bin = ENV["SPARKLE_GENERATE_APPCAST_BIN"].to_s.strip
   return explicit_bin if !explicit_bin.empty? && File.executable?(explicit_bin)
 
-  checkout = sparkle_checkout_path!
-  build_dir = project_root_path("build", "sparkle-tools")
+  pin = sparkle_pin!
+  build_dir = ReleaseAutomation.sparkle_tools_dir(project_root: PROJECT_ROOT, revision: pin[:revision])
   binary_path = File.join(build_dir, "generate_appcast")
   return binary_path if File.executable?(binary_path)
 
+  checkout = sparkle_checkout_path!
   FileUtils.mkdir_p(build_dir)
-  UI.message("Building Sparkle generate_appcast tool (one-time, may take a minute)...")
+  UI.message("Building Sparkle #{pin[:version]} generate_appcast tool (one-time per pinned revision, may take a minute)...")
   capture_command!(
     xcrun_path, "xcodebuild",
     "-project", File.join(checkout, "Sparkle.xcodeproj"),
@@ -1060,6 +1105,11 @@ platform :mac do
   desc "Notarize the DMG"
   lane :notarize_dmg do
     notarize_release_dmg!
+  end
+
+  desc "Build Sparkle's generate_appcast from the revision pinned in Package.resolved"
+  lane :build_generate_appcast do
+    UI.success("generate_appcast ready -> #{sparkle_generate_appcast_binary!}")
   end
 
   desc "Build GhosttyKit.xcframework from source"

--- a/fastlane/release_automation.rb
+++ b/fastlane/release_automation.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require "json"
+
 module ReleaseAutomation
   CHANNELS = %w[stable beta].freeze
   STABLE_VERSION_REGEX = /\A\d+\.\d+\.\d+\z/
   BETA_VERSION_REGEX = /\A\d+\.\d+\.\d+-beta\.\d+\z/
   APPCAST_FILENAME = "appcast.xml"
+  SPARKLE_PACKAGE_IDENTITY = "sparkle"
 
   module_function
 
@@ -124,6 +127,39 @@ module ReleaseAutomation
     %w[SENTRY_URL SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT].select do |name|
       env.fetch(name, "").to_s.strip.empty?
     end
+  end
+
+  # Reads the pinned Sparkle revision from an Xcode workspace Package.resolved.
+  # Returns { location:, revision:, version: } or nil when Sparkle is not pinned.
+  def sparkle_pin(resolved_json)
+    resolved = resolved_json.is_a?(String) ? JSON.parse(resolved_json) : resolved_json
+    pin = Array(resolved["pins"]).find { |entry| entry["identity"].to_s.casecmp?(SPARKLE_PACKAGE_IDENTITY) }
+    return nil unless pin
+
+    state = pin["state"] || {}
+    revision = state["revision"].to_s.strip
+    return nil if revision.empty?
+
+    {
+      location: pin["location"].to_s.strip,
+      revision: revision,
+      version: state["version"].to_s.strip
+    }
+  end
+
+  # candidates: [{ path:, head: }] where head is the checkout's git HEAD (nil if unknown).
+  # Returns the first path whose HEAD matches the pinned revision, or nil.
+  def select_pinned_checkout(candidates, revision:)
+    match = candidates.find { |candidate| candidate[:head].to_s.strip == revision }
+    match && match[:path]
+  end
+
+  def sparkle_tools_dir(project_root:, revision:)
+    File.join(project_root, "build", "sparkle-tools", revision)
+  end
+
+  def sparkle_clone_dir(project_root:, revision:)
+    File.join(project_root, "build", "sparkle-tools", "checkouts", "Sparkle-#{revision}")
   end
 
   def codex_release_notes_command(output_path:, prompt:)

--- a/fastlane/release_automation_test.rb
+++ b/fastlane/release_automation_test.rb
@@ -133,4 +133,55 @@ assert_match(/Stable releases/, error.message)
 error = assert_raises(ArgumentError) { ReleaseAutomation.validate_version!(channel: "beta", version: "1.2.3") }
 assert_match(/Beta releases/, error.message)
 
+resolved_fixture = <<~JSON
+  {
+    "originHash" : "abc",
+    "pins" : [
+      {
+        "identity" : "sentry-cocoa",
+        "kind" : "remoteSourceControl",
+        "location" : "https://github.com/getsentry/sentry-cocoa",
+        "state" : { "revision" : "1111111111111111111111111111111111111111", "version" : "9.13.0" }
+      },
+      {
+        "identity" : "sparkle",
+        "kind" : "remoteSourceControl",
+        "location" : "https://github.com/sparkle-project/Sparkle",
+        "state" : { "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b", "version" : "2.9.2" }
+      }
+    ],
+    "version" : 3
+  }
+JSON
+
+sparkle_pin = ReleaseAutomation.sparkle_pin(resolved_fixture)
+assert_equal "https://github.com/sparkle-project/Sparkle", sparkle_pin[:location]
+assert_equal "6276ba2b404829d139c45ff98427cf90e2efc59b", sparkle_pin[:revision]
+assert_equal "2.9.2", sparkle_pin[:version]
+assert_nil ReleaseAutomation.sparkle_pin('{"pins":[],"version":3}')
+assert_nil ReleaseAutomation.sparkle_pin('{"pins":[{"identity":"sparkle","state":{"version":"2.9.2"}}]}')
+assert_raises(JSON::ParserError) { ReleaseAutomation.sparkle_pin("not json") }
+
+checkouts = [
+  { path: "/dd/A/SourcePackages/checkouts/Sparkle", head: "0000000000000000000000000000000000000000" },
+  { path: "/dd/B/SourcePackages/checkouts/Sparkle", head: nil },
+  { path: "/dd/C/SourcePackages/checkouts/Sparkle", head: "6276ba2b404829d139c45ff98427cf90e2efc59b\n" },
+  { path: "/dd/D/SourcePackages/checkouts/Sparkle", head: "6276ba2b404829d139c45ff98427cf90e2efc59b" }
+]
+assert_equal(
+  "/dd/C/SourcePackages/checkouts/Sparkle",
+  ReleaseAutomation.select_pinned_checkout(checkouts, revision: "6276ba2b404829d139c45ff98427cf90e2efc59b")
+)
+assert_nil ReleaseAutomation.select_pinned_checkout(checkouts, revision: "ffffffffffffffffffffffffffffffffffffffff")
+assert_nil ReleaseAutomation.select_pinned_checkout([], revision: "6276ba2b404829d139c45ff98427cf90e2efc59b")
+
+assert_equal(
+  "/repo/build/sparkle-tools/6276ba2b404829d139c45ff98427cf90e2efc59b",
+  ReleaseAutomation.sparkle_tools_dir(project_root: "/repo", revision: "6276ba2b404829d139c45ff98427cf90e2efc59b")
+)
+assert_equal(
+  "/repo/build/sparkle-tools/checkouts/Sparkle-6276ba2b404829d139c45ff98427cf90e2efc59b",
+  ReleaseAutomation.sparkle_clone_dir(project_root: "/repo", revision: "6276ba2b404829d139c45ff98427cf90e2efc59b")
+)
+
 puts "release automation helper tests passed"


### PR DESCRIPTION
Closes #78.

## Why

`project.yml` declares version ranges but the workspace `Package.resolved` was gitignored, so a fresh checkout could resolve different versions without any source change. The release lane also picked the newest Sparkle checkout in DerivedData by mtime and built `generate_appcast` from it.

That drift is real, not theoretical. The shipped 0.2.0 app bundles Sparkle 2.9.2. The Sparkle checkout in DerivedData on the release machine is already at 2.9.6. A release today would have signed the appcast with a tool built from a different Sparkle than the app ships.

## What changed

- `Package.resolved` is committed (Sentry 9.13.0, Sparkle 2.9.2, ArgumentParser 1.7.1). These match what 0.2.0 shipped. Regenerating the project with xcodegen leaves the file untouched.
- The archive step passes `disable_package_automatic_updates` and clones packages into `build/SourcePackages`. If the pins stop satisfying the ranges, the build fails instead of quietly picking a new version.
- `sparkle_checkout_path!` reads the Sparkle pin, checks candidate checkouts by `git rev-parse HEAD`, and clones Sparkle at the pinned revision into `build/sparkle-tools` when nothing matches. A `SPARKLE_PACKAGE_PATH` at the wrong revision is rejected. The `/tmp/zentty-agent-*` glob is gone. The built binary is cached per revision.
- `ensure_release_tools_ready!` checks the pin up front so a missing resolved file fails before signing starts.
- New lane `bundle exec fastlane mac build_generate_appcast` builds the tool on its own.
- README and AGENTS.md document the pin and the bump recipe.

Dependabot alerts were already enabled on the repo, so nothing to do there.

## Verification

- Pure logic lives in `ReleaseAutomation` with tests. `ruby fastlane/release_automation_test.rb` passes.
- Ran the new lane end to end: it rejected the 2.9.6 DerivedData checkout, cloned 2.9.2, built the tool in about 35s, and reused the cached binary in under 2s on rerun.
- `xcodebuild -resolvePackageDependencies -disableAutomaticPackageResolution` with the committed file lands Sparkle at the exact pinned commit. Editing the pin to a bogus revision makes it fail rather than re-resolve.

## Note

The main checkout's local `.git/info/exclude` still lists `Package.resolved`. Harmless once the file is tracked, but worth deleting to avoid confusion.
