### PR TITLE
feat: keep sidebar visibility and width per window

### DIFF
--- a/Zentty/Config/AppConfigStore.swift
+++ b/Zentty/Config/AppConfigStore.swift
@@ -3,8 +3,17 @@ import OSLog
 
 private let appConfigLogger = Logger(subsystem: "be.zenjoy.zentty", category: "Config")
 
+/// Where a config change originated. In-process updates come from this app
+/// (any window or settings pane calling `update`); external reloads come from
+/// the config file changing on disk.
+enum AppConfigChangeOrigin: Equatable, Sendable {
+    case inProcess
+    case externalReload
+}
+
 final class AppConfigStore: @unchecked Sendable {
     typealias ChangeHandler = @Sendable (AppConfig) -> Void
+    typealias OriginChangeHandler = @Sendable (AppConfig, AppConfigChangeOrigin) -> Void
 
     private enum LoadResult {
         case missing
@@ -81,7 +90,7 @@ final class AppConfigStore: @unchecked Sendable {
     /// don't overwrite a config we couldn't read (e.g. a forward-version file).
     let didLoadFromValidFile: Bool
     private let fileWatcher = FileWatcher()
-    private var changeHandlers: [UUID: ChangeHandler] = [:]
+    private var changeHandlers: [UUID: OriginChangeHandler] = [:]
 
     init(
         fileURL: URL? = nil,
@@ -149,11 +158,20 @@ final class AppConfigStore: @unchecked Sendable {
         updated = updated.normalized()
         try Self.persist(config: updated, to: fileURL, fileManager: .default)
         current = updated
-        notifyChange()
+        notifyChange(origin: .inProcess)
     }
 
     @discardableResult
     func addObserver(_ handler: @escaping ChangeHandler) -> UUID {
+        addObserver(withOrigin: { config, _ in handler(config) })
+    }
+
+    /// Like `addObserver(_:)` but also reports where the change came from, so
+    /// observers can treat an in-app edit (another window persisting its own
+    /// sidebar state, a settings pane) differently from an external edit of the
+    /// config file on disk.
+    @discardableResult
+    func addObserver(withOrigin handler: @escaping OriginChangeHandler) -> UUID {
         let observerID = UUID()
         changeHandlers[observerID] = handler
         return observerID
@@ -175,7 +193,7 @@ final class AppConfigStore: @unchecked Sendable {
             }
 
             current = reloaded
-            notifyChange()
+            notifyChange(origin: .externalReload)
         case .invalid:
             appConfigLogger.error("Ignoring invalid config reload at \(self.fileURL.path, privacy: .public)")
         case .missing:
@@ -183,9 +201,9 @@ final class AppConfigStore: @unchecked Sendable {
         }
     }
 
-    private func notifyChange() {
+    private func notifyChange(origin: AppConfigChangeOrigin) {
         for handler in changeHandlers.values {
-            handler(current)
+            handler(current, origin)
         }
     }
 

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -174,6 +174,9 @@ final class RootViewController: NSViewController {
     private var paneLayoutPreferences: PaneLayoutPreferences
     private var shortcutManager: ShortcutManager
     private var lastAppliedAppearanceSettings: AppConfig.Appearance
+    /// The sidebar section of the config as this window last observed it. Used to
+    /// tell a real on-disk sidebar edit apart from an unrelated external change.
+    private var lastObservedConfigSidebar: AppConfig.Sidebar
     private var currentPaneLayoutContext: PaneLayoutContext
     private var sidebarWidthConstraint: NSLayoutConstraint?
     private var sidebarLeadingConstraint: NSLayoutConstraint?
@@ -289,6 +292,7 @@ final class RootViewController: NSViewController {
         self.paneLayoutPreferences = configStore.current.paneLayout
         self.shortcutManager = ShortcutManager(shortcuts: configStore.current.shortcuts)
         self.lastAppliedAppearanceSettings = configStore.current.appearance
+        self.lastObservedConfigSidebar = configStore.current.sidebar
         self.currentPaneLayoutContext = initialLayoutContext
         self.isUpdateAvailable = appUpdateStateStore.current.isUpdateAvailable
         self.sidebarMotionCoordinator = SidebarMotionCoordinator(
@@ -378,11 +382,11 @@ final class RootViewController: NSViewController {
         appUpdateObserverID = appUpdateStateStore.addObserver { [weak self] state in
             self?.handleAppUpdateAvailabilityChange(state.isUpdateAvailable)
         }
-        configObserverID = configStore.addObserver { [weak self] config in
+        configObserverID = configStore.addObserver(withOrigin: { [weak self] config, origin in
             DispatchQueue.main.async {
-                self?.applyPersistedConfig(config)
+                self?.applyPersistedConfig(config, origin: origin)
             }
-        }
+        })
         worklaneStore.scrollbackProvider = { [weak self] paneID in
             guard let self else { return nil }
             guard let runtime = self.runtimeRegistry.runtime(for: paneID),
@@ -2637,6 +2641,11 @@ final class RootViewController: NSViewController {
             updateSidebarWidth(width, persist: false)
         }
 
+        /// Mirrors a user drag of the sidebar resize handle: applies and persists.
+        func resizeSidebarAsUserForTesting(_ width: CGFloat) {
+            handleSidebarWidthChange(width)
+        }
+
         func settleSidebarTransitionForTesting() {
             applySidebarMotionState(
                 sidebarMotionCoordinator.currentMotionState,
@@ -2842,7 +2851,7 @@ final class RootViewController: NSViewController {
         appCanvasView.updateShortcutTooltips(shortcutManager)
     }
 
-    private func applyPersistedConfig(_ config: AppConfig) {
+    private func applyPersistedConfig(_ config: AppConfig, origin: AppConfigChangeOrigin) {
         let appearanceDidChange = config.appearance != lastAppliedAppearanceSettings
         lastAppliedAppearanceSettings = config.appearance
         paneLayoutPreferences = config.paneLayout
@@ -2852,11 +2861,20 @@ final class RootViewController: NSViewController {
         preloadOpenWithIcons()
         windowChromeView.apply(panes: config.panes)
         preloadProjectIcons()
-        sidebarMotionCoordinator.applyPersistedSidebarSettings(
-            config.sidebar,
-            availableWidth: resolvedSidebarAvailableWidth()
-        )
-        sidebarWidthConstraint?.constant = sidebarMotionCoordinator.currentSidebarWidth
+        // Sidebar visibility and width are per-window state. The config store only
+        // holds the most recently changed value so that new windows can seed from
+        // it; a change persisted by another window must not ripple into this one.
+        // An external edit of the sidebar section in the config file is still
+        // applied everywhere; unrelated external edits leave the sidebar alone.
+        let sidebarDidChangeOnDisk = origin == .externalReload && config.sidebar != lastObservedConfigSidebar
+        lastObservedConfigSidebar = config.sidebar
+        if sidebarDidChangeOnDisk {
+            sidebarMotionCoordinator.applyPersistedSidebarSettings(
+                config.sidebar,
+                availableWidth: resolvedSidebarAvailableWidth()
+            )
+            sidebarWidthConstraint?.constant = sidebarMotionCoordinator.currentSidebarWidth
+        }
         syncSidebarVisibilityControls(animated: false)
         applySidebarMotionState(
             sidebarMotionCoordinator.currentMotionState,

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -1003,6 +1003,32 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertEqual(store.current.shortcuts.bindings, [])
     }
 
+    func test_store_reports_change_origin_to_observers() throws {
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
+        let store = AppConfigStore(
+            fileURL: fileURL,
+            sidebarWidthDefaults: sidebarWidthDefaults,
+            sidebarVisibilityDefaults: sidebarVisibilityDefaults,
+            paneLayoutDefaults: paneLayoutDefaults
+        )
+        let origins = OriginRecorder()
+        _ = store.addObserver(withOrigin: { _, origin in
+            origins.append(origin)
+        })
+
+        try store.update { config in
+            config.sidebar.width = 333
+        }
+
+        var edited = store.current
+        edited.sidebar.width = 351
+        try AppConfigTOML.encode(edited).write(to: fileURL, atomically: true, encoding: .utf8)
+        store.reloadFromDisk()
+
+        XCTAssertEqual(origins.values, [.inProcess, .externalReload])
+        XCTAssertEqual(store.current.sidebar.width, 351)
+    }
+
     func test_store_notifies_multiple_observers_for_updates() throws {
         let fileURL = temporaryDirectoryURL.appendingPathComponent("config.toml")
         let store = AppConfigStore(
@@ -1657,5 +1683,22 @@ final class AgentCaffeinationControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(harness.endedTokenIDs, [1])
+    }
+}
+
+private final class OriginRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [AppConfigChangeOrigin] = []
+
+    var values: [AppConfigChangeOrigin] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ origin: AppConfigChangeOrigin) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(origin)
     }
 }

--- a/ZenttyLogicTests/RootViewCompositionTests.swift
+++ b/ZenttyLogicTests/RootViewCompositionTests.swift
@@ -1029,6 +1029,110 @@ final class RootViewCompositionTests: AppKitTestCase {
         XCTAssertEqual(controller.activeWorklaneIDForTesting, WorklaneID("other"))
     }
 
+    func test_sidebar_toggle_stays_per_window_but_seeds_new_windows() throws {
+        let configStore = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyLogicTests.RootView.PerWindowSidebarToggle")
+        )
+        let firstController = makeController(configStore: configStore)
+        let secondController = makeController(configStore: configStore)
+        firstController.loadViewIfNeeded()
+        secondController.loadViewIfNeeded()
+        XCTAssertEqual(firstController.sidebarVisibilityMode, .pinnedOpen)
+        XCTAssertEqual(secondController.sidebarVisibilityMode, .pinnedOpen)
+
+        firstController.routeToggleSidebar()
+        waitForMainQueue()
+
+        XCTAssertEqual(firstController.sidebarVisibilityMode, .hidden)
+        XCTAssertEqual(secondController.sidebarVisibilityMode, .pinnedOpen, "toggle must not ripple to other windows")
+        XCTAssertEqual(configStore.current.sidebar.visibility, .hidden, "last change is remembered as the seed")
+
+        let thirdController = makeController(configStore: configStore)
+        thirdController.loadViewIfNeeded()
+        XCTAssertEqual(thirdController.sidebarVisibilityMode, .hidden, "new windows start from the last change")
+    }
+
+    func test_sidebar_width_change_stays_per_window_but_seeds_new_windows() throws {
+        let configStore = AppConfigStore(
+            fileURL: AppConfigStore.temporaryFileURL(prefix: "ZenttyLogicTests.RootView.PerWindowSidebarWidth")
+        )
+        let firstController = makeController(configStore: configStore)
+        let secondController = makeController(configStore: configStore)
+        for controller in [firstController, secondController] {
+            controller.loadViewIfNeeded()
+            controller.view.frame = NSRect(x: 0, y: 0, width: 1400, height: 840)
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        firstController.resizeSidebarAsUserForTesting(340)
+        waitForMainQueue()
+        secondController.view.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(firstController.currentSidebarWidth, 340, accuracy: 0.001)
+        XCTAssertEqual(
+            secondController.currentSidebarWidth,
+            SidebarWidthPreference.defaultWidth,
+            accuracy: 0.001,
+            "width change must not ripple to other windows"
+        )
+        XCTAssertEqual(configStore.current.sidebar.width, 340, accuracy: 0.001)
+
+        let thirdController = makeController(configStore: configStore)
+        thirdController.loadViewIfNeeded()
+        XCTAssertEqual(thirdController.currentSidebarWidth, 340, accuracy: 0.001, "new windows start from the last change")
+    }
+
+    func test_external_config_reload_applies_sidebar_settings_to_every_window() throws {
+        let fileURL = AppConfigStore.temporaryFileURL(prefix: "ZenttyLogicTests.RootView.ExternalSidebarReload")
+        let configStore = AppConfigStore(fileURL: fileURL)
+        let firstController = makeController(configStore: configStore)
+        let secondController = makeController(configStore: configStore)
+        for controller in [firstController, secondController] {
+            controller.loadViewIfNeeded()
+            controller.view.frame = NSRect(x: 0, y: 0, width: 1400, height: 840)
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        var edited = configStore.current
+        edited.sidebar.width = 360
+        edited.sidebar.visibility = .hidden
+        try AppConfigTOML.encode(edited).write(to: fileURL, atomically: true, encoding: .utf8)
+        configStore.reloadFromDisk()
+        waitForMainQueue()
+
+        for controller in [firstController, secondController] {
+            XCTAssertEqual(controller.sidebarVisibilityMode, .hidden)
+            XCTAssertEqual(controller.currentSidebarWidth, 360, accuracy: 0.001)
+        }
+    }
+
+    func test_unrelated_external_config_reload_keeps_per_window_sidebar_state() throws {
+        let fileURL = AppConfigStore.temporaryFileURL(prefix: "ZenttyLogicTests.RootView.UnrelatedExternalReload")
+        let configStore = AppConfigStore(fileURL: fileURL)
+        let firstController = makeController(configStore: configStore)
+        let secondController = makeController(configStore: configStore)
+        firstController.loadViewIfNeeded()
+        secondController.loadViewIfNeeded()
+
+        firstController.routeToggleSidebar()
+        waitForMainQueue()
+        XCTAssertEqual(firstController.sidebarVisibilityMode, .hidden)
+        XCTAssertEqual(secondController.sidebarVisibilityMode, .pinnedOpen)
+
+        var edited = configStore.current
+        edited.confirmations.confirmBeforeClosingPane.toggle()
+        try AppConfigTOML.encode(edited).write(to: fileURL, atomically: true, encoding: .utf8)
+        configStore.reloadFromDisk()
+        waitForMainQueue()
+
+        XCTAssertEqual(firstController.sidebarVisibilityMode, .hidden)
+        XCTAssertEqual(
+            secondController.sidebarVisibilityMode,
+            .pinnedOpen,
+            "an on-disk edit that leaves the sidebar section alone must not snap windows to the seed"
+        )
+    }
+
     func test_root_controller_restores_persisted_sidebar_width() {
         let defaults = SidebarWidthPreference.userDefaults()
         defaults.set(312, forKey: SidebarWidthPreference.persistenceKey)


### PR DESCRIPTION
## Why

Hiding the sidebar or dragging its width in one window immediately did the same in every other open window. That's because both values live in the shared config store, and every window's root controller reapplied the whole config (sidebar included) on any change.

## What changed

Sidebar visibility and width are now per-window state. Each window still persists its own change to the config store, so the store always holds the most recent value and a newly opened window starts from it. Other open windows are left alone.

To tell the two cases apart, `AppConfigStore` now reports where a change came from: an in-process `update` or an external edit of `config.toml`. The existing `addObserver(_:)` is unchanged; the new `addObserver(withOrigin:)` adds the origin.

`RootViewController` only re-applies the sidebar section on an external reload, and only when that section actually differs from what the window last observed. Hand-editing a shortcut in the file no longer snaps every window back to the seed value, while hand-editing the sidebar section still applies everywhere.

## Not in scope

Windows restored at launch all start from the same seed, because the workspace recipe doesn't store sidebar state per window. Easy follow-up if wanted.

## Testing

New tests in `ZenttyLogicTests`:

- toggle in one window stays there, new window inherits it
- width drag in one window stays there, new window inherits it
- external edit of the sidebar section applies to every window
- external edit of an unrelated key leaves per-window sidebar state alone
- store reports `.inProcess` for `update` and `.externalReload` for a disk reload

Checked that the two per-window tests fail with the origin gate disabled. Full `RootViewCompositionTests`, `AppConfigStoreTests` and `SidebarMotionCoordinatorTests` pass (161 tests).