### PR TITLE
fix: clear Claude "Needs input" once work resumes after a prompt

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 		DE22542885A2BE164FE9090E /* KeyboardShortcutPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF1AD0DA5648D1E48300407 /* KeyboardShortcutPreview.swift */; };
 		DF1048E3F1F45A233C595280 /* PaneAgentReducerState+Codex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8552E3232235804F4AB8FB80 /* PaneAgentReducerState+Codex.swift */; };
 		DFC95AFE3D93BC03C215FC0E /* WorkspaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E99517E9EAA4D99552859C /* WorkspaceTemplate.swift */; };
+		E04EBA3DB2C42DBD5F114123 /* ClaudeApprovalResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B314CBC82EBD530AEDF0330 /* ClaudeApprovalResumeTests.swift */; };
 		E091B391CA413E9D9C495CB6 /* WorklaneAttentionSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1BDFF2B71B2BDFF1DF60EA /* WorklaneAttentionSummaryBuilder.swift */; };
 		E092E65843424D641089F829 /* MenuBarAgentIconInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77EBA78773A292B4B9858DD5 /* MenuBarAgentIconInspector.swift */; };
 		E0D0A39516DBC6367F61E913 /* MenuBarStatusKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E6AFBC242DD01217E89E74 /* MenuBarStatusKind.swift */; };
@@ -1004,6 +1005,7 @@
 		97BCD869C25CE3A03966E138 /* MenuBarStatusIconRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusIconRendererTests.swift; sourceTree = "<group>"; };
 		97D22B5BDA360AE3F6A96AE3 /* WorklaneColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorTests.swift; sourceTree = "<group>"; };
 		994F524FDC5F10D6A7A96354 /* AboutMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutMetadata.swift; sourceTree = "<group>"; };
+		9B314CBC82EBD530AEDF0330 /* ClaudeApprovalResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeApprovalResumeTests.swift; sourceTree = "<group>"; };
 		9B4AE87CC3F4EB591D08B9A7 /* WorkspaceTemplateExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateExporterTests.swift; sourceTree = "<group>"; };
 		9B89A97084B5AF5AFF873E2C /* BookmarkRestoreLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRestoreLogger.swift; sourceTree = "<group>"; };
 		9C0FDE2EFAFDF416D3D66490 /* HookCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCanonicalReEmitter.swift; sourceTree = "<group>"; };
@@ -2064,6 +2066,7 @@
 				E33FF8DDD0088600F542E4B1 /* AppMenuBuilderTests.swift */,
 				8BBC344380B6DDA89645BBDD /* AppUpdateStateStoreTests.swift */,
 				0EA071E0AD16A044F7C2F644 /* BookmarkStoreTests.swift */,
+				9B314CBC82EBD530AEDF0330 /* ClaudeApprovalResumeTests.swift */,
 				EDDFDCEF34526A6C5882223E /* ClaudeStopNotificationRaceTests.swift */,
 				41D3D22F3E783C0247024435 /* CleanCopyCommandFlatteningTests.swift */,
 				FD08AC7A7561005FD819D5D4 /* CleanCopyPipelineTests.swift */,
@@ -2502,6 +2505,7 @@
 				6511CF33CD9B8F480EDB6926 /* AppUpdateStateStoreTests.swift in Sources */,
 				ADEC09B96C29BD6B05776B2A /* AppearanceSettingsSectionViewControllerTests.swift in Sources */,
 				105EFDDB2995F6500AE4DF21 /* BookmarkStoreTests.swift in Sources */,
+				E04EBA3DB2C42DBD5F114123 /* ClaudeApprovalResumeTests.swift in Sources */,
 				44A22AB9819823EBE62144BE /* ClaudeStopNotificationRaceTests.swift in Sources */,
 				A1E9D4AC7D56DF6F533F5B0A /* CleanCopyCommandFlatteningTests.swift in Sources */,
 				FDC316FB9C5E49E5F368CCFD /* CleanCopyPipelineTests.swift in Sources */,

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -834,6 +834,8 @@ enum AgentLaunchBootstrap {
                 "PermissionRequest": claudeHookEntries(command: hookCommand, timeout: 10),
                 "UserPromptSubmit": claudeHookEntries(command: hookCommand, timeout: 10),
                 "PreToolUse": claudePreToolUseHookEntries(command: hookCommand, timeout: 5),
+                "PostToolUse": claudeHookEntries(command: hookCommand, timeout: 5),
+                "PostToolUseFailure": claudeHookEntries(command: hookCommand, timeout: 5),
                 "PreCompact": claudeHookEntries(command: hookCommand, timeout: 10),
                 "PostCompact": claudeHookEntries(command: hookCommand, timeout: 10),
                 "TaskCreated": claudeHookEntries(command: hookCommand, timeout: 5),

--- a/Zentty/AppState/Agent/ClaudeHookSessionStore.swift
+++ b/Zentty/AppState/Agent/ClaudeHookSessionStore.swift
@@ -14,6 +14,10 @@ struct ClaudeHookSessionRecord: Codable, Equatable {
     var lastStructuredInteractionText: String?
     var lastStructuredInteractionKindRawValue: String?
     var lastStructuredInteractionConfidenceRawValue: String?
+    /// `tool_use_id` of the tool call whose PermissionRequest /
+    /// AskUserQuestion prompt is currently open. Lets PostToolUse for a
+    /// sibling tool in the same batch leave the open prompt alone.
+    var lastStructuredInteractionToolUseID: String? = nil
     var lastNotificationText: String?
     var tasksByID: [String: Bool] = [:]
     var updatedAt: TimeInterval
@@ -178,7 +182,8 @@ final class ClaudeHookSessionStore {
         pid: Int32?,
         text: String,
         kind: PaneAgentInteractionKind,
-        confidence: AgentSignalConfidence
+        confidence: AgentSignalConfidence,
+        toolUseID: String? = nil
     ) throws {
         let normalizedSessionID = normalized(sessionID)
         guard !normalizedSessionID.isEmpty else {
@@ -216,6 +221,7 @@ final class ClaudeHookSessionStore {
             record.structuredInteractionText = normalizedOptional(text)
             record.structuredInteractionKind = kind
             record.structuredInteractionConfidence = confidence
+            record.lastStructuredInteractionToolUseID = normalizedOptional(toolUseID)
             record.lastNotificationText = nil
             record.updatedAt = now
             state.sessions[normalizedSessionID] = record
@@ -251,6 +257,7 @@ final class ClaudeHookSessionStore {
             record.structuredInteractionText = nil
             record.structuredInteractionKind = nil
             record.structuredInteractionConfidence = nil
+            record.lastStructuredInteractionToolUseID = nil
             record.lastNotificationText = nil
             record.updatedAt = Date().timeIntervalSince1970
             state.sessions[normalizedSessionID] = record

--- a/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
@@ -24,6 +24,7 @@ struct ClaudeAdapterInput {
     let transcriptPath: String?
     let toolName: String?
     let toolInput: [String: Any]
+    let toolUseID: String?
     let taskID: String?
     let taskSubject: String?
 }
@@ -46,6 +47,7 @@ extension AgentEventBridge {
             transcriptPath: JSONKeyAccess.firstString(in: json, keys: ["transcript_path", "transcriptPath"]),
             toolName: JSONKeyAccess.firstString(in: json, keys: ["tool_name", "toolName"]),
             toolInput: (json["tool_input"] as? [String: Any]) ?? [:],
+            toolUseID: JSONKeyAccess.firstString(in: json, keys: ["tool_use_id", "toolUseId"]),
             taskID: JSONKeyAccess.firstString(in: json, keys: ["task_id", "taskId"]),
             taskSubject: JSONKeyAccess.firstString(in: json, keys: ["task", "task_subject", "taskSubject", "title"])
         )
@@ -138,7 +140,8 @@ extension AgentEventBridge {
                     pid: existing?.pid,
                     text: message,
                     kind: interaction.interactionKind,
-                    confidence: .explicit
+                    confidence: .explicit,
+                    toolUseID: input.toolUseID
                 )
             }
             return [claudeLifecyclePayload(target: target, state: .needsInput, text: message, interactionKind: interaction.interactionKind, confidence: .explicit, sessionID: input.sessionID)]
@@ -164,7 +167,8 @@ extension AgentEventBridge {
                     pid: existing?.pid,
                     text: message,
                     kind: prompt.interactionKind,
-                    confidence: .explicit
+                    confidence: .explicit,
+                    toolUseID: input.toolUseID
                 )
                 return [claudeLifecyclePayload(target: target, state: .needsInput, text: message, interactionKind: prompt.interactionKind, confidence: .explicit, sessionID: input.sessionID)]
             }
@@ -175,6 +179,28 @@ extension AgentEventBridge {
             return [claudeLifecyclePayload(
                 target: target, state: .running, cwd: input.cwd ?? preToolExisting?.cwd,
                 interactionKind: .none, confidence: .explicit, sessionID: input.sessionID,
+                taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID)
+            )]
+
+        case "PostToolUse", "PostToolUseFailure":
+            // The only hooks Claude Code emits between an approved tool and the
+            // next Bash/Write/Edit call. Without them an approval prompt
+            // answered with `1`/`y` (no Enter) stayed "Needs input" while
+            // Claude worked through Read/Grep/Agent tools (agent-bench
+            // claude/approval_then_work: 11 s of silence after approval).
+            let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
+            let existing = try claudeLookupRecord(for: input, sessionStore: sessionStore)
+            if claudeShouldKeepPendingInteraction(existing: existing, completedToolUseID: input.toolUseID) {
+                // A sibling tool from the same parallel batch finished while
+                // another tool's permission / question dialog is still open.
+                return []
+            }
+            if let sessionID = input.sessionID {
+                try sessionStore.clearInteractionContext(sessionID: sessionID)
+            }
+            return [claudeLifecyclePayload(
+                target: target, state: .running, cwd: input.cwd ?? existing?.cwd,
+                interactionKind: PaneAgentInteractionKind.none, confidence: .explicit, sessionID: input.sessionID,
                 taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID)
             )]
 
@@ -285,6 +311,20 @@ extension AgentEventBridge {
     ) throws -> ClaudeHookSessionRecord? {
         guard let sessionID = input.sessionID else { return nil }
         return try sessionStore.lookup(sessionID: sessionID)
+    }
+
+    static func claudeShouldKeepPendingInteraction(
+        existing: ClaudeHookSessionRecord?,
+        completedToolUseID: String?
+    ) -> Bool {
+        guard let existing,
+              existing.structuredInteractionKind?.requiresHumanAttention == true,
+              let pendingToolUseID = existing.lastStructuredInteractionToolUseID,
+              let completedToolUseID = AgentInteractionClassifier.trimmed(completedToolUseID)
+        else {
+            return false
+        }
+        return pendingToolUseID != completedToolUseID
     }
 
     static func claudeDescribePermissionRequest(

--- a/Zentty/AppState/Agent/PaneAgentReducer.swift
+++ b/Zentty/AppState/Agent/PaneAgentReducer.swift
@@ -285,6 +285,39 @@ struct PaneAgentReducerState: Equatable, Sendable {
         return true
     }
 
+    /// Claude Code parks its terminal title on the idle glyph "✳" while a
+    /// permission or AskUserQuestion dialog is open and brings the spinner
+    /// back the moment the user answers. That title flip is the earliest
+    /// "resumed" signal Zentty gets: approving with `1` / `y` emits no
+    /// keystroke Zentty recognises, and the next hook (PostToolUse) only
+    /// arrives once the approved tool has finished.
+    @discardableResult
+    mutating func resumeExplicitClaudeCodeSessionFromSpinnerTitle(now: Date = Date()) -> Bool {
+        let candidateSessions = sessionsByID.values.filter { session in
+            session.tool == .claudeCode
+                && session.source == .explicit
+                && session.origin != .shell
+                && (session.state == .needsInput || session.interactionKind.requiresHumanAttention)
+        }
+        guard let sessionID = candidateSessions.sorted(by: Self.preferred(lhs:rhs:)).first?.sessionID,
+              var session = sessionsByID[sessionID]
+        else {
+            return false
+        }
+
+        session.state = .running
+        session.text = nil
+        session.interactionKind = .none
+        session.completionCandidateDeadline = nil
+        session.idleVisibleUntil = nil
+        session.unresolvedStopVisibleUntil = nil
+        session.hasObservedRunning = true
+        session.explicitIdleSince = nil
+        session.updatedAt = now
+        sessionsByID[sessionID] = session
+        return true
+    }
+
     @discardableResult
     mutating func markExplicitClaudeCodeSessionIdleFromIdleTitle(now: Date = Date()) -> Bool {
         let candidateSessions = sessionsByID.values.filter { session in

--- a/Zentty/AppState/Agent/TerminalMetadataChangeClassifier.swift
+++ b/Zentty/AppState/Agent/TerminalMetadataChangeClassifier.swift
@@ -165,8 +165,10 @@ enum TerminalMetadataChangeClassifier {
             return volatileAgentStatusTitleSignature(normalized, recognizedTool: .codex)
         case .claudeCode:
             // Claude Code 2.x encodes status in the title glyph: "✳" (U+2733)
-            // on the idle prompt, braille spinner glyphs (U+2800…U+28FF) while
-            // the agent is thinking. After a user interrupt (Escape) the
+            // on the idle prompt (and while a permission / question dialog is
+            // open), spinner glyphs while the agent is working — braille
+            // (U+2800…U+28FF) on older builds, "◐ ◑ ◒ ◓" (U+25D0…U+25D3) on
+            // 2.1+. After a user interrupt (Escape) the
             // spinner is replaced by "✳", with the subject left intact — this
             // is what lets us detect the interrupt when no Stop hook fires.
             if let signature = parseClaudeCodeGlyphTitle(normalized) {
@@ -343,7 +345,8 @@ enum TerminalMetadataChangeClassifier {
         switch first.value {
         case 0x2733:
             phase = .idle
-        case 0x2800...0x28FF:
+        case 0x2800...0x28FF, 0x25D0...0x25D3:
+            // Braille spinner on older builds; "◐ ◑ ◒ ◓" on Claude Code 2.1+.
             phase = .running
         default:
             return nil

--- a/Zentty/AppState/WorklaneStore+Metadata.swift
+++ b/Zentty/AppState/WorklaneStore+Metadata.swift
@@ -146,6 +146,12 @@ extension WorklaneStore {
                 metadata: metadata,
                 in: &worklane
             )
+        resumeClaudeCodeSessionIfTitleIndicatesSpinner(
+            paneID: paneID,
+            previousMetadata: previousMetadata,
+            metadata: metadata,
+            in: &worklane
+        )
         let claudeCodeInterrupted = markClaudeCodeSessionIdleIfTitleIndicatesIdle(
             paneID: paneID,
             metadata: metadata,
@@ -683,6 +689,56 @@ extension WorklaneStore {
         now: Date = Date()
     ) -> Bool {
         codexResolver.titleIdleSuppressionIsActive(raw, now: now)
+    }
+
+    /// When a Claude Code session is blocked on a permission / question prompt
+    /// and the terminal title flips from the idle glyph "✳" (which Claude shows
+    /// while the dialog is open) to a spinner glyph, the user has answered and
+    /// Claude is working again. Requires the *previous* title to be the idle
+    /// glyph so a stale spinner title racing the PermissionRequest hook cannot
+    /// clear a prompt that is still on screen.
+    private func resumeClaudeCodeSessionIfTitleIndicatesSpinner(
+        paneID: PaneID,
+        previousMetadata: TerminalMetadata?,
+        metadata: TerminalMetadata,
+        in worklane: inout WorklaneState
+    ) {
+        guard
+            let signature = TerminalMetadataChangeClassifier.diagnosticAgentStatusTitleSignature(
+                metadata.title,
+                recognizedTool: .claudeCode
+            ),
+            signature.phase == .running,
+            let previousSignature = TerminalMetadataChangeClassifier.diagnosticAgentStatusTitleSignature(
+                previousMetadata?.title,
+                recognizedTool: .claudeCode
+            ),
+            previousSignature.phase == .idle,
+            var auxiliaryState = worklane.auxiliaryStateByPaneID[paneID],
+            let existingStatus = auxiliaryState.agentStatus,
+            existingStatus.tool == .claudeCode,
+            existingStatus.state == .needsInput || existingStatus.interactionKind.requiresHumanAttention
+        else {
+            return
+        }
+
+        auxiliaryState.agentReducerState = AgentStatusReconciliation.seededReducerState(
+            auxiliaryState.agentReducerState,
+            from: existingStatus
+        )
+        let now = currentDateProvider()
+        guard auxiliaryState.agentReducerState.resumeExplicitClaudeCodeSessionFromSpinnerTitle(now: now) else {
+            return
+        }
+
+        auxiliaryState.agentStatus = AgentStatusReconciliation.hydratedStatus(
+            auxiliaryState.agentReducerState.reducedStatus(now: now),
+            existingStatus: existingStatus
+        )
+        worklane.auxiliaryStateByPaneID[paneID] = auxiliaryState
+        stopSignalLogger.debug(
+            "metadata.claudeSpinnerResume pane=\(paneID.rawValue, privacy: .public) title=\(metadata.title ?? "<nil>", privacy: .public)"
+        )
     }
 
     /// When a Claude Code session is running but the terminal title transitions

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -1961,6 +1961,26 @@ final class AgentEventBridgeTests: XCTestCase {
         XCTAssertEqual(payloads[0].text, "Run npm install?")
     }
 
+    func test_claude_adapter_post_tool_use_sets_running() throws {
+        let json = #"{"hook_event_name": "PostToolUse", "session_id": "cs1", "tool_name": "Read", "tool_use_id": "tu-1", "cwd": "/tmp/project"}"#
+        let payloads = try AgentEventBridge.claudeAdapter(data: json.data(using: .utf8)!, environment: claudeEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.state, .running)
+        XCTAssertEqual(payloads.first?.interactionKind, PaneAgentInteractionKind.none)
+        XCTAssertEqual(payloads.first?.confidence, .explicit)
+        XCTAssertEqual(payloads.first?.agentWorkingDirectory, "/tmp/project")
+    }
+
+    func test_claude_adapter_post_tool_use_failure_sets_running() throws {
+        let json = #"{"hook_event_name": "PostToolUseFailure", "session_id": "cs1", "tool_name": "Bash", "tool_use_id": "tu-1", "error": "exit 1"}"#
+        let payloads = try AgentEventBridge.claudeAdapter(data: json.data(using: .utf8)!, environment: claudeEnvironment())
+
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.state, .running)
+        XCTAssertEqual(payloads.first?.interactionKind, PaneAgentInteractionKind.none)
+    }
+
     func test_claude_adapter_unknown_event_returns_empty() throws {
         let json = #"{"hook_event_name": "SomeNewEvent"}"#
         let payloads = try AgentEventBridge.claudeAdapter(data: json.data(using: .utf8)!, environment: claudeEnvironment())

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -2324,6 +2324,14 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertNotNil(hooks["PreCompact"])
         XCTAssertNotNil(hooks["PostCompact"])
         XCTAssertNotNil(hooks["TaskCompleted"])
+        // PostToolUse / PostToolUseFailure are the only hooks Claude Code emits
+        // between an approved tool and the next Bash/Write/Edit call; without
+        // them an approval prompt stays "Needs input" while Claude works
+        // through Read/Grep/Agent tools.
+        for event in ["PostToolUse", "PostToolUseFailure"] {
+            let entries = try XCTUnwrap(hooks[event] as? [[String: Any]], "missing \(event) hook")
+            XCTAssertEqual(entries.compactMap { $0["matcher"] as? String }, [""], "\(event) must match every tool")
+        }
     }
 
     func test_agent_launch_bootstrap_preserves_explicit_claude_color_environment() throws {
@@ -8170,7 +8178,7 @@ final class AgentStatusSupportTests: XCTestCase {
     func test_claude_hook_ignores_unknown_events() throws {
         let input = try AgentEventBridge.claudeParseInput(
             Data("""
-            {"hook_event_name":"PostToolUse","session_id":"session-1","message":"tool finished"}
+            {"hook_event_name":"SomeFutureEvent","session_id":"session-1","message":"tool finished"}
             """.utf8)
         )
         let store = try makeClaudeHookSessionStore()

--- a/ZenttyLogicTests/ClaudeApprovalResumeTests.swift
+++ b/ZenttyLogicTests/ClaudeApprovalResumeTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import XCTest
+@testable import Zentty
+
+/// Reproduces the "Needs input while Claude is clearly working" symptom.
+///
+/// Live agent-bench trace (claude/approval_then_work, Claude Code 2.1.261):
+///
+///   PreToolUse(Write) → PermissionRequest(Write) → [user approves] →
+///   Write runs → Read runs → Grep runs → PreToolUse(Bash) → Stop
+///
+/// Between the approval and the next Bash/Write/Edit PreToolUse there were
+/// eleven seconds with zero hook events. Only Enter, a PreToolUse for the
+/// narrow matcher set, or Stop ever cleared the approval prompt. Approving
+/// with `1`/`y` and then working through Read/Grep/Agent tools left the pane
+/// on "Needs input" for the whole stretch.
+///
+/// These tests drive the real Claude adapter through a fresh session store
+/// and assert the reduced status after each PostToolUse.
+final class ClaudeApprovalResumeTests: XCTestCase {
+
+    private let defaultEnvironment: [String: String] = [
+        "ZENTTY_WORKLANE_ID": "worklane-approval-resume",
+        "ZENTTY_PANE_ID": "pane-approval-resume",
+        "ZENTTY_WINDOW_ID": "window-approval-resume",
+        "ZENTTY_CLAUDE_PID": "4242",
+    ]
+
+    private var sessionStore: ClaudeHookSessionStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("zentty-claude-approval-resume-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        sessionStore = ClaudeHookSessionStore(
+            stateURL: directory.appendingPathComponent("claude-hook-sessions.json", isDirectory: false)
+        )
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    func test_post_tool_use_after_approval_returns_to_running() throws {
+        var reducer = PaneAgentReducerState()
+        let base = Date(timeIntervalSince1970: 1_000)
+
+        try replay(#"{"hook_event_name":"SessionStart","session_id":"s1"}"#, into: &reducer, at: base)
+        try replay(#"{"hook_event_name":"UserPromptSubmit","session_id":"s1"}"#, into: &reducer, at: base + 0.1)
+        try replay(#"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Write","tool_use_id":"tu-write"}"#, into: &reducer, at: base + 4.7)
+        try replay(#"{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"Write","tool_use_id":"tu-write","message":"Create file ZENTTY_OK?"}"#, into: &reducer, at: base + 4.72)
+
+        XCTAssertEqual(reducer.reducedStatus(now: base + 5)?.state, .needsInput)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 5)?.interactionKind, .approval)
+
+        // User approved with `1` (no Enter, so no userSubmittedInput event).
+        // The approved tool finishes: PostToolUse is the first hook Claude
+        // Code emits after the permission was resolved.
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Write","tool_use_id":"tu-write","tool_response":{"success":true}}"#, into: &reducer, at: base + 10.8)
+
+        let afterWrite = reducer.reducedStatus(now: base + 11)
+        XCTAssertEqual(afterWrite?.state, .running, "PostToolUse for the approved tool must clear the approval prompt. Got \(String(describing: afterWrite?.state)) text=\(afterWrite?.text ?? "nil")")
+        XCTAssertEqual(afterWrite?.interactionKind, PaneAgentInteractionKind.none)
+        XCTAssertNil(afterWrite?.text)
+
+        // Read/Grep never fire PreToolUse (narrow matcher); PostToolUse keeps
+        // the pane on running.
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Read","tool_use_id":"tu-read"}"#, into: &reducer, at: base + 14)
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Grep","tool_use_id":"tu-grep"}"#, into: &reducer, at: base + 18)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 19)?.state, .running)
+
+        try replay(#"{"hook_event_name":"Stop","session_id":"s1"}"#, into: &reducer, at: base + 23.8)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 24)?.state, .idle)
+    }
+
+    func test_post_tool_use_failure_after_approval_returns_to_running() throws {
+        var reducer = PaneAgentReducerState()
+        let base = Date(timeIntervalSince1970: 2_000)
+
+        try replay(#"{"hook_event_name":"SessionStart","session_id":"s2"}"#, into: &reducer, at: base)
+        try replay(#"{"hook_event_name":"UserPromptSubmit","session_id":"s2"}"#, into: &reducer, at: base + 0.1)
+        try replay(#"{"hook_event_name":"PreToolUse","session_id":"s2","tool_name":"Bash","tool_use_id":"tu-bash"}"#, into: &reducer, at: base + 1)
+        try replay(#"{"hook_event_name":"PermissionRequest","session_id":"s2","tool_name":"Bash","tool_use_id":"tu-bash","message":"Run make?"}"#, into: &reducer, at: base + 1.02)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 2)?.state, .needsInput)
+
+        try replay(#"{"hook_event_name":"PostToolUseFailure","session_id":"s2","tool_name":"Bash","tool_use_id":"tu-bash","error":"exit 2"}"#, into: &reducer, at: base + 9)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 10)?.state, .running)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 10)?.interactionKind, PaneAgentInteractionKind.none)
+    }
+
+    func test_post_tool_use_for_sibling_tool_keeps_pending_approval_visible() throws {
+        // Parallel tool batch: Read A and Bash B are issued together. B needs
+        // permission; A completes while B's dialog is still open. A's
+        // PostToolUse must not clear B's prompt.
+        var reducer = PaneAgentReducerState()
+        let base = Date(timeIntervalSince1970: 3_000)
+
+        try replay(#"{"hook_event_name":"SessionStart","session_id":"s3"}"#, into: &reducer, at: base)
+        try replay(#"{"hook_event_name":"UserPromptSubmit","session_id":"s3"}"#, into: &reducer, at: base + 0.1)
+        try replay(#"{"hook_event_name":"PreToolUse","session_id":"s3","tool_name":"Bash","tool_use_id":"tu-b"}"#, into: &reducer, at: base + 1)
+        try replay(#"{"hook_event_name":"PermissionRequest","session_id":"s3","tool_name":"Bash","tool_use_id":"tu-b","message":"Run rm -rf build?"}"#, into: &reducer, at: base + 1.02)
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s3","tool_name":"Read","tool_use_id":"tu-a"}"#, into: &reducer, at: base + 1.3)
+
+        let status = reducer.reducedStatus(now: base + 2)
+        XCTAssertEqual(status?.state, .needsInput)
+        XCTAssertEqual(status?.interactionKind, .approval)
+        XCTAssertEqual(status?.text, "Run rm -rf build?")
+
+        // B's own completion clears it.
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s3","tool_name":"Bash","tool_use_id":"tu-b"}"#, into: &reducer, at: base + 8)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 9)?.state, .running)
+    }
+
+    func test_post_tool_use_after_ask_user_question_returns_to_running() throws {
+        var reducer = PaneAgentReducerState()
+        let base = Date(timeIntervalSince1970: 4_000)
+        let ask = #"""
+        {"hook_event_name":"PreToolUse","session_id":"s4","tool_name":"AskUserQuestion","tool_use_id":"tu-ask",
+         "tool_input":{"questions":[{"question":"Which approach?","options":[{"label":"A"},{"label":"B"}]}]}}
+        """#
+
+        try replay(#"{"hook_event_name":"SessionStart","session_id":"s4"}"#, into: &reducer, at: base)
+        try replay(#"{"hook_event_name":"UserPromptSubmit","session_id":"s4"}"#, into: &reducer, at: base + 0.1)
+        try replay(ask, into: &reducer, at: base + 1)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 2)?.state, .needsInput)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 2)?.interactionKind, .decision)
+
+        try replay(#"{"hook_event_name":"PostToolUse","session_id":"s4","tool_name":"AskUserQuestion","tool_use_id":"tu-ask"}"#, into: &reducer, at: base + 20)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 21)?.state, .running)
+        XCTAssertEqual(reducer.reducedStatus(now: base + 21)?.interactionKind, PaneAgentInteractionKind.none)
+    }
+
+    private func replay(_ json: String, into reducer: inout PaneAgentReducerState, at now: Date) throws {
+        let payloads = try AgentEventBridge.claudeMakePayloads(
+            from: AgentEventBridge.claudeParseInput(Data(json.utf8)),
+            environment: defaultEnvironment,
+            sessionStore: sessionStore
+        )
+        for payload in payloads {
+            reducer.apply(payload, now: now)
+        }
+    }
+}
+
+/// Terminal-title half of the same symptom. While a Claude Code permission or
+/// AskUserQuestion dialog is open the title carries the idle glyph "✳"; the
+/// moment the user answers (with `1`, `y`, Enter, or a click elsewhere) the
+/// spinner glyphs "◐ ◑" come back — several seconds before any hook fires.
+/// Live bench timeline (claude/approval_then_work):
+///
+///   4707 ms  title "✳ …"   (dialog open)
+///   4721 ms  PermissionRequest
+///  10737 ms  user types 1
+///  10747 ms  title "◐ …"   ← resume signal
+///  21893 ms  PreToolUse(Bash) — first hook after approval
+@MainActor
+final class ClaudeSpinnerTitleResumeTests: XCTestCase {
+
+    func test_spinner_title_after_idle_title_resumes_blocked_claude_session() throws {
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        store.knownNonRepositoryPaths.insert("/tmp/project")
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "◐ regression test"))
+        store.applyAgentStatusPayload(claudePayload(paneID: paneID, worklaneID: store.activeWorklaneID, state: .running))
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "✳ regression test"))
+        store.applyAgentStatusPayload(
+            claudePayload(
+                paneID: paneID, worklaneID: store.activeWorklaneID,
+                state: .needsInput, text: "Create file ZENTTY_OK?", interactionKind: .approval
+            )
+        )
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .needsInput)
+
+        // Title stays on the idle glyph while the dialog is open: no change.
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "✳ regression test"))
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .needsInput)
+
+        // User answers; spinner returns.
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "◐ regression test"))
+        let status = store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus
+        XCTAssertEqual(status?.state, .running, "spinner title after the idle-glyph dialog title must resume the session")
+        XCTAssertEqual(status?.interactionKind, PaneAgentInteractionKind.none)
+        XCTAssertNil(status?.text)
+    }
+
+    func test_stale_spinner_title_before_dialog_title_does_not_clear_prompt() throws {
+        // Reverse race: PermissionRequest lands before the "✳" title does. The
+        // spinner glyph that is still on screen must not be read as a resume.
+        let store = WorklaneStore(readyStatusDebounceInterval: 0)
+        store.knownNonRepositoryPaths.insert("/tmp/project")
+        let paneID = try XCTUnwrap(store.activeWorklane?.paneStripState.focusedPaneID)
+
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "◐ regression test"))
+        store.applyAgentStatusPayload(claudePayload(paneID: paneID, worklaneID: store.activeWorklaneID, state: .running))
+        store.applyAgentStatusPayload(
+            claudePayload(
+                paneID: paneID, worklaneID: store.activeWorklaneID,
+                state: .needsInput, text: "Run make?", interactionKind: .approval
+            )
+        )
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "◑ regression test"))
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .needsInput)
+
+        store.updateMetadata(paneID: paneID, metadata: metadata(title: "✳ regression test"))
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.state, .needsInput)
+        XCTAssertEqual(store.activeWorklane?.auxiliaryStateByPaneID[paneID]?.agentStatus?.text, "Run make?")
+    }
+
+    private func metadata(title: String) -> TerminalMetadata {
+        TerminalMetadata(
+            title: title,
+            currentWorkingDirectory: "/tmp/project",
+            processName: "claude",
+            gitBranch: "main"
+        )
+    }
+
+    private func claudePayload(
+        paneID: PaneID,
+        worklaneID: WorklaneID,
+        state: PaneAgentState,
+        text: String? = nil,
+        interactionKind: PaneAgentInteractionKind? = nil
+    ) -> AgentStatusPayload {
+        AgentStatusPayload(
+            worklaneID: worklaneID,
+            paneID: paneID,
+            signalKind: .lifecycle,
+            state: state,
+            origin: .explicitHook,
+            toolName: "Claude Code",
+            text: text,
+            lifecycleEvent: .update,
+            interactionKind: interactionKind,
+            confidence: .explicit,
+            sessionID: "session-claude-spinner",
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        )
+    }
+}

--- a/scripts/agent-bench/README.md
+++ b/scripts/agent-bench/README.md
@@ -65,3 +65,17 @@ python3 scripts/agent-bench/agent_bench.py run --agents codex --scenarios approv
 Claude scenarios pass `--setting-sources project,local` so user-level hooks do
 not inject unrelated context into the live model run. The bench still supplies
 its own hook settings through the wrapper bootstrap path.
+
+Interactive Claude Code (2.1.261+) skips every hook while the workspace trust
+dialog has not been accepted, and it never shows that dialog inside the bench
+pty. The bench therefore marks each temporary Claude repo as trusted in
+`~/.claude.json` (`hasTrustDialogAccepted` only) before launching and prunes
+entries for bench repos that no longer exist. Print-mode scenarios (`smoke`,
+`session_capture`) are unaffected.
+
+`approval_then_work` is the regression scenario for the sidebar status: it
+approves a Write, then has Claude continue with Read and Grep before
+finishing. The trace must show `PostToolUse` events between
+`PermissionRequest` and `Stop`; those are the only hooks Claude emits while it
+works through tools outside the PreToolUse matcher, and without them the pane
+stays on "Needs input" after an approval typed as `1`/`y`.

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -799,6 +799,56 @@ def source_sort_key(source: str) -> int:
     return {"process": 0, "hook": 1, "terminal": 2}.get(source, 3)
 
 
+
+CLAUDE_CONFIG_PATH = pathlib.Path.home() / ".claude.json"
+BENCH_REPO_MARKER = "/repos/claude-"
+
+
+def ensure_claude_workspace_trust(repo: pathlib.Path, config_path: pathlib.Path = CLAUDE_CONFIG_PATH) -> bool:
+    """Mark the bench's temporary repo as a trusted Claude Code workspace.
+
+    Interactive Claude Code (2.1.261+) skips *all* hook execution while the
+    workspace trust dialog has not been accepted, and it does not show that
+    dialog in the bench's pty. Without this every interactive Claude scenario
+    reports ``missing-hook`` even though the wrapper injected the hooks.
+
+    Only ``hasTrustDialogAccepted`` is written. Stale bench entries (repos
+    that no longer exist on disk) are pruned so ``~/.claude.json`` does not
+    accumulate one project per run. Returns True when the file changed.
+    """
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(config, dict):
+        return False
+    projects = config.setdefault("projects", {})
+    if not isinstance(projects, dict):
+        return False
+
+    changed = False
+    for key in list(projects):
+        if BENCH_REPO_MARKER in key and not pathlib.Path(key).exists():
+            del projects[key]
+            changed = True
+
+    for candidate in {str(repo), str(repo.resolve())}:
+        entry = projects.get(candidate)
+        if not isinstance(entry, dict):
+            entry = {}
+            projects[candidate] = entry
+        if entry.get("hasTrustDialogAccepted") is not True:
+            entry["hasTrustDialogAccepted"] = True
+            changed = True
+
+    if not changed:
+        return False
+    temporary = config_path.with_name(config_path.name + ".agent-bench.tmp")
+    temporary.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    os.replace(temporary, config_path)
+    return True
+
+
 def scenario_requires_task_observation(agent: str, scenario: str) -> bool:
     return scenario == "tasks"
 
@@ -1558,6 +1608,11 @@ class LaunchPlanner:
             {"matcher": matcher, "hooks": [{"type": "command", "command": hook_command, "timeout": 5}]}
             for matcher in ("AskUserQuestion", "Bash|Write|Edit|MultiEdit|NotebookEdit")
         ]
+        # Mirror AgentLaunchBootstrap.claudePlan: PostToolUse / PostToolUseFailure
+        # are the only signals between an approved tool and the next matched
+        # PreToolUse, so the sidebar can leave "Needs input" once work resumes.
+        for event in ("PostToolUse", "PostToolUseFailure"):
+            settings["hooks"][event] = [{"matcher": "", "hooks": [{"type": "command", "command": hook_command, "timeout": 5}]}]
         planned = ["--session-id", str(uuid.uuid4()).lower(), "--settings", compact_json(settings)] + arguments
         return self._launch_plan(executable, planned, {"ZENTTY_AGENT_TOOL": "claude"}, unset=["CLAUDECODE"])
 
@@ -2387,12 +2442,23 @@ class BenchRunner:
         output_parts: list[str] = []
         completed = PtyResult(0, False, "", terminal_observations=[])
         repeat_count = max(1, profile.repeat_by_scenario.get(scenario, 1))
+        repo = self._make_repo(agent, scenario)
+        if profile.tool == "claude":
+            try:
+                if ensure_claude_workspace_trust(repo):
+                    self.recorder.append(
+                        TraceRecord(kind="note", agent=agent, scenario=scenario, extra={"claude_workspace_trust": str(repo)})
+                    )
+            except OSError as error:
+                self.recorder.append(
+                    TraceRecord(kind="note", agent=agent, scenario=scenario, extra={"claude_workspace_trust_error": str(error)})
+                )
         for iteration in range(repeat_count):
             iteration_transcript_path = transcript_path if repeat_count == 1 else self.run_dir / f"{agent}-{scenario}-{iteration + 1}.terminal.log"
             completed = run_pty(
                 argv,
                 env=env,
-                cwd=self._make_repo(agent, scenario),
+                cwd=repo,
                 inputs=profile.input_by_scenario.get(scenario, []),
                 timeout=self.args.timeout,
                 transcript_path=iteration_transcript_path,

--- a/scripts/agent-bench/profiles/claude.json
+++ b/scripts/agent-bench/profiles/claude.json
@@ -1,8 +1,12 @@
 {
   "name": "claude",
   "command": "claude",
-  "real_binary_names": ["claude"],
-  "version_args": ["--version"],
+  "real_binary_names": [
+    "claude"
+  ],
+  "version_args": [
+    "--version"
+  ],
   "launch_args_by_scenario": {
     "smoke": [
       "--setting-sources",
@@ -44,34 +48,80 @@
     "restore_launch": [
       "--resume",
       "237d8c32-2a27-4850-8da8-3a110f13682c"
+    ],
+    "approval_then_work": [
+      "--setting-sources",
+      "project,local",
+      "--permission-mode",
+      "default",
+      "--max-budget-usd",
+      "1.00",
+      "For an integration hook regression test: 1) create a file named ZENTTY_AGENT_BENCH_APPROVAL_OK in the current directory using the Write tool with the text ZENTTY_AGENT_BENCH_APPROVAL_OK. 2) Then, without asking me anything, read README.md with the Read tool. 3) Then search for the word bench in this directory with the Grep tool. 4) Then reply with exactly DONE."
     ]
   },
   "expectations": {
     "smoke": {
-      "required_events": ["SessionStart", "UserPromptSubmit", "Stop"]
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop"
+      ]
     },
     "session_capture": {
-      "required_events": ["SessionStart", "UserPromptSubmit", "Stop"],
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop"
+      ],
       "session_identity": {
         "session_id_pattern": "uuid",
         "tracked_pid": true
       }
     },
     "approval": {
-      "required_events": ["SessionStart", "UserPromptSubmit", "PreToolUse", "PermissionRequest"]
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PermissionRequest"
+      ]
     },
     "stop_race": {
       "synthetic": true,
       "fixture": "claude_stop_then_late_notification.jsonl",
-      "required_events": ["SessionStart", "UserPromptSubmit", "PreToolUse", "Stop", "Notification"],
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "Stop",
+        "Notification"
+      ],
       "post_stop_notification_required": true
     },
     "manual_compact": {
-      "required_events": ["SessionStart", "PreCompact"]
+      "required_events": [
+        "SessionStart",
+        "PreCompact"
+      ]
     },
     "restore_launch": {
       "required_events": [],
-      "required_bootstrap_arguments": [["--resume", "237d8c32-2a27-4850-8da8-3a110f13682c"]]
+      "required_bootstrap_arguments": [
+        [
+          "--resume",
+          "237d8c32-2a27-4850-8da8-3a110f13682c"
+        ]
+      ]
+    },
+    "approval_then_work": {
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PermissionRequest",
+        "PostToolUse",
+        "Stop"
+      ]
     }
   },
   "input_by_scenario": {
@@ -88,7 +138,20 @@
         "text": "/compact\r",
         "label": "manual-compact"
       }
+    ],
+    "approval_then_work": [
+      {
+        "match": "Command to approve|Yes, allow|Do you want|Permission|allow",
+        "text": "1\n"
+      }
     ]
   },
-  "skip_patterns": ["login", "auth", "not authenticated", "api key", "subscription", "maximum dollar amount"]
+  "skip_patterns": [
+    "login",
+    "auth",
+    "not authenticated",
+    "api key",
+    "subscription",
+    "maximum dollar amount"
+  ]
 }

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -240,6 +240,68 @@ class SyntheticScenarioTests(unittest.TestCase):
             ["sessionStart", "subagentStart", "subagentStop", "stop"],
         )
 
+    def test_ensure_claude_workspace_trust_marks_repo_and_prunes_stale_bench_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            config = root / ".claude.json"
+            repo = root / "run" / "repos" / "claude-approval"
+            repo.mkdir(parents=True)
+            stale = str(root / "old-run" / "repos" / "claude-smoke")
+            config.write_text(
+                json.dumps(
+                    {
+                        "projects": {
+                            "/Users/someone/project": {"hasTrustDialogAccepted": True, "lastCost": 1},
+                            stale: {"hasTrustDialogAccepted": True},
+                        },
+                        "other": "kept",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(agent_bench.ensure_claude_workspace_trust(repo, config_path=config))
+            written = json.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual(written["other"], "kept")
+            self.assertEqual(written["projects"]["/Users/someone/project"], {"hasTrustDialogAccepted": True, "lastCost": 1})
+            self.assertNotIn(stale, written["projects"])
+            self.assertTrue(written["projects"][str(repo)]["hasTrustDialogAccepted"])
+            # Second call is a no-op.
+            self.assertFalse(agent_bench.ensure_claude_workspace_trust(repo, config_path=config))
+
+    def test_ensure_claude_workspace_trust_creates_config_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            config = root / ".claude.json"
+            repo = root / "repos" / "claude-smoke"
+            repo.mkdir(parents=True)
+            self.assertTrue(agent_bench.ensure_claude_workspace_trust(repo, config_path=config))
+            written = json.loads(config.read_text(encoding="utf-8"))
+            self.assertTrue(written["projects"][str(repo)]["hasTrustDialogAccepted"])
+
+    def test_claude_plan_mirrors_app_hook_set_including_post_tool_use(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            plan = agent_bench.LaunchPlanner(
+                profile=agent_bench.load_profiles(ROOT / "profiles")["claude"],
+                scenario="approval_then_work",
+                run_dir=root,
+                resources_dir=None,
+            ).plan(
+                {
+                    "arguments": ["hello"],
+                    "environment": {"ZENTTY_REAL_BINARY": "/usr/local/bin/claude", "ZENTTY_CLI_BIN": "/tmp/zentty-bench"},
+                }
+            )
+            arguments = plan["arguments"]
+            hooks = json.loads(arguments[arguments.index("--settings") + 1])["hooks"]
+            for event in ("PostToolUse", "PostToolUseFailure"):
+                self.assertEqual([entry["matcher"] for entry in hooks[event]], [""], event)
+            self.assertEqual(
+                [entry["matcher"] for entry in hooks["PreToolUse"]],
+                ["AskUserQuestion", "Bash|Write|Edit|MultiEdit|NotebookEdit"],
+            )
+
     def test_stop_race_fixture_contains_late_notification_after_stop(self):
         fixture_path = ROOT / "fixtures" / "claude_stop_then_late_notification.jsonl"
         events = []


### PR DESCRIPTION
## What was wrong

The sidebar kept saying "Needs input" for Claude Code sessions that were clearly working, and sometimes after they had finished. I drove the agent bench through a real approval flow to see what Zentty actually receives:

```
 4.7s  PreToolUse(Write)
 4.7s  PermissionRequest(Write)      -> Needs input
10.7s  user approves
21.9s  PreToolUse(Bash)              -> first hook after the approval
23.8s  Stop
```

Eleven seconds of Write, Read and Grep with no hook at all. Zentty had three ways to learn that Claude was working again: an Enter keypress, a PreToolUse for Bash/Write/Edit, or Stop. Approve with `1` or `y`, then let Claude read files or run a subagent, and the pane stays on "Needs input" until the turn ends. If the turn gets interrupted first it never clears.

## Fix

- Register `PostToolUse` and `PostToolUseFailure` for every tool. Both map to running and clear the cached prompt. A pending prompt is tagged with its `tool_use_id`, so a sibling tool finishing in the same parallel batch leaves an open dialog alone.
- Claude parks the terminal title on `✳` while a permission or AskUserQuestion dialog is open and brings the spinner back the moment you answer. A blocked session now resumes on that `✳` to spinner flip. That covers approvals typed as `1`/`y` without waiting for the approved tool to finish.
- The title parser only knew the braille spinner; it now also recognises `◐ ◑ ◒ ◓`, which is what Claude Code 2.1 emits.

Hook cost is about 10 ms per call, so both hooks stay synchronous to keep ordering intact.

## Bench

Two things I ran into while doing this, both fixed here:

- Interactive Claude Code 2.1.261 skips every hook while workspace trust is not accepted, and it does not show the trust dialog in the bench pty. Every interactive Claude scenario was failing with missing hooks. The bench now marks its temp repo trusted in `~/.claude.json` (only `hasTrustDialogAccepted`) and prunes stale bench entries.
- The bench answers the wrapper's bootstrap with its own Python copy of the launch plan, so the Swift hook change did not reach a bench run until `_plan_claude` was updated too. A test now pins the Claude hook set.

New `approval_then_work` scenario: approve a Write, then Read and Grep, then finish. It requires `PostToolUse` between `PermissionRequest` and `Stop`. With this branch:

```
PreToolUse(Write) -> PermissionRequest -> [1] -> PostToolUse(Write) +50ms
-> PostToolUse(Read) -> PostToolUse(ToolSearch) x2 -> PreToolUse(Bash) -> PostToolUse(Bash) -> Stop
```

## Verification

- ZenttyLogicTests: 3781 tests, 0 failures. New tests replay the recorded hook sequence and the title flip, including the reverse-order race where the stale spinner title lands before the dialog title.
- Bench Python tests: 149 pass.
- Live bench with this build: `approval_then_work` and `stop_race` pass.

## Not covered

An Esc-cancelled permission prompt still sticks on "Needs input" until the next turn. Neither a hook nor a title change distinguishes it from a dialog that is still open.