### PR TITLE
fix(clipboard): respect pane width when cleaning terminal copies

### DIFF
--- a/Zentty/Terminal/CleanCopyCommandFlattening.swift
+++ b/Zentty/Terminal/CleanCopyCommandFlattening.swift
@@ -22,7 +22,8 @@ extension CleanCopyPipeline {
     static func transformMultiLineCommandIfNeeded(
         _ input: String,
         options: CleanCopyOptions,
-        lineShapeEvidence: PlainProseLineShapeEvidence? = nil
+        lineShapeEvidence: PlainProseLineShapeEvidence? = nil,
+        columns: Int? = nil
     ) -> String? {
         guard options.flattenMultiLineCommands else { return nil }
         guard input.contains("\n") else { return nil }
@@ -41,6 +42,15 @@ extension CleanCopyPipeline {
             options: .regularExpression
         ) != nil
         let hasExplicitLineJoin = hasLineContinuation || hasLineJoinerAtEOL || hasIndentedPipeline
+
+        if let columns, columns > 0, !hasExplicitLineJoin {
+            let wrapWidth = WrapWidthEvidence(input: input, columns: columns)
+            // A path or indentation alone can make terminal output look like a command.
+            // Keep deliberate short rows before this pass can erase their newlines.
+            if lines.dropLast().contains(where: { wrapWidth.endsBeforeWrapEdge(String($0)) }) {
+                return nil
+            }
+        }
 
         if lineShapeEvidence?.hasMultiplePaddedShortRows == true,
            !hasExplicitLineJoin

--- a/Zentty/Terminal/CleanCopyPipeline.swift
+++ b/Zentty/Terminal/CleanCopyPipeline.swift
@@ -18,8 +18,9 @@ enum CleanCopyPipeline {
     // MARK: - Public API
 
     /// - Parameter columns: the terminal's column count at copy time, when known.
-    ///   Lines that end well short of this width end in a real newline (libghostty
-    ///   already joins rows it soft-wrapped itself), so they are never folded.
+    ///   Short lines are evidence of deliberate newlines when reflowing prose or
+    ///   inferring wrapped commands. Explicit continuations and agent decoration
+    ///   have their own cleanup rules; libghostty already joins its soft wraps.
     static func clean(
         _ input: String,
         options: CleanCopyOptions = Self.options,
@@ -61,7 +62,8 @@ enum CleanCopyPipeline {
         if let flattened = transformMultiLineCommandIfNeeded(
             text,
             options: options,
-            lineShapeEvidence: lineShapeEvidence
+            lineShapeEvidence: lineShapeEvidence,
+            columns: columns
         ) {
             text = flattened
         }
@@ -499,18 +501,21 @@ enum CleanCopyPipeline {
 
     /// The width at which wrapped lines in this selection end. Uses the terminal's
     /// column count when the caller knows it; otherwise the longest line stands in
-    /// for it. Either way a line shorter than the width by more than one long word
-    /// ended in a real newline.
+    /// for it. Short selections must not shrink a known pane width: the unused
+    /// space is evidence that their newlines were deliberate.
     struct WrapWidthEvidence {
         let width: Int?
 
         init(input: String, columns: Int?) {
+            if let columns, columns > 0 {
+                self.width = columns
+                return
+            }
             let longest = input
                 .split(separator: "\n", omittingEmptySubsequences: true)
                 .map { $0.trimmingCharacters(in: .whitespaces).count }
                 .max() ?? 0
-            let width = min(columns ?? Int.max, longest)
-            self.width = width > 0 ? width : nil
+            self.width = longest > 0 ? longest : nil
         }
 
         /// The gap tolerated before a line counts as ending short: one long word

--- a/Zentty/Terminal/LibghosttyView.swift
+++ b/Zentty/Terminal/LibghosttyView.swift
@@ -2411,13 +2411,16 @@ final class LibghosttyView: NSView, TerminalFocusReporting, TerminalViewportDiag
         return SecondaryMouseRouting(button: GHOSTTY_MOUSE_RIGHT, behavesLikePrimarySelection: false)
     }
 
+    var terminalColumns: Int? {
+        (surfaceController as? LibghosttySurface)?.columns
+    }
+
     @IBAction func copy(_ sender: Any?) {
         if CleanCopyPipeline.shouldCleanTerminalCopyAction() {
             CleanCopyPipeline.suppressCallbackCleaning = true
             _ = surfaceController?.performBindingAction(TerminalBindingAction.copyToClipboard)
             CleanCopyPipeline.suppressCallbackCleaning = false
-            let columns = (surfaceController as? LibghosttySurface)?.columns
-            let result = CleanCopyPipeline.cleanPasteboardInPlace(.general, columns: columns)
+            let result = CleanCopyPipeline.cleanPasteboardInPlace(.general, columns: terminalColumns)
             if result?.wasModified == true {
                 NotificationCenter.default.post(name: .cleanCopyDidModifyPasteboard, object: nil)
             }

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -1847,6 +1847,9 @@ final class RootViewController: NSViewController {
     }
 
     private func performCleanCopy() {
+        // Resolve the copy recipient so text fields don't inherit the active pane's width.
+        let copyTarget = NSApp.target(forAction: #selector(NSText.copy(_:)))
+        let columns = (copyTarget as? LibghosttyView)?.terminalColumns
         // Suppress callback cleaning — we clean at this call site instead.
         // Safe because ghostty_surface_binding_action is a synchronous C FFI call:
         // the clipboard write callback fires within performBindingAction before
@@ -1855,7 +1858,7 @@ final class RootViewController: NSViewController {
         NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
         CleanCopyPipeline.suppressCallbackCleaning = false
 
-        let result = CleanCopyPipeline.cleanPasteboardInPlace(.general)
+        let result = CleanCopyPipeline.cleanPasteboardInPlace(.general, columns: columns)
         let message = (result?.wasModified == true) ? "Copied (cleaned)" : "Copied"
         showCopyToast(message: message)
     }

--- a/ZenttyLogicTests/CleanCopyCommandFlatteningTests.swift
+++ b/ZenttyLogicTests/CleanCopyCommandFlatteningTests.swift
@@ -123,6 +123,21 @@ final class CleanCopyCommandFlatteningTests: XCTestCase {
         XCTAssertEqual(result.text, "git push origin feature/login-flow --force")
     }
 
+    func test_clean_preserves_short_output_with_path_in_a_wide_pane() {
+        let input = "Loaded configuration from config/server.yaml\n  (waiting for incoming connections)"
+
+        XCTAssertEqual(CleanCopyPipeline.clean(input, columns: 160).text, input)
+    }
+
+    func test_clean_still_flattens_explicit_pipeline_in_a_wide_pane() {
+        let input = "git log --oneline |\n  head -n 5"
+
+        XCTAssertEqual(
+            CleanCopyPipeline.clean(input, columns: 160).text,
+            "git log --oneline | head -n 5"
+        )
+    }
+
     private func padded(_ line: String, width: Int = 100) -> String {
         line + String(repeating: " ", count: max(0, width - line.count))
     }

--- a/ZenttyLogicTests/CleanCopyPipelineTests.swift
+++ b/ZenttyLogicTests/CleanCopyPipelineTests.swift
@@ -625,6 +625,54 @@ final class CleanCopyPipelineTests: XCTestCase {
         )
     }
 
+    func test_pipeline_preserves_short_terminal_output_in_a_wide_pane() {
+        let input = """
+        The service finished checking all configured connections successfully.
+        Another status message follows on its own deliberately separate line.
+        """
+
+        let result = CleanCopyPipeline.clean(input, columns: 160)
+        XCTAssertEqual(result.text, input)
+        XCTAssertFalse(result.wasModified)
+        // The same text close to the edge remains a candidate for prose reflow.
+        XCTAssertEqual(
+            CleanCopyPipeline.clean(input, columns: 80).text,
+            input.replacingOccurrences(of: "\n", with: " ")
+        )
+    }
+
+    func test_pipeline_ignores_invalid_terminal_width() {
+        let input = """
+        The service finished checking all configured connections successfully.
+        Another status message follows on its own deliberately separate line.
+        """
+        for columns in [0, -1] {
+            XCTAssertEqual(
+                CleanCopyPipeline.clean(input, columns: columns),
+                CleanCopyPipeline.clean(input)
+            )
+        }
+    }
+
+    func test_pipeline_still_flattens_explicit_command_continuations_in_a_wide_pane() {
+        let input = "curl https://example.com/api \\\n  --fail \\\n  --silent"
+        XCTAssertEqual(
+            CleanCopyPipeline.clean(input, columns: 160).text,
+            "curl https://example.com/api --fail --silent"
+        )
+    }
+
+    func test_pipeline_still_reflows_agent_message_in_a_wide_pane() {
+        let input = """
+        ⏺ The service finished checking all configured connections successfully
+          and is ready to accept new requests.
+        """
+        XCTAssertEqual(
+            CleanCopyPipeline.clean(input, columns: 160).text,
+            "The service finished checking all configured connections successfully and is ready to accept new requests."
+        )
+    }
+
     func test_pipeline_uses_longest_line_as_wrap_width_when_columns_are_unknown() {
         // Longest line is 62 chars; the other two stop well before that, so
         // both newlines are real even though nothing here looks structured.


### PR DESCRIPTION
Clean Copy could merge deliberately separate terminal lines even when they stopped far short of the pane edge. The width heuristic capped the pane width at the longest selected line, and explicit Clean Copy did not pass the terminal width at all.

Use the actual terminal column count when available, resolve the copy recipient for explicit Clean Copy, and apply the width guard before command cleanup can erase newlines. Keep the existing fallback when width is unknown and preserve explicit shell continuations and agent-message cleanup.

Validation: reproduced both incorrect merging cases with failing regression tests, then passed all 179 clean-copy, command-flattening, and URL tests through the virtual-display harness. `git diff --check` passed. Live copy routing was not manually exercised.
