### PR TITLE
feat(pane): copy ssh connection instead of path for remote panes

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		C57DE7B45F0BEFFDC8EC7371 /* MenuBarStatusPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6996377692DF2C92D7428A5 /* MenuBarStatusPillView.swift */; };
 		C5873608D623BCF0F56FADD2 /* HermesEventAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9BDBFAF4FD6C6BA172731D /* HermesEventAdapter.swift */; };
 		C6172682FC0925AEB869BAE8 /* SettingsDetailContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E1D70DC92F5918033D26D /* SettingsDetailContainerViewController.swift */; };
+		C6DC3C8DBF31DE43DBE58445 /* PaneCopyTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AF078000EB0DB28D1C23F5 /* PaneCopyTargetResolverTests.swift */; };
 		C6FC32D748BD8642629B7321 /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C749B84F3DFA56E1241551D1 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A00B46795D7A242D2C9107 /* SettingsWindowController.swift */; };
 		C7E03A7F4908AC8B2713A19B /* SidebarVisibilityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163D5C0FE862CC71E8B354E2 /* SidebarVisibilityController.swift */; };
@@ -500,6 +501,7 @@
 		CEDAF9621D24A72064947A90 /* SidebarDropPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */; };
 		CEE6C654BA6B3D3F6FCFCAE2 /* PaneFocusHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CE6484C3A7D0F443F1FF10 /* PaneFocusHistoryController.swift */; };
 		CF13A269F19FE08C54099974 /* MenuBarStatusPillViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A01AB73197CAAE9E3D77A0 /* MenuBarStatusPillViewTests.swift */; };
+		CFEC25BEE8B4D5F2EAABA355 /* PaneCopyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FDC5EDD20974ABB71D7C8E /* PaneCopyTarget.swift */; };
 		D089F5366F16515499AD92E4 /* TmuxFormatRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8595DD2E83A66FAD57B960 /* TmuxFormatRendererTests.swift */; };
 		D11DCA299BC0C937EAED0001 /* PaneSplitBehaviorOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7137F467A63630BC5D08A61 /* PaneSplitBehaviorOptionView.swift */; };
 		D1563C751D1009F259B1BB08 /* PaneLayoutMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F4CE288A07931095E26D13 /* PaneLayoutMenuCoordinator.swift */; };
@@ -560,6 +562,7 @@
 		E6D0CAB78E81B81367E2F583 /* AgentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEEE6EDBC73B9A55E684093 /* AgentStatus.swift */; };
 		E6DB3D37929BDB0F6583E0E5 /* OpenWithCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19801FEA1E31AE1665776372 /* OpenWithCatalog.swift */; };
 		E7AF4214CD5B4B304CD0AB12 /* SidebarCreateWorklaneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51D9EBCFFBCD584611F064 /* SidebarCreateWorklaneButton.swift */; };
+		E80ADCAAD028AACCF2414C1C /* PaneSSHDestinationResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3E291B743D66D2A5474B10 /* PaneSSHDestinationResolver.swift */; };
 		E89B19464162224F2C5AC2BD /* ThemeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BFAD9337055E61275E0F7D /* ThemeCoordinatorTests.swift */; };
 		E94E1DACAFBCE24E8AA485C5 /* SidebarShimmerColorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7F2B3A458136A7651CA4BA /* SidebarShimmerColorResolver.swift */; };
 		E95C4FC6740D1885397423A2 /* ServerIPCCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0633B563FD38C6FAF61062 /* ServerIPCCommands.swift */; };
@@ -1110,6 +1113,7 @@
 		BFF869D6D306AFE18589C8CF /* WorklaneStoreTeamAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreTeamAnchorTests.swift; sourceTree = "<group>"; };
 		C15A14BDE2EEBB8C5AA0F3DD /* TmuxCompatCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatCLITests.swift; sourceTree = "<group>"; };
 		C18B2FF6F681F4948B49A9FE /* CodexEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexEventAdapter.swift; sourceTree = "<group>"; };
+		C1FDC5EDD20974ABB71D7C8E /* PaneCopyTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCopyTarget.swift; sourceTree = "<group>"; };
 		C222FA689B8B7C8E932BE43D /* WindowChromeCenteringInterleavingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeCenteringInterleavingTests.swift; sourceTree = "<group>"; };
 		C2671C2153DB1DFA70522E94 /* LibghosttyAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyAdapterTests.swift; sourceTree = "<group>"; };
 		C2DAA76C6247F60AA55ACB5D /* SidebarUpdateRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarUpdateRowTests.swift; sourceTree = "<group>"; };
@@ -1237,6 +1241,7 @@
 		F557AF9F9BF4989153692316 /* SidebarViewChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewChrome.swift; sourceTree = "<group>"; };
 		F564EFD678FB31CE540FBDEE /* AgentEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEventBridgeTests.swift; sourceTree = "<group>"; };
 		F56A80724E5ABFBF4B39D945 /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
+		F5AF078000EB0DB28D1C23F5 /* PaneCopyTargetResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCopyTargetResolverTests.swift; sourceTree = "<group>"; };
 		F5FB4A13C3399DF51323778E /* WorklanePeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklanePeekView.swift; sourceTree = "<group>"; };
 		F876089DABC0460791806F3E /* PaneDragHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragHitTesting.swift; sourceTree = "<group>"; };
 		F9FCFF921453188C98C2AC4D /* TmuxCompatPaneContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatPaneContextTests.swift; sourceTree = "<group>"; };
@@ -1256,6 +1261,7 @@
 		FE03606CCDB80BACDE1EB39E /* URLQueryParamRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLQueryParamRules.swift; sourceTree = "<group>"; };
 		FE8E85EADB93A2FE0E71BEA6 /* TerminalPaneHostViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneHostViewTests.swift; sourceTree = "<group>"; };
 		FEFFC2CAEA605772B62E73E5 /* PaneStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStripView.swift; sourceTree = "<group>"; };
+		FF3E291B743D66D2A5474B10 /* PaneSSHDestinationResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSSHDestinationResolver.swift; sourceTree = "<group>"; };
 		FFA39255E836211E35CAFF5F /* WorklaneState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneState+Testing.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1366,6 +1372,7 @@
 				E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */,
 				9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */,
 				E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */,
+				C1FDC5EDD20974ABB71D7C8E /* PaneCopyTarget.swift */,
 				BC039C620770B29A8DC711C1 /* PaneDisplayIdentityResolver.swift */,
 				54894343178398AA618315E4 /* PaneFocusHistory.swift */,
 				41CE6484C3A7D0F443F1FF10 /* PaneFocusHistoryController.swift */,
@@ -1849,6 +1856,7 @@
 				50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */,
 				E85888C3C5FE4E110531EBC8 /* MarkdownReformatter.swift */,
 				765B5594B1CFDD53C4A7C00B /* MockTerminalAdapter.swift */,
+				FF3E291B743D66D2A5474B10 /* PaneSSHDestinationResolver.swift */,
 				4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */,
 				D7B504722337DBCB03722FD8 /* RemoteFileUploadRequest.swift */,
 				457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */,
@@ -2141,6 +2149,7 @@
 				61A8FD7688E72C2B2A8099EE /* PaneCommandExecutorTests.swift */,
 				37F4631D0A8465D807F16977 /* PaneContainerViewTests.swift */,
 				D468A4AAC25D668673CC51CE /* PaneContainerViewWorklaneBorderTests.swift */,
+				F5AF078000EB0DB28D1C23F5 /* PaneCopyTargetResolverTests.swift */,
 				9EA2D0CE5BE10DFD7CDB4CBC /* PaneDisplayIdentityResolverTests.swift */,
 				7F6BDCBDE4E090275233D9D3 /* PaneDragHitTestingTests.swift */,
 				286127859CC1D0E1D6E24ECE /* PaneDragPreviewSizingTests.swift */,
@@ -2585,6 +2594,7 @@
 				4B0C3768E3A6A13ACC424E7A /* PaneCommandExecutorTests.swift in Sources */,
 				9305DFB3157057C5F774497D /* PaneContainerViewTests.swift in Sources */,
 				BB1BCADC002057CB2A8211ED /* PaneContainerViewWorklaneBorderTests.swift in Sources */,
+				C6DC3C8DBF31DE43DBE58445 /* PaneCopyTargetResolverTests.swift in Sources */,
 				CD53494A66CC5B4B0CDF23BA /* PaneDisplayIdentityResolverTests.swift in Sources */,
 				81AF86AEEA79AD53667ECBE3 /* PaneDragHitTestingTests.swift in Sources */,
 				A7D1705788C04A62E0EC684C /* PaneDragPreviewSizingTests.swift in Sources */,
@@ -2877,6 +2887,7 @@
 				4777880E60AB7C29B7CD2E12 /* PaneCommand.swift in Sources */,
 				C5472B502864FDAF36E08684 /* PaneCommandExecutor.swift in Sources */,
 				3F270AD6399CAA5729853F2D /* PaneContainerView.swift in Sources */,
+				CFEC25BEE8B4D5F2EAABA355 /* PaneCopyTarget.swift in Sources */,
 				48ECF9EAFA83C8B95CB644E3 /* PaneDisplayIdentityResolver.swift in Sources */,
 				624B1BB94834F08B1F75C877 /* PaneDragCoordinator.swift in Sources */,
 				65ADCFA85CAA56E91E14C014 /* PaneDragEdgeScrollDriver.swift in Sources */,
@@ -2899,6 +2910,7 @@
 				4BB0E4171C495664EF0324FE /* PaneNavigationButtons.swift in Sources */,
 				7C269AA7741BA793A8DD4BD7 /* PaneNotificationCoordinator.swift in Sources */,
 				8D4C37D86BAA9B1B23DF164B /* PaneRestorationBuilder.swift in Sources */,
+				E80ADCAAD028AACCF2414C1C /* PaneSSHDestinationResolver.swift in Sources */,
 				A3DF172F7DBD4AD8B215E680 /* PaneSSHProcessProbe.swift in Sources */,
 				731E192A944AF30FB531F314 /* PaneSearchHUDView.swift in Sources */,
 				13A456B3644AB1AA586D10E9 /* PaneShellContext.swift in Sources */,

--- a/Zentty/AppState/PaneCopyTarget.swift
+++ b/Zentty/AppState/PaneCopyTarget.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// What "Copy Path" puts on the pasteboard for a pane.
+///
+/// A local pane copies its working directory. A remote pane copies the SSH
+/// command that reaches it instead, because the remote path is rarely useful
+/// on the local machine while `ssh user@host` is exactly what you want to
+/// paste into another terminal.
+enum PaneCopyTarget: Equatable, Sendable {
+    case path(String)
+    case sshConnection(String)
+
+    var pasteboardString: String {
+        switch self {
+        case .path(let value), .sshConnection(let value):
+            return value
+        }
+    }
+
+    var copiedToastMessage: String {
+        switch self {
+        case .path:
+            return "Path copied"
+        case .sshConnection:
+            return "Connection copied"
+        }
+    }
+
+    var commandPaletteSubtitle: String {
+        switch self {
+        case .path(let path):
+            return "Copy Path — \(path)"
+        case .sshConnection(let command):
+            return "Copy Connection — \(command)"
+        }
+    }
+}
+
+enum PaneCopyTargetResolver {
+    static func target(for auxiliaryState: PaneAuxiliaryState) -> PaneCopyTarget? {
+        if auxiliaryState.presentation.isRemotePane,
+           let destination = PaneSSHDestinationResolver.destination(from: auxiliaryState) {
+            return .sshConnection(destination.sshCommand)
+        }
+
+        guard let path = WorklaneContextFormatter.trimmed(auxiliaryState.shellContext?.path) else {
+            return nil
+        }
+
+        return .path(path)
+    }
+}
+
+extension SSHDestination {
+    /// The shortest `ssh` invocation that reconnects to this destination.
+    var sshCommand: String {
+        var parts = ["ssh"]
+        if let port {
+            parts += ["-p", String(port)]
+        }
+        parts.append(target)
+        return parts.joined(separator: " ")
+    }
+}

--- a/Zentty/Terminal/PaneSSHDestinationResolver.swift
+++ b/Zentty/Terminal/PaneSSHDestinationResolver.swift
@@ -1,0 +1,35 @@
+/// Resolves the SSH destination a pane is currently talking to.
+///
+/// Sources, in priority order: the live `ssh` process found by the
+/// foreground probe, the pane's `ssh ...` command title, the inferred
+/// connection label, and finally the remote shell-integration context.
+/// Shared by remote image paste and "Copy Path" on remote panes.
+enum PaneSSHDestinationResolver {
+    static func destination(from auxiliaryState: PaneAuxiliaryState) -> SSHDestination? {
+        if let destination = auxiliaryState.raw.foregroundSSHDestination {
+            return destination
+        }
+
+        if let title = WorklaneContextFormatter.trimmed(auxiliaryState.raw.metadata?.title),
+           let destination = WorklaneContextFormatter.sshDestination(fromCommandTitle: title) {
+            return destination
+        }
+
+        if let label = WorklaneContextFormatter.trimmed(auxiliaryState.presentation.sshConnectionLabel) {
+            return SSHDestination(target: label)
+        }
+
+        if let shellContext = auxiliaryState.raw.shellContext,
+           shellContext.scope == .remote,
+           let host = WorklaneContextFormatter.trimmed(shellContext.host) {
+            let user = WorklaneContextFormatter.trimmed(shellContext.user)
+            return SSHDestination(
+                target: user.map { "\($0)@\(host)" } ?? host,
+                user: user,
+                host: host
+            )
+        }
+
+        return nil
+    }
+}

--- a/Zentty/Terminal/RemoteImagePasteDecision.swift
+++ b/Zentty/Terminal/RemoteImagePasteDecision.swift
@@ -20,36 +20,6 @@ struct RemoteImagePastePaneState: Equatable, Sendable {
     let destination: SSHDestination?
 }
 
-enum RemoteImagePasteDestination {
-    static func destination(from auxiliaryState: PaneAuxiliaryState) -> SSHDestination? {
-        if let destination = auxiliaryState.raw.foregroundSSHDestination {
-            return destination
-        }
-
-        if let title = WorklaneContextFormatter.trimmed(auxiliaryState.raw.metadata?.title),
-           let destination = WorklaneContextFormatter.sshDestination(fromCommandTitle: title) {
-            return destination
-        }
-
-        if let label = WorklaneContextFormatter.trimmed(auxiliaryState.presentation.sshConnectionLabel) {
-            return SSHDestination(target: label)
-        }
-
-        if let shellContext = auxiliaryState.raw.shellContext,
-           shellContext.scope == .remote,
-           let host = WorklaneContextFormatter.trimmed(shellContext.host) {
-            let user = WorklaneContextFormatter.trimmed(shellContext.user)
-            return SSHDestination(
-                target: user.map { "\($0)@\(host)" } ?? host,
-                user: user,
-                host: host
-            )
-        }
-
-        return nil
-    }
-}
-
 enum RemoteImagePasteDecision {
     static func shouldUploadRemotely(
         paneState: RemoteImagePastePaneState,

--- a/Zentty/UI/CommandPalette/CommandPaletteController.swift
+++ b/Zentty/UI/CommandPalette/CommandPaletteController.swift
@@ -32,6 +32,7 @@ final class CommandPaletteController {
         shortcutManager: ShortcutManager,
         availabilityContext: CommandAvailabilityContext,
         focusedPanePath: String?,
+        focusedPaneCopyTarget: PaneCopyTarget? = nil,
         focusedBranchName: String?,
         focusedRestoredCommand: String? = nil,
         worklanes: [WorklaneState] = [],
@@ -56,6 +57,7 @@ final class CommandPaletteController {
             availableCommandIDs: availableIDs,
             shortcutManager: shortcutManager,
             focusedPanePath: focusedPanePath,
+            focusedPaneCopyTarget: focusedPaneCopyTarget,
             focusedBranchName: focusedBranchName,
             rightPaneCommandPresentation: rightPaneCommandPresentation
         )

--- a/Zentty/UI/CommandPalette/CommandPaletteItem.swift
+++ b/Zentty/UI/CommandPalette/CommandPaletteItem.swift
@@ -120,6 +120,7 @@ enum CommandPaletteItemBuilder {
         availableCommandIDs: Set<AppCommandID>,
         shortcutManager: ShortcutManager,
         focusedPanePath: String? = nil,
+        focusedPaneCopyTarget: PaneCopyTarget? = nil,
         focusedBranchName: String? = nil,
         rightPaneCommandPresentation: PaneRightCommandPresentation = .addsToWorklane
     ) -> [CommandPaletteItem] {
@@ -134,7 +135,7 @@ enum CommandPaletteItemBuilder {
             )
             let subtitle = enrichedSubtitle(
                 for: definition,
-                focusedPanePath: focusedPanePath,
+                focusedPaneCopyTarget: focusedPaneCopyTarget ?? focusedPanePath.map(PaneCopyTarget.path),
                 focusedBranchName: focusedBranchName,
                 rightPaneCommandPresentation: rightPaneCommandPresentation
             )
@@ -400,7 +401,7 @@ enum CommandPaletteItemBuilder {
 
     private static func enrichedSubtitle(
         for definition: AppCommandDefinition,
-        focusedPanePath: String?,
+        focusedPaneCopyTarget: PaneCopyTarget?,
         focusedBranchName: String?,
         rightPaneCommandPresentation: PaneRightCommandPresentation
     ) -> String {
@@ -410,10 +411,10 @@ enum CommandPaletteItemBuilder {
 
         switch definition.id {
         case .copyFocusedPanePath:
-            guard let path = focusedPanePath else {
+            guard let focusedPaneCopyTarget else {
                 return definition.detailDescription
             }
-            return "Copy Path — \(path)"
+            return focusedPaneCopyTarget.commandPaletteSubtitle
         case .openBranchOnRemote:
             guard let focusedBranchName, focusedBranchName.isEmpty == false else {
                 return definition.detailDescription

--- a/Zentty/UI/RemotePaste/RemoteImagePasteController.swift
+++ b/Zentty/UI/RemotePaste/RemoteImagePasteController.swift
@@ -363,7 +363,7 @@ final class RemoteImagePasteController {
     }
 
     private func remoteImageDestination(from auxiliaryState: PaneAuxiliaryState) -> SSHDestination? {
-        RemoteImagePasteDestination.destination(from: auxiliaryState)
+        PaneSSHDestinationResolver.destination(from: auxiliaryState)
     }
 
     func cancelAll() {

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -1641,6 +1641,11 @@ final class RootViewController: NSViewController {
             guard let paneID = activeWorklane?.paneStripState.focusedPaneID else { return nil }
             return activeWorklane?.auxiliaryStateByPaneID[paneID]?.shellContext?.path
         }()
+        let focusedPaneCopyTarget: PaneCopyTarget? = {
+            guard let paneID = activeWorklane?.paneStripState.focusedPaneID,
+                  let auxiliaryState = activeWorklane?.auxiliaryStateByPaneID[paneID] else { return nil }
+            return PaneCopyTargetResolver.target(for: auxiliaryState)
+        }()
         let focusedRestoredCommand: String? = {
             guard let paneID = activeWorklane?.paneStripState.focusedPaneID else { return nil }
             return worklaneStore.restoredRerunnableCommand(for: paneID)
@@ -1668,6 +1673,7 @@ final class RootViewController: NSViewController {
             shortcutManager: shortcutManager,
             availabilityContext: availabilityContext,
             focusedPanePath: focusedPanePath,
+            focusedPaneCopyTarget: focusedPaneCopyTarget,
             focusedBranchName: focusedBranchName,
             focusedRestoredCommand: focusedRestoredCommand,
             worklanes: worklaneStore.worklanes,
@@ -1830,20 +1836,15 @@ final class RootViewController: NSViewController {
 
     private func copyPath(forPaneID paneID: PaneID) {
         guard
-            let path = worklaneStore.activeWorklane?.auxiliaryStateByPaneID[paneID]?.shellContext?
-                .path,
-            !path.isEmpty
+            let auxiliaryState = worklaneStore.activeWorklane?.auxiliaryStateByPaneID[paneID],
+            let target = PaneCopyTargetResolver.target(for: auxiliaryState)
         else {
             return
         }
 
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(path, forType: .string)
-        showPathCopiedToast()
-    }
-
-    private func showPathCopiedToast() {
-        showToast(message: "Path copied")
+        NSPasteboard.general.setString(target.pasteboardString, forType: .string)
+        showToast(message: target.copiedToastMessage)
     }
 
     private func performCleanCopy() {

--- a/ZenttyLogicTests/PaneCopyTargetResolverTests.swift
+++ b/ZenttyLogicTests/PaneCopyTargetResolverTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Zentty
+
+final class PaneCopyTargetResolverTests: XCTestCase {
+    func test_local_pane_copies_working_directory() {
+        let shellContext = PaneShellContext(
+            scope: .local,
+            path: "/Users/peter/Development/zentty",
+            home: "/Users/peter",
+            user: "peter",
+            host: "mbp"
+        )
+        let auxiliaryState = makeAuxiliaryState(raw: PaneRawState(shellContext: shellContext), title: "zsh")
+
+        XCTAssertEqual(
+            PaneCopyTargetResolver.target(for: auxiliaryState),
+            .path("/Users/peter/Development/zentty")
+        )
+    }
+
+    func test_local_pane_without_path_has_nothing_to_copy() {
+        let auxiliaryState = makeAuxiliaryState(raw: PaneRawState(), title: "zsh")
+
+        XCTAssertNil(PaneCopyTargetResolver.target(for: auxiliaryState))
+    }
+
+    func test_remote_shell_context_copies_ssh_command_instead_of_remote_path() {
+        let shellContext = PaneShellContext(
+            scope: .remote,
+            path: "/srv/app",
+            home: "/home/peter",
+            user: "peter",
+            host: "prod-box"
+        )
+        let auxiliaryState = makeAuxiliaryState(raw: PaneRawState(shellContext: shellContext), title: "zsh")
+
+        XCTAssertEqual(
+            PaneCopyTargetResolver.target(for: auxiliaryState),
+            .sshConnection("ssh peter@prod-box")
+        )
+    }
+
+    func test_foreground_ssh_process_wins_and_keeps_port() {
+        let raw = PaneRawState(
+            metadata: TerminalMetadata(title: "ssh stale@example.test", processName: "ssh"),
+            shellContext: PaneShellContext(
+                scope: .local,
+                path: "/Users/peter",
+                home: "/Users/peter",
+                user: "peter",
+                host: "mbp"
+            ),
+            foregroundSSHDestination: SSHDestination(
+                target: "peter@live.example.test",
+                user: "peter",
+                host: "live.example.test",
+                port: 2222
+            )
+        )
+        let auxiliaryState = makeAuxiliaryState(raw: raw, title: "ssh stale@example.test")
+
+        XCTAssertEqual(
+            PaneCopyTargetResolver.target(for: auxiliaryState),
+            .sshConnection("ssh -p 2222 peter@live.example.test")
+        )
+    }
+
+    func test_ssh_command_title_without_probe_copies_parsed_destination() {
+        let raw = PaneRawState(
+            metadata: TerminalMetadata(title: "ssh -p 2200 deploy@example.test", processName: "ssh"),
+            foregroundSSHDestination: nil
+        )
+        let auxiliaryState = makeAuxiliaryState(raw: raw, title: "ssh -p 2200 deploy@example.test")
+
+        XCTAssertEqual(
+            PaneCopyTargetResolver.target(for: auxiliaryState),
+            .sshConnection("ssh -p 2200 deploy@example.test")
+        )
+    }
+
+    func test_copy_target_presentation_strings() {
+        XCTAssertEqual(PaneCopyTarget.path("/tmp").pasteboardString, "/tmp")
+        XCTAssertEqual(PaneCopyTarget.path("/tmp").copiedToastMessage, "Path copied")
+        XCTAssertEqual(PaneCopyTarget.path("/tmp").commandPaletteSubtitle, "Copy Path — /tmp")
+
+        let connection = PaneCopyTarget.sshConnection("ssh peter@prod-box")
+        XCTAssertEqual(connection.pasteboardString, "ssh peter@prod-box")
+        XCTAssertEqual(connection.copiedToastMessage, "Connection copied")
+        XCTAssertEqual(connection.commandPaletteSubtitle, "Copy Connection — ssh peter@prod-box")
+    }
+
+    func test_command_palette_subtitle_uses_copy_target_over_path() throws {
+        let items = CommandPaletteItemBuilder.buildItems(
+            availableCommandIDs: [.copyFocusedPanePath],
+            shortcutManager: ShortcutManager(shortcuts: .default),
+            focusedPanePath: "/srv/app",
+            focusedPaneCopyTarget: .sshConnection("ssh peter@prod-box")
+        )
+        let item = try XCTUnwrap(items.first { $0.id == .command(.copyFocusedPanePath) })
+
+        XCTAssertEqual(item.subtitle, "Copy Connection — ssh peter@prod-box")
+    }
+
+    private func makeAuxiliaryState(raw: PaneRawState, title: String) -> PaneAuxiliaryState {
+        PaneAuxiliaryState(
+            raw: raw,
+            presentation: PanePresentationNormalizer.normalize(paneTitle: title, raw: raw, previous: nil)
+        )
+    }
+}

--- a/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
+++ b/ZenttyLogicTests/RemoteImagePasteDecisionTests.swift
@@ -19,7 +19,7 @@ final class RemoteImagePasteDecisionTests: XCTestCase {
             )
         )
 
-        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+        let destination = try XCTUnwrap(PaneSSHDestinationResolver.destination(from: auxiliaryState))
         XCTAssertEqual(destination.target, "peter@prod-box")
         XCTAssertEqual(destination.user, "peter")
         XCTAssertEqual(destination.host, "prod-box")
@@ -45,7 +45,7 @@ final class RemoteImagePasteDecisionTests: XCTestCase {
             )
         )
 
-        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+        let destination = try XCTUnwrap(PaneSSHDestinationResolver.destination(from: auxiliaryState))
 
         XCTAssertEqual(destination.target, "peter@live.example.test")
         XCTAssertEqual(destination.user, "peter")
@@ -67,7 +67,7 @@ final class RemoteImagePasteDecisionTests: XCTestCase {
             )
         )
 
-        let destination = try XCTUnwrap(RemoteImagePasteDestination.destination(from: auxiliaryState))
+        let destination = try XCTUnwrap(PaneSSHDestinationResolver.destination(from: auxiliaryState))
 
         XCTAssertEqual(destination.target, "stale@example.test")
         XCTAssertEqual(destination.user, "stale")
@@ -114,7 +114,7 @@ final class RemoteImagePasteDecisionTests: XCTestCase {
         )
         let paneState = RemoteImagePastePaneState(
             isRemotePane: presentation.isRemotePane,
-            destination: RemoteImagePasteDestination.destination(
+            destination: PaneSSHDestinationResolver.destination(
                 from: PaneAuxiliaryState(raw: raw, presentation: presentation)
             )
         )


### PR DESCRIPTION
When a pane is inside an ssh session, the remote working directory is rarely what you want on the local clipboard. What you want is the thing that gets you back there.

Copy Path on a remote pane now copies `ssh user@host` (with `-p PORT` when the session uses one). Local panes still copy their working directory.

How the destination is picked, in order:

1. the live `ssh` process the foreground probe already tracks, so `ssh prod` copies as `ssh prod` and not an expanded form
2. the pane's `ssh ...` command title
3. the inferred connection label
4. the remote shell-integration host and user

This is the same chain remote image paste uses. That resolver moved into its own file and got a name that fits both callers.

The toast says "Connection copied" or "Path copied", and the command palette subtitle shows the exact string that will land on the pasteboard.

Not covered: jump hosts and other ssh flags are dropped, since the probe parser only keeps user, host and port. The pane border chip tooltip still reads "Copy Path" on remote panes.

Tests: seven new cases in `PaneCopyTargetResolverTests`. Full ZenttyLogicTests run is green (3885 tests).