### PR TITLE
feat(ui): name the pane and its process in close confirmations

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		65ADCFA85CAA56E91E14C014 /* PaneDragEdgeScrollDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC113A53E86E67BCA330D9A /* PaneDragEdgeScrollDriver.swift */; };
 		65C0729CCCDB639440DD90EF /* WindowChromeCenteringInterleavingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C222FA689B8B7C8E932BE43D /* WindowChromeCenteringInterleavingTests.swift */; };
 		65C5388D0DFD8FB84B5FCD14 /* AppConfigTOML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C38CE6BD2D5F5D24B1B7FE /* AppConfigTOML.swift */; };
+		65F7A5CB3F1EF2571AADB53F /* CloseConfirmationCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FB8F60EA767D7F7E3C4E2F /* CloseConfirmationCopy.swift */; };
 		661F1B3E5187816B392E2100 /* CommandAvailabilityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5788E143BDA3D1DF37882 /* CommandAvailabilityResolver.swift */; };
 		667A04C8CFE0127371DF68C6 /* BookmarksPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483D9BCEB73BBB83700BF024 /* BookmarksPopoverViewModel.swift */; };
 		66C08CF2772217FE3A796ECB /* ServerBrowserSettingsIgnoredPortsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCFE97B9537DD8EE7B91BB14 /* ServerBrowserSettingsIgnoredPortsTests.swift */; };
@@ -323,6 +324,7 @@
 		852D3A257A4577222F2B329E /* TerminalScrollFrameSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6575E65B3E99957183F02B /* TerminalScrollFrameSamplerTests.swift */; };
 		8553A4E49623C76F26D166F5 /* AgentStatusCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C0293DF0B4BA096A6646CC /* AgentStatusCenter.swift */; };
 		858BC8739A32EF3A0240EF81 /* OpenWithService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373831CBF716D9C9497FE53 /* OpenWithService.swift */; };
+		85AA36B075A627B684DA8C88 /* CloseConfirmationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE5397C365594A855625BE1 /* CloseConfirmationContext.swift */; };
 		860CBB896950670C3BD5842A /* ServerOutputURLDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087C2ACC1BD5F24FD8F5A39F /* ServerOutputURLDetector.swift */; };
 		863C32186E18155D92C16E25 /* TaskManagerPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664E62FC352B56CA7B035AC1 /* TaskManagerPresentationTests.swift */; };
 		865B982474BFB184B68A8544 /* SidebarViewRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A862FA7C8BA94CEE8A5237 /* SidebarViewRenderTests.swift */; };
@@ -457,6 +459,7 @@
 		BF98C820ECF82C8A5810259F /* CursorHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A07AF51FBC28C9CC07ABA /* CursorHooksInstaller.swift */; };
 		C01A739643B858C0F3A69C88 /* PaneStripMotionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6261C82AADF1EDAAA09BC9 /* PaneStripMotionController.swift */; };
 		C02A4C3BC63E5516FBCF2DEA /* SidebarPanePrimaryRowViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F99D1FE29FEEA09DDD823A /* SidebarPanePrimaryRowViewTests.swift */; };
+		C0345B22CCE90E84F6CBA252 /* CloseConfirmationContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA310007A676CA2214DD81F7 /* CloseConfirmationContextTests.swift */; };
 		C038C6FB8A7F9335CC3AFB1A /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C5CDA1B0A63C72FE9048F9 /* AboutViewController.swift */; };
 		C0581A87CA13EF4A6DE2E5D0 /* GlobalSearchFocusChoreographer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6786CCBB776BDFA10AD59873 /* GlobalSearchFocusChoreographer.swift */; };
 		C0D977BB8AC73437601103F0 /* CommandFlattenAggressiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DB8F94BDF5915567FD8FE9 /* CommandFlattenAggressiveness.swift */; };
@@ -1059,6 +1062,7 @@
 		A8A1D79CA942A2AC09A2981D /* TerminalViewportDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewportDiagnostics.swift; sourceTree = "<group>"; };
 		A8BBED34BE061909F63C315D /* CopilotEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotEventAdapter.swift; sourceTree = "<group>"; };
 		A9D0A8D1F663DD3E708212FD /* WorklanePeekSelectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklanePeekSelectionStateTests.swift; sourceTree = "<group>"; };
+		AAE5397C365594A855625BE1 /* CloseConfirmationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseConfirmationContext.swift; sourceTree = "<group>"; };
 		AAEEA79E63463D7882B80FE0 /* SessionRestoreStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestoreStore.swift; sourceTree = "<group>"; };
 		AAEEE6EDBC73B9A55E684093 /* AgentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatus.swift; sourceTree = "<group>"; };
 		AB2D48FA0772881220D4EFED /* PaneDropResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropResolver.swift; sourceTree = "<group>"; };
@@ -1180,6 +1184,7 @@
 		D95ED44A37CDE51882628D20 /* GlobalSearchFocusChoreographerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchFocusChoreographerTests.swift; sourceTree = "<group>"; };
 		D99E1E58109E4888F6925F30 /* MenuBarStatusPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPalette.swift; sourceTree = "<group>"; };
 		D9C47104BD130C28676BA079 /* SparkleAppUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleAppUpdateController.swift; sourceTree = "<group>"; };
+		DA310007A676CA2214DD81F7 /* CloseConfirmationContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseConfirmationContextTests.swift; sourceTree = "<group>"; };
 		DAA052B6DDCA1EE9D9F58BC0 /* PaneLayoutPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutPreferencesTests.swift; sourceTree = "<group>"; };
 		DB7A0155A7517D3459081223 /* TmuxCompatStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatStoreTests.swift; sourceTree = "<group>"; };
 		DBAD1A9BF197EEA6E4F636D7 /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
@@ -1238,6 +1243,7 @@
 		F564EFD678FB31CE540FBDEE /* AgentEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEventBridgeTests.swift; sourceTree = "<group>"; };
 		F56A80724E5ABFBF4B39D945 /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
 		F5FB4A13C3399DF51323778E /* WorklanePeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklanePeekView.swift; sourceTree = "<group>"; };
+		F6FB8F60EA767D7F7E3C4E2F /* CloseConfirmationCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseConfirmationCopy.swift; sourceTree = "<group>"; };
 		F876089DABC0460791806F3E /* PaneDragHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragHitTesting.swift; sourceTree = "<group>"; };
 		F9FCFF921453188C98C2AC4D /* TmuxCompatPaneContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatPaneContextTests.swift; sourceTree = "<group>"; };
 		FA47D32BA165D8930DF1C3D6 /* PaneDragSidebarEdgeScrollDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragSidebarEdgeScrollDriver.swift; sourceTree = "<group>"; };
@@ -1363,6 +1369,7 @@
 		1C0506CDB868054B09C5CA8D /* AppState */ = {
 			isa = PBXGroup;
 			children = (
+				AAE5397C365594A855625BE1 /* CloseConfirmationContext.swift */,
 				E706A2076EAD5DD8C5AD0882 /* NotificationSoundManager.swift */,
 				9E06B6AF9A2D4A3F2872F62E /* NotificationStore.swift */,
 				E101FFDD49FF6625AC16DDED /* PaneAuxiliaryState.swift */,
@@ -2008,6 +2015,7 @@
 			isa = PBXGroup;
 			children = (
 				609771315B7DE1068E588518 /* AppActionRouter.swift */,
+				F6FB8F60EA767D7F7E3C4E2F /* CloseConfirmationCopy.swift */,
 				5712CB2F8BC16BB3B666A085 /* DragReorderHapticFeedback.swift */,
 				9E5374262D4ED03A210B05CA /* PaneCommandExecutor.swift */,
 				7B93F46C5542A31805301C02 /* RootViewController.swift */,
@@ -2086,6 +2094,7 @@
 				41D3D22F3E783C0247024435 /* CleanCopyCommandFlatteningTests.swift */,
 				FD08AC7A7561005FD819D5D4 /* CleanCopyPipelineTests.swift */,
 				A56D0544A9DC91F1BB3E0B88 /* CleanCopyURLHelpersTests.swift */,
+				DA310007A676CA2214DD81F7 /* CloseConfirmationContextTests.swift */,
 				8ED6DB175BCF8A6E62E5BAAF /* ClosedPaneCWDResolverTests.swift */,
 				555A3E876B04160BA692FCFB /* ClosedPaneRestoreCommandResolverTests.swift */,
 				8C76A528123220C3D01AA0AE /* ClosedPaneStackTests.swift */,
@@ -2531,6 +2540,7 @@
 				A1E9D4AC7D56DF6F533F5B0A /* CleanCopyCommandFlatteningTests.swift in Sources */,
 				FDC316FB9C5E49E5F368CCFD /* CleanCopyPipelineTests.swift in Sources */,
 				4E1373DAB8FC1A583D982FFA /* CleanCopyURLHelpersTests.swift in Sources */,
+				C0345B22CCE90E84F6CBA252 /* CloseConfirmationContextTests.swift in Sources */,
 				9C885D2B4DAD71748F42EDE8 /* ClosedPaneCWDResolverTests.swift in Sources */,
 				E445F2D11B56410F2C85C6F4 /* ClosedPaneRestoreCommandResolverTests.swift in Sources */,
 				35CFAC4877B509D64DF620DE /* ClosedPaneStackTests.swift in Sources */,
@@ -2769,6 +2779,8 @@
 				ED27476E195CD5905EA8FE99 /* CleanCopyPipeline.swift in Sources */,
 				34A713B3F6840863015ABB41 /* CleanCopyPrompts.swift in Sources */,
 				FBDA06CC21019E395A19A6ED /* CleanCopyURLHelpers.swift in Sources */,
+				85AA36B075A627B684DA8C88 /* CloseConfirmationContext.swift in Sources */,
+				65F7A5CB3F1EF2571AADB53F /* CloseConfirmationCopy.swift in Sources */,
 				7C47C97F74DD168347F1CB2F /* ClosedPaneEntry.swift in Sources */,
 				7416113E7130419074A5842C /* ClosedPaneRestoreHelpers.swift in Sources */,
 				2E7726CCE8D1D2DC6D44DB22 /* ClosedPaneStack.swift in Sources */,

--- a/Zentty/AppState/CloseConfirmationContext.swift
+++ b/Zentty/AppState/CloseConfirmationContext.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/// What is running in a pane, resolved for a close-confirmation prompt.
+enum CloseConfirmationActivity: Equatable, Sendable {
+    /// A recognized agent tool such as Claude Code or Codex.
+    case tool(String)
+    /// The last shell command the user ran, e.g. `pnpm dev`.
+    case command(String)
+    /// The foreground process name when no command is known, e.g. `node`.
+    case process(String)
+
+    /// Plain text without decoration, for lists.
+    var plainText: String {
+        switch self {
+        case .tool(let name), .command(let name), .process(let name):
+            return name
+        }
+    }
+
+    /// Text for use inside a sentence: commands are quoted, names are not.
+    var sentenceText: String {
+        switch self {
+        case .tool(let name), .process(let name):
+            return name
+        case .command(let command):
+            return "“\(command)”"
+        }
+    }
+}
+
+/// Everything the close-pane confirmation needs to say *which* pane is about
+/// to close and what will be lost. Built from state the sidebar already shows.
+struct PaneCloseConfirmationContext: Equatable, Sendable {
+    static let maximumActivityLength = 48
+
+    let reason: WorklaneStore.PaneCloseReason
+    let paneName: String
+    let worklaneName: String?
+    /// Branch and home-relative working directory, e.g. `main · ~/Development/zentty`.
+    let locationLine: String?
+    let activity: CloseConfirmationActivity?
+
+    var runningActivity: String? {
+        activity?.plainText
+    }
+
+    static func make(paneID: PaneID, in worklane: WorklaneState) -> PaneCloseConfirmationContext? {
+        guard let pane = worklane.paneStripState.panes.first(where: { $0.id == paneID }) else {
+            return nil
+        }
+        let auxiliaryState = worklane.auxiliaryStateByPaneID[paneID] ?? PaneAuxiliaryState()
+        guard let reason = WorklaneStore.quitConfirmationReason(for: auxiliaryState) else {
+            return nil
+        }
+
+        return PaneCloseConfirmationContext(
+            reason: reason,
+            paneName: paneName(pane: pane, auxiliaryState: auxiliaryState),
+            worklaneName: worklane.title,
+            locationLine: locationLine(for: auxiliaryState),
+            activity: reason == .runningProcess ? activity(for: auxiliaryState) : nil
+        )
+    }
+
+    // MARK: - Derivation
+
+    /// Prefers stable, user-meaningful names over volatile terminal titles:
+    /// custom title, SSH target, agent tool, remembered title, foreground
+    /// process, working directory, then the pane's default title.
+    static func paneName(pane: PaneState, auxiliaryState: PaneAuxiliaryState) -> String {
+        let presentation = auxiliaryState.presentation
+        let metadata = auxiliaryState.metadata
+        let candidates: [String?] = [
+            PaneDisplayIdentityResolver.trimmedCustomTitle(for: pane),
+            WorklaneContextFormatter.trimmed(presentation.sshConnectionLabel),
+            currentTool(for: auxiliaryState)?.displayName,
+            WorklaneContextFormatter.trimmed(presentation.rememberedTitle),
+            WorklaneContextFormatter.displayMeaningfulTerminalIdentity(for: metadata),
+            directoryName(workingDirectory(for: auxiliaryState)),
+            WorklaneContextFormatter.normalizeSidebarFallbackTitle(pane.title),
+        ]
+        return candidates.compactMap { $0 }.first ?? "Shell"
+    }
+
+    /// Full home-relative path rather than the sidebar's compacted form, so
+    /// two panes in sibling directories stay distinguishable. Remote shells
+    /// report their host and remote path instead of a local directory.
+    static func locationLine(for auxiliaryState: PaneAuxiliaryState) -> String? {
+        let presentation = auxiliaryState.presentation
+        if presentation.isRemoteShell {
+            return WorklaneContextFormatter.trimmed(presentation.remoteLocationLabel)
+                ?? WorklaneContextFormatter.trimmed(presentation.remoteHostLabel)
+        }
+
+        let branch = WorklaneContextFormatter.displayBranch(
+            presentation.branch ?? auxiliaryState.metadata?.gitBranch
+        )
+        let directory = workingDirectory(for: auxiliaryState).map {
+            WorklaneContextFormatter.homeRelativePath($0) ?? $0
+        }
+        let parts = [branch, directory].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// The agent tool that is actually current. While a command runs, only a
+    /// tool launched by that command counts; the metadata-derived tool can be
+    /// stale after an agent exits and something else starts.
+    static func currentTool(for auxiliaryState: PaneAuxiliaryState) -> AgentTool? {
+        if auxiliaryState.shellActivityState == .commandRunning,
+           let command = WorklaneContextFormatter.trimmed(auxiliaryState.raw.lastRunCommand) {
+            return AgentTool.resolveKnown(named: executableName(of: command))
+        }
+        return auxiliaryState.presentation.recognizedTool
+            ?? AgentToolRecognizer.recognize(metadata: auxiliaryState.metadata)
+    }
+
+    /// The shell reports the command it is running in the same event that
+    /// marks the pane busy, so that command is the most accurate source. A
+    /// recognized tool from metadata can be stale after the agent exits.
+    static func activity(for auxiliaryState: PaneAuxiliaryState) -> CloseConfirmationActivity? {
+        let metadata = auxiliaryState.metadata
+
+        if let command = WorklaneContextFormatter.trimmed(auxiliaryState.raw.lastRunCommand) {
+            if let tool = AgentTool.resolveKnown(named: executableName(of: command)) {
+                return .tool(tool.displayName)
+            }
+            return .command(truncated(command))
+        }
+
+        if let tool = auxiliaryState.presentation.recognizedTool
+            ?? AgentToolRecognizer.recognize(metadata: metadata) {
+            return .tool(tool.displayName)
+        }
+
+        if let process = WorklaneContextFormatter.trimmed(metadata?.processName),
+           !WorklaneContextFormatter.isGenericShellIdentity(process) {
+            return .process(process)
+        }
+
+        return nil
+    }
+
+    /// First token that is not a `VAR=value` prefix, reduced to its basename,
+    /// so `FOO=1 /opt/homebrew/bin/claude --resume` resolves as `claude`.
+    private static func executableName(of command: String) -> String? {
+        let token = command
+            .split(whereSeparator: \.isWhitespace)
+            .first { !$0.contains("=") }
+            .map(String.init)
+        guard let token else { return nil }
+        return URL(fileURLWithPath: token).lastPathComponent
+    }
+
+    private static func workingDirectory(for auxiliaryState: PaneAuxiliaryState) -> String? {
+        auxiliaryState.presentation.cwd
+            ?? WorklaneContextFormatter.resolvedWorkingDirectory(
+                for: auxiliaryState.metadata,
+                shellContext: auxiliaryState.raw.shellContext
+            )
+    }
+
+    private static func directoryName(_ workingDirectory: String?) -> String? {
+        guard let workingDirectory = WorklaneContextFormatter.trimmed(workingDirectory) else {
+            return nil
+        }
+        if WorklaneContextFormatter.homeRelativePath(workingDirectory) == "~" {
+            return "~"
+        }
+        let name = URL(fileURLWithPath: workingDirectory).lastPathComponent
+        return name.isEmpty || name == "/" ? nil : name
+    }
+
+    private static func truncated(_ value: String) -> String {
+        let singleLine = value.split(whereSeparator: \.isNewline).first.map(String.init) ?? value
+        guard singleLine.count > maximumActivityLength else {
+            return singleLine
+        }
+        return String(singleLine.prefix(maximumActivityLength - 1))
+            .trimmingCharacters(in: .whitespaces) + "…"
+    }
+}
+
+/// Aggregate of every pane in a worklane that needs confirmation before close.
+struct WorklaneCloseConfirmationContext: Equatable, Sendable {
+    let reason: WorklaneStore.PaneCloseReason
+    let worklaneName: String?
+    let paneCount: Int
+    let runningPaneCount: Int
+    let historyPaneCount: Int
+    /// Activities of running panes that could be named, in pane order.
+    let runningActivities: [String]
+
+    static func make(worklane: WorklaneState) -> WorklaneCloseConfirmationContext? {
+        var runningPaneCount = 0
+        var historyPaneCount = 0
+        var runningActivities: [String] = []
+
+        for pane in worklane.paneStripState.panes {
+            guard let auxiliaryState = worklane.auxiliaryStateByPaneID[pane.id],
+                  let reason = WorklaneStore.quitConfirmationReason(for: auxiliaryState)
+            else {
+                continue
+            }
+
+            switch reason {
+            case .runningProcess:
+                runningPaneCount += 1
+                if let activity = PaneCloseConfirmationContext.activity(for: auxiliaryState) {
+                    runningActivities.append(activity.plainText)
+                }
+            case .sessionHistory:
+                historyPaneCount += 1
+            }
+        }
+
+        guard runningPaneCount > 0 || historyPaneCount > 0 else {
+            return nil
+        }
+
+        return WorklaneCloseConfirmationContext(
+            reason: runningPaneCount > 0 ? .runningProcess : .sessionHistory,
+            worklaneName: worklane.title,
+            paneCount: worklane.paneStripState.panes.count,
+            runningPaneCount: runningPaneCount,
+            historyPaneCount: historyPaneCount,
+            runningActivities: runningActivities
+        )
+    }
+}
+
+extension WorklaneStore {
+    func paneCloseConfirmationContext(_ paneID: PaneID) -> PaneCloseConfirmationContext? {
+        for worklane in worklanes {
+            guard worklane.paneStripState.panes.contains(where: { $0.id == paneID }) else {
+                continue
+            }
+            return PaneCloseConfirmationContext.make(paneID: paneID, in: worklane)
+        }
+        return nil
+    }
+
+    func worklaneCloseConfirmationContext(_ worklaneID: WorklaneID) -> WorklaneCloseConfirmationContext? {
+        guard let worklane = worklanes.first(where: { $0.id == worklaneID }) else {
+            return nil
+        }
+        return WorklaneCloseConfirmationContext.make(worklane: worklane)
+    }
+}

--- a/Zentty/AppState/WorklaneContextFormatter.swift
+++ b/Zentty/AppState/WorklaneContextFormatter.swift
@@ -918,7 +918,7 @@ enum WorklaneContextFormatter {
         "-l", "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w"
     ]
 
-    private static func isGenericShellIdentity(_ value: String) -> Bool {
+    static func isGenericShellIdentity(_ value: String) -> Bool {
         switch value.lowercased() {
         case "zsh", "bash", "fish", "sh":
             return true

--- a/Zentty/AppState/WorklaneStore.swift
+++ b/Zentty/AppState/WorklaneStore.swift
@@ -636,7 +636,7 @@ final class WorklaneStore {
         notifyServerDetectionChanged(worklaneID: worklaneID, paneID: nil)
     }
 
-    enum PaneCloseReason {
+    enum PaneCloseReason: Equatable, Sendable {
         case runningProcess
         case sessionHistory
     }
@@ -644,7 +644,7 @@ final class WorklaneStore {
     func paneCloseConfirmationReason(_ paneID: PaneID) -> PaneCloseReason? {
         for worklane in worklanes {
             guard let aux = worklane.auxiliaryStateByPaneID[paneID] else { continue }
-            return quitConfirmationReason(for: aux)
+            return Self.quitConfirmationReason(for: aux)
         }
         return nil
     }
@@ -657,7 +657,7 @@ final class WorklaneStore {
         var hasSessionHistory = false
         for pane in worklane.paneStripState.panes {
             guard let auxiliaryState = worklane.auxiliaryStateByPaneID[pane.id],
-                  let reason = quitConfirmationReason(for: auxiliaryState)
+                  let reason = Self.quitConfirmationReason(for: auxiliaryState)
             else {
                 continue
             }
@@ -676,7 +676,7 @@ final class WorklaneStore {
     var anyPaneRequiresQuitConfirmation: Bool {
         worklanes.contains { worklane in
             worklane.auxiliaryStateByPaneID.values.contains {
-                quitConfirmationReason(for: $0) != nil
+                Self.quitConfirmationReason(for: $0) != nil
             }
         }
     }
@@ -697,7 +697,7 @@ final class WorklaneStore {
         }
     }
 
-    private func quitConfirmationReason(for auxiliaryState: PaneAuxiliaryState) -> PaneCloseReason? {
+    nonisolated static func quitConfirmationReason(for auxiliaryState: PaneAuxiliaryState) -> PaneCloseReason? {
         if auxiliaryState.shellActivityState == .commandRunning
             || auxiliaryState.terminalProgress?.state.indicatesActivity == true {
             return .runningProcess

--- a/Zentty/UI/CloseConfirmationCopy.swift
+++ b/Zentty/UI/CloseConfirmationCopy.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Text for the close-pane and close-worklane confirmation alerts.
+struct CloseConfirmationCopy: Equatable {
+    let messageText: String
+    let informativeText: String
+    let confirmButtonTitle: String
+
+    static func pane(_ context: PaneCloseConfirmationContext) -> CloseConfirmationCopy {
+        let reasonLine: String
+        switch context.reason {
+        case .runningProcess:
+            if let activity = context.activity {
+                reasonLine = "\(activity.sentenceText) is still running and will be terminated."
+            } else {
+                reasonLine = "The running process in this pane will be terminated."
+            }
+        case .sessionHistory:
+            reasonLine = "This pane's session history will be lost."
+        }
+
+        let detailLines = [
+            context.worklaneName.map { "Worklane: \($0)" },
+            context.locationLine.map { "Location: \($0)" },
+        ].compactMap { $0 }
+
+        return CloseConfirmationCopy(
+            messageText: "Close pane “\(context.paneName)”?",
+            informativeText: joined(reasonLine, detailLines),
+            confirmButtonTitle: "Close Pane"
+        )
+    }
+
+    static func worklane(_ context: WorklaneCloseConfirmationContext) -> CloseConfirmationCopy {
+        let messageText = context.worklaneName.map { "Close worklane “\($0)”?" }
+            ?? "Close this worklane?"
+
+        let informativeText: String
+        switch context.reason {
+        case .runningProcess:
+            informativeText = runningLine(context)
+        case .sessionHistory:
+            informativeText = historyLine(context)
+        }
+
+        return CloseConfirmationCopy(
+            messageText: messageText,
+            informativeText: informativeText,
+            confirmButtonTitle: "Close Worklane"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func runningLine(_ context: WorklaneCloseConfirmationContext) -> String {
+        let names = context.runningActivities.joined(separator: ", ")
+
+        if context.paneCount == 1 {
+            if let name = context.runningActivities.first {
+                return "\(name) is still running and will be terminated."
+            }
+            return "The running process in this pane will be terminated."
+        }
+
+        let subject = context.runningPaneCount == 1
+            ? "\(context.runningPaneCount) of \(context.paneCount) panes has a running process"
+            : "\(context.runningPaneCount) of \(context.paneCount) panes have running processes"
+        let suffix = names.isEmpty ? "" : ": \(names)"
+        return "\(subject) that will be terminated\(suffix)."
+    }
+
+    private static func historyLine(_ context: WorklaneCloseConfirmationContext) -> String {
+        if context.paneCount == 1 {
+            return "Session history in this pane will be lost."
+        }
+        let count = context.historyPaneCount
+        return "Session history in \(count) \(count == 1 ? "pane" : "panes") will be lost."
+    }
+
+    private static func joined(_ reasonLine: String, _ detailLines: [String]) -> String {
+        guard !detailLines.isEmpty else {
+            return reasonLine
+        }
+        return reasonLine + "\n\n" + detailLines.joined(separator: "\n")
+    }
+}

--- a/Zentty/UI/PaneCommandExecutor.swift
+++ b/Zentty/UI/PaneCommandExecutor.swift
@@ -29,7 +29,7 @@ final class PaneCommandExecutor {
     }
 
     struct UIHooks {
-        var presentClosePaneConfirmation: (WorklaneStore.PaneCloseReason, @escaping () -> Void) -> Void
+        var presentClosePaneConfirmation: (PaneCloseConfirmationContext, @escaping () -> Void) -> Void
         var showToast: (String) -> Void
         var requestWindowClose: () -> Void
     }
@@ -150,9 +150,9 @@ final class PaneCommandExecutor {
             let focusedPaneID = worklaneStore.activeWorklane?.paneStripState.focusedPaneID
             if configStore.current.confirmations.confirmBeforeClosingPane,
                 let focusedPaneID,
-                let reason = worklaneStore.paneCloseConfirmationReason(focusedPaneID)
+                let context = worklaneStore.paneCloseConfirmationContext(focusedPaneID)
             {
-                hooks.presentClosePaneConfirmation(reason) { [weak self] in
+                hooks.presentClosePaneConfirmation(context) { [weak self] in
                     self?.closeFocusedPane()
                 }
             } else {

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -150,8 +150,8 @@ final class RootViewController: NSViewController {
         runtimeRegistry: runtimeRegistry,
         canvas: appCanvasView,
         hooks: PaneCommandExecutor.UIHooks(
-            presentClosePaneConfirmation: { [weak self] reason, onConfirm in
-                self?.showClosePaneConfirmation(reason: reason, onConfirm: onConfirm)
+            presentClosePaneConfirmation: { [weak self] context, onConfirm in
+                self?.showClosePaneConfirmation(context: context, onConfirm: onConfirm)
             },
             showToast: { [weak self] message in self?.showToast(message: message) },
             requestWindowClose: { [weak self] in self?.requestContainingWindowClose() }
@@ -801,9 +801,10 @@ final class RootViewController: NSViewController {
         appCanvasView.paneStripView.onPaneCloseRequested = { [weak self] paneID in
             guard let self else { return }
             if self.configStore.current.confirmations.confirmBeforeClosingPane,
-                let reason = self.worklaneStore.paneCloseConfirmationReason(paneID)
+                let context = self.worklaneStore.paneCloseConfirmationContext(paneID)
             {
-                self.showClosePaneConfirmation(reason: reason) {
+                self.worklaneStore.focusPane(id: paneID)
+                self.showClosePaneConfirmation(context: context) {
                     self.paneCommands.closePane(id: paneID)
                 }
             } else {
@@ -1029,9 +1030,10 @@ final class RootViewController: NSViewController {
         sidebarView.onCloseWorklaneRequested = { [weak self] worklaneID in
             guard let self else { return }
             if self.configStore.current.confirmations.confirmBeforeClosingPane,
-               let reason = self.worklaneStore.worklaneCloseConfirmationReason(worklaneID)
+               let context = self.worklaneStore.worklaneCloseConfirmationContext(worklaneID)
             {
-                self.showCloseWorklaneConfirmation(reason: reason) {
+                self.worklaneStore.selectWorklane(id: worklaneID)
+                self.showCloseWorklaneConfirmation(context: context) {
                     self.closeWorklane(id: worklaneID)
                 }
             } else {
@@ -1048,9 +1050,13 @@ final class RootViewController: NSViewController {
         sidebarView.onClosePaneRequested = { [weak self] worklaneID, paneID in
             guard let self else { return }
             if self.configStore.current.confirmations.confirmBeforeClosingPane,
-                let reason = self.worklaneStore.paneCloseConfirmationReason(paneID)
+                let context = self.worklaneStore.paneCloseConfirmationContext(paneID)
             {
-                self.showClosePaneConfirmation(reason: reason) {
+                self.worklaneStore.selectWorklaneAndFocusPane(
+                    worklaneID: worklaneID, paneID: paneID)
+                self.showClosePaneConfirmation(context: context) {
+                    // Re-select: the active worklane can change while the
+                    // sheet is up, and closePane(id:) only sees the active one.
                     self.worklaneStore.selectWorklaneAndFocusPane(
                         worklaneID: worklaneID, paneID: paneID)
                     self.paneCommands.closePane(id: paneID)
@@ -1523,55 +1529,31 @@ final class RootViewController: NSViewController {
     private var isShowingCloseConfirmation = false
 
     private func showClosePaneConfirmation(
-        reason: WorklaneStore.PaneCloseReason,
+        context: PaneCloseConfirmationContext,
         onConfirm: @escaping () -> Void
     ) {
-        let informativeText = switch reason {
-        case .runningProcess:
-            "The running process in this pane will be terminated."
-        case .sessionHistory:
-            "This pane's session history will be lost."
-        }
-        showCloseConfirmation(
-            messageText: "Close this pane?",
-            informativeText: informativeText,
-            confirmButtonTitle: "Close Pane",
-            onConfirm: onConfirm
-        )
+        showCloseConfirmation(copy: .pane(context), onConfirm: onConfirm)
     }
 
     private func showCloseWorklaneConfirmation(
-        reason: WorklaneStore.PaneCloseReason,
+        context: WorklaneCloseConfirmationContext,
         onConfirm: @escaping () -> Void
     ) {
-        let informativeText = switch reason {
-        case .runningProcess:
-            "Running processes in this worklane will be terminated."
-        case .sessionHistory:
-            "This worklane's session history will be lost."
-        }
-        showCloseConfirmation(
-            messageText: "Close this worklane?",
-            informativeText: informativeText,
-            confirmButtonTitle: "Close Worklane",
-            onConfirm: onConfirm
-        )
+        showCloseConfirmation(copy: .worklane(context), onConfirm: onConfirm)
     }
 
     private func showCloseConfirmation(
-        messageText: String,
-        informativeText: String,
-        confirmButtonTitle: String,
+        copy: CloseConfirmationCopy,
         onConfirm: @escaping () -> Void
     ) {
         guard !isShowingCloseConfirmation else { return }
         isShowingCloseConfirmation = true
 
         let alert = NSAlert()
-        alert.messageText = messageText
-        alert.informativeText = informativeText
+        alert.messageText = copy.messageText
+        alert.informativeText = copy.informativeText
         alert.alertStyle = .warning
-        alert.addButton(withTitle: confirmButtonTitle)
+        alert.addButton(withTitle: copy.confirmButtonTitle)
         alert.addButton(withTitle: "Cancel")
         let isDark = currentTheme.windowBackground.isDarkThemeColor
         alert.window.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)

--- a/ZenttyLogicTests/CloseConfirmationContextTests.swift
+++ b/ZenttyLogicTests/CloseConfirmationContextTests.swift
@@ -1,0 +1,368 @@
+import XCTest
+
+@testable import Zentty
+
+@MainActor
+final class CloseConfirmationContextTests: XCTestCase {
+    private let worklaneID = WorklaneID("wl")
+    private let paneA = PaneID("pane-a")
+    private let paneB = PaneID("pane-b")
+    private let paneC = PaneID("pane-c")
+
+    private var repoPath: String {
+        NSHomeDirectory() + "/Development/Personal/zentty"
+    }
+
+    // MARK: - Pane context
+
+    func test_pane_context_uses_custom_title_and_last_command() throws {
+        let worklane = makeWorklane(
+            title: "zentty",
+            panes: [PaneState(id: paneA, title: "shell", customTitle: "api")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, processName: "node", gitBranch: "main")],
+            running: [paneA: "pnpm dev"]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.reason, .runningProcess)
+        XCTAssertEqual(context.paneName, "api")
+        XCTAssertEqual(context.worklaneName, "zentty")
+        XCTAssertEqual(context.runningActivity, "pnpm dev")
+        XCTAssertEqual(context.locationLine, "main · ~/Development/Personal/zentty")
+    }
+
+    func test_pane_context_names_recognized_agent_as_activity() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, processName: "claude", gitBranch: "main")],
+            running: [paneA: "claude"]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.reason, .runningProcess)
+        XCTAssertEqual(context.runningActivity, "Claude Code")
+        XCTAssertNil(context.worklaneName)
+        XCTAssertFalse(context.paneName.isEmpty)
+    }
+
+    func test_pane_context_resolves_agent_from_running_command_with_flags_and_env() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "node")],
+            running: [paneA: "FOO=1 /opt/homebrew/bin/claude --resume abc123"]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.activity, .tool("Claude Code"))
+    }
+
+    func test_pane_context_prefers_running_command_over_stale_recognized_tool() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "claude")],
+            running: [paneA: "pnpm dev"]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.activity, .command("pnpm dev"))
+        XCTAssertNotEqual(context.paneName, "Claude Code")
+    }
+
+    func test_pane_context_keeps_recognized_tool_name_when_idle() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "claude")],
+            history: [paneA]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.paneName, "Claude Code")
+    }
+
+    func test_pane_context_uses_remote_location_for_remote_shells() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, gitBranch: "main")],
+            shellContext: [
+                paneA: PaneShellContext(
+                    scope: .remote, path: "/srv/app", home: "/home/deploy", user: "deploy", host: "web-1")
+            ],
+            running: [paneA: "tail -f log"]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let location = try XCTUnwrap(context.locationLine)
+        XCTAssertTrue(location.hasPrefix("web-1"), location)
+        XCTAssertFalse(location.contains("Development"), location)
+    }
+
+    func test_pane_context_ignores_plain_shell_process_as_activity() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "zsh")],
+            running: [paneA: nil]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.reason, .runningProcess)
+        XCTAssertNil(context.runningActivity)
+        XCTAssertNil(context.locationLine)
+    }
+
+    func test_pane_context_truncates_long_commands() throws {
+        let longCommand = "pnpm exec vitest run --coverage --reporter=verbose --watch=false src/components"
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "node")],
+            running: [paneA: longCommand]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let activity = try XCTUnwrap(context.runningActivity)
+        XCTAssertLessThanOrEqual(activity.count, PaneCloseConfirmationContext.maximumActivityLength)
+        XCTAssertTrue(activity.hasSuffix("…"), activity)
+        XCTAssertTrue(activity.hasPrefix("pnpm exec vitest"), activity)
+    }
+
+    func test_pane_context_reports_session_history_when_idle() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [:],
+            history: [paneA]
+        )
+
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        XCTAssertEqual(context.reason, .sessionHistory)
+        XCTAssertNil(context.runningActivity)
+    }
+
+    func test_pane_context_is_nil_when_nothing_to_confirm() {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [:]
+        )
+
+        XCTAssertNil(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+    }
+
+    // MARK: - Pane copy
+
+    func test_pane_copy_for_running_command() throws {
+        let worklane = makeWorklane(
+            title: "zentty",
+            panes: [PaneState(id: paneA, title: "shell", customTitle: "api")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, processName: "node", gitBranch: "main")],
+            running: [paneA: "pnpm dev"]
+        )
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let copy = CloseConfirmationCopy.pane(context)
+
+        XCTAssertEqual(copy.messageText, "Close pane “api”?")
+        XCTAssertEqual(copy.confirmButtonTitle, "Close Pane")
+        XCTAssertTrue(
+            copy.informativeText.hasPrefix("“pnpm dev” is still running and will be terminated."),
+            copy.informativeText
+        )
+        XCTAssertTrue(copy.informativeText.contains("zentty"), copy.informativeText)
+        XCTAssertTrue(copy.informativeText.contains("main"), copy.informativeText)
+    }
+
+    func test_pane_copy_for_agent_does_not_quote_tool_name() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, processName: "claude", gitBranch: "main")],
+            running: [paneA: "claude"]
+        )
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let copy = CloseConfirmationCopy.pane(context)
+
+        XCTAssertTrue(
+            copy.informativeText.hasPrefix("Claude Code is still running and will be terminated."),
+            copy.informativeText
+        )
+    }
+
+    func test_pane_copy_falls_back_to_generic_running_text() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "zsh")],
+            running: [paneA: nil]
+        )
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let copy = CloseConfirmationCopy.pane(context)
+
+        XCTAssertEqual(copy.informativeText, "The running process in this pane will be terminated.")
+    }
+
+    func test_pane_copy_for_session_history() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [paneA: TerminalMetadata(currentWorkingDirectory: repoPath, gitBranch: "main")],
+            history: [paneA]
+        )
+        let context = try XCTUnwrap(PaneCloseConfirmationContext.make(paneID: paneA, in: worklane))
+
+        let copy = CloseConfirmationCopy.pane(context)
+
+        XCTAssertTrue(
+            copy.informativeText.hasPrefix("This pane's session history will be lost."),
+            copy.informativeText
+        )
+        XCTAssertTrue(copy.informativeText.contains("main"), copy.informativeText)
+    }
+
+    // MARK: - Worklane context and copy
+
+    func test_worklane_context_aggregates_running_activities() throws {
+        let worklane = makeWorklane(
+            title: "zentty",
+            panes: [
+                PaneState(id: paneA, title: "shell"),
+                PaneState(id: paneB, title: "shell", customTitle: "api"),
+                PaneState(id: paneC, title: "shell"),
+            ],
+            metadata: [
+                paneA: TerminalMetadata(processName: "claude"),
+                paneB: TerminalMetadata(processName: "node"),
+            ],
+            running: [paneA: "claude", paneB: "pnpm dev"],
+            history: [paneC]
+        )
+
+        let context = try XCTUnwrap(WorklaneCloseConfirmationContext.make(worklane: worklane))
+        let copy = CloseConfirmationCopy.worklane(context)
+
+        XCTAssertEqual(context.reason, .runningProcess)
+        XCTAssertEqual(context.worklaneName, "zentty")
+        XCTAssertEqual(context.paneCount, 3)
+        XCTAssertEqual(context.runningActivities, ["Claude Code", "pnpm dev"])
+        XCTAssertEqual(copy.messageText, "Close worklane “zentty”?")
+        XCTAssertEqual(copy.confirmButtonTitle, "Close Worklane")
+        XCTAssertEqual(
+            copy.informativeText,
+            "2 of 3 panes have running processes that will be terminated: Claude Code, pnpm dev."
+        )
+    }
+
+    func test_worklane_copy_singular_running_pane_without_activity_name() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell"), PaneState(id: paneB, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "zsh")],
+            running: [paneA: nil]
+        )
+
+        let context = try XCTUnwrap(WorklaneCloseConfirmationContext.make(worklane: worklane))
+        let copy = CloseConfirmationCopy.worklane(context)
+
+        XCTAssertEqual(copy.messageText, "Close this worklane?")
+        XCTAssertEqual(copy.informativeText, "1 of 2 panes has a running process that will be terminated.")
+    }
+
+    func test_worklane_copy_for_session_history_only() throws {
+        let worklane = makeWorklane(
+            title: "docs",
+            panes: [PaneState(id: paneA, title: "shell"), PaneState(id: paneB, title: "shell")],
+            metadata: [:],
+            history: [paneA, paneB]
+        )
+
+        let context = try XCTUnwrap(WorklaneCloseConfirmationContext.make(worklane: worklane))
+        let copy = CloseConfirmationCopy.worklane(context)
+
+        XCTAssertEqual(context.reason, .sessionHistory)
+        XCTAssertEqual(copy.informativeText, "Session history in 2 panes will be lost.")
+    }
+
+    func test_worklane_copy_for_single_pane_session_history() throws {
+        let worklane = makeWorklane(
+            title: nil,
+            panes: [PaneState(id: paneA, title: "shell")],
+            metadata: [:],
+            history: [paneA]
+        )
+
+        let context = try XCTUnwrap(WorklaneCloseConfirmationContext.make(worklane: worklane))
+        let copy = CloseConfirmationCopy.worklane(context)
+
+        XCTAssertEqual(copy.informativeText, "Session history in this pane will be lost.")
+    }
+
+    // MARK: - Store integration
+
+    func test_store_resolves_pane_and_worklane_contexts() throws {
+        let worklane = makeWorklane(
+            title: "zentty",
+            panes: [PaneState(id: paneA, title: "shell"), PaneState(id: paneB, title: "shell")],
+            metadata: [paneA: TerminalMetadata(processName: "claude")],
+            running: [paneA: "claude"]
+        )
+        let store = WorklaneStore(worklanes: [worklane], activeWorklaneID: worklaneID)
+
+        let paneContext = try XCTUnwrap(store.paneCloseConfirmationContext(paneA))
+        XCTAssertEqual(paneContext.worklaneName, "zentty")
+        XCTAssertEqual(paneContext.runningActivity, "Claude Code")
+        XCTAssertNil(store.paneCloseConfirmationContext(paneB))
+
+        let worklaneContext = try XCTUnwrap(store.worklaneCloseConfirmationContext(worklaneID))
+        XCTAssertEqual(worklaneContext.runningActivities, ["Claude Code"])
+        XCTAssertNil(store.worklaneCloseConfirmationContext(WorklaneID("missing")))
+    }
+
+    // MARK: - Helpers
+
+    /// `running` maps a pane to its last run command (nil = running with no
+    /// known command); `history` lists idle panes with session history.
+    private func makeWorklane(
+        title: String?,
+        panes: [PaneState],
+        metadata: [PaneID: TerminalMetadata],
+        shellContext: [PaneID: PaneShellContext] = [:],
+        running: [PaneID: String?] = [:],
+        history: [PaneID] = []
+    ) -> WorklaneState {
+        var worklane = WorklaneState(
+            id: worklaneID,
+            title: title,
+            paneStripState: PaneStripState(panes: panes, focusedPaneID: panes.first?.id),
+            metadataByPaneID: metadata,
+            paneContextByPaneID: shellContext
+        )
+        for (paneID, command) in running {
+            var aux = worklane.auxiliaryStateByPaneID[paneID] ?? PaneAuxiliaryState()
+            aux.shellActivityState = .commandRunning
+            aux.raw.lastRunCommand = command
+            worklane.auxiliaryStateByPaneID[paneID] = aux
+        }
+        for paneID in history {
+            var aux = worklane.auxiliaryStateByPaneID[paneID] ?? PaneAuxiliaryState()
+            aux.hasCommandHistory = true
+            worklane.auxiliaryStateByPaneID[paneID] = aux
+        }
+        return worklane
+    }
+}

--- a/ZenttyLogicTests/PaneCommandExecutorTests.swift
+++ b/ZenttyLogicTests/PaneCommandExecutorTests.swift
@@ -150,15 +150,16 @@ private final class StubCanvas: PaneCanvasGeometry {
 
 @MainActor
 private final class HooksSpy {
-    var presentedReason: WorklaneStore.PaneCloseReason?
+    var presentedContext: PaneCloseConfirmationContext?
+    var presentedReason: WorklaneStore.PaneCloseReason? { presentedContext?.reason }
     var capturedOnConfirm: (() -> Void)?
     var toastMessages: [String] = []
     var windowCloseCount = 0
 
     func makeHooks() -> PaneCommandExecutor.UIHooks {
         PaneCommandExecutor.UIHooks(
-            presentClosePaneConfirmation: { [self] reason, onConfirm in
-                presentedReason = reason
+            presentClosePaneConfirmation: { [self] context, onConfirm in
+                presentedContext = context
                 capturedOnConfirm = onConfirm
             },
             showToast: { [self] message in toastMessages.append(message) },


### PR DESCRIPTION
## Why

Cmd+W on a busy pane pops "Close this pane?" and nothing else. When you have a few Claude panes and a dev server open, it's easy to hit Close Pane before checking which one is about to die. The store already knows the pane name, the running command, the branch and the directory. The sheet just never asked.

## What changed

The confirmation now reads like this:

```
Close pane "api"?

"pnpm dev" is still running and will be terminated.

Worklane: zentty
Location: main · ~/Development/Personal/zentty/apps/api
```

For an agent pane it says `Claude Code is still running` instead of quoting a raw command. An idle pane with history says so and still shows where it lives. Closing a worklane lists what's running: `2 of 3 panes have running processes that will be terminated: Claude Code, pnpm dev.`

How the name is picked, in order: custom title, SSH target, the agent launched by the running command, remembered title, foreground process, directory name, default title. Volatile agent titles like "Thinking…" are skipped on purpose. The location line uses the full home-relative path rather than the sidebar's compacted form so sibling directories stay distinguishable. Remote shells show host and remote path.

One behavior change worth knowing: closing a pane or worklane from the sidebar now selects it before the sheet appears, so the highlight and the prompt agree. If you cancel, focus stays there.

## Files

- `Zentty/AppState/CloseConfirmationContext.swift` (new): pane and worklane context types, derivation, store lookups.
- `Zentty/UI/CloseConfirmationCopy.swift` (new): turns a context into title, body and button.
- `RootViewController` and `PaneCommandExecutor`: the confirmation hook carries a context instead of a bare reason. The old reason-only store methods stay since other tests use them.
- `WorklaneStore`: the reason helper became a nonisolated static so the context builder can share it.

## Testing

19 new logic tests cover name and activity resolution, command truncation, stale-tool handling, remote locations, worklane aggregation and the store lookups. Full `ZenttyLogicTests` target passes on the virtual display (3896 tests). Hosted tests weren't run; nothing there touches this path.
