### PR TITLE
feat: jump to the pane behind a 1Password approval prompt

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		29DED4BE28EE3F6BAA589705 /* SettingsNavigationHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3094AA8521BDAB3096CF18D /* SettingsNavigationHistoryTests.swift */; };
 		2A08D5A8D71D847DA5EBB8FC /* DiscoveryIPCHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8132E7564D882D85A155D2B5 /* DiscoveryIPCHandlerTests.swift */; };
 		2A64F29063B13F85F622F207 /* SidebarBookmarkRowAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D603FA3B4BCDFE0AC7C4342 /* SidebarBookmarkRowAction.swift */; };
+		2B3520C9D571691FB2D09616 /* OnePasswordPromptDarwinProcessProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A877F28C926381BDC394539 /* OnePasswordPromptDarwinProcessProvider.swift */; };
 		2BC7421FF9D00CF7851A5E32 /* JSONCRelaxedParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AFCE0DB1F7E072081C9D41 /* JSONCRelaxedParse.swift */; };
 		2C6C6FCC081720E010745882 /* AmpResumeArgumentSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */; };
 		2CB00C84D0A16237C1D18814 /* HermesHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F5891F160455B55F41BB5F /* HermesHooksInstaller.swift */; };
@@ -271,6 +272,7 @@
 		6FF9CBE04C1698140C7DA14F /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56A80724E5ABFBF4B39D945 /* MenuBarStatusPresentation.swift */; };
 		701C39983F9037EC0FCFFEE4 /* AgentIPCDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C15EEBB2B6060FDC3C8A05 /* AgentIPCDiscoveryTests.swift */; };
 		70376AF5E484DF3488252AF0 /* GenericProgressReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E9CA26FCDC9E619509598B /* GenericProgressReducer.swift */; };
+		7050E94B6C4AEDD28D22A2E3 /* OnePasswordPromptFocusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DEA0732CC16A0ED51E2FF2 /* OnePasswordPromptFocusCoordinator.swift */; };
 		7092D2398E62448ACE248486 /* UpdatesPrivacySettingsSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D089E7F235904D263884DDE /* UpdatesPrivacySettingsSectionViewController.swift */; };
 		7115A33B57187951D4A21AC9 /* MenuBarStatusPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A737F0825F4D13EFA5A94495 /* MenuBarStatusPaletteTests.swift */; };
 		71A0F88C4E10E1934E39BBEE /* CommandPaletteBackdropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B012FD12A48B0C31EE3634C /* CommandPaletteBackdropTests.swift */; };
@@ -301,6 +303,7 @@
 		7C269AA7741BA793A8DD4BD7 /* PaneNotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53055103EE2424B9E14A2878 /* PaneNotificationCoordinator.swift */; };
 		7C47C97F74DD168347F1CB2F /* ClosedPaneEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E9BE732833C02E123BA5AF /* ClosedPaneEntry.swift */; };
 		7C521E970883BA95DA6C8E62 /* ServerProcessTerminator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759BDA335E0FADCA1591AAEE /* ServerProcessTerminator.swift */; };
+		7C7C9956FEE2B693F3D176C7 /* OnePasswordPromptAttributor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7F7BF9DF753AEB2FC16031 /* OnePasswordPromptAttributor.swift */; };
 		7CE41197B205C6CF70AFC9E6 /* WorkspaceRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771FEDEE47A531015097EFC7 /* WorkspaceRecipeTests.swift */; };
 		7DD2CFCE524E07DC28C237AA /* OpenCodeOverlayLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B5D7C3DB0445971F90C314 /* OpenCodeOverlayLayout.swift */; };
 		7ED5FFE55C98A62091A15F31 /* WorkspaceTemplateCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401E6BE21FE6807C37229D42 /* WorkspaceTemplateCaptureTests.swift */; };
@@ -500,6 +503,7 @@
 		CEDAF9621D24A72064947A90 /* SidebarDropPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */; };
 		CEE6C654BA6B3D3F6FCFCAE2 /* PaneFocusHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CE6484C3A7D0F443F1FF10 /* PaneFocusHistoryController.swift */; };
 		CF13A269F19FE08C54099974 /* MenuBarStatusPillViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A01AB73197CAAE9E3D77A0 /* MenuBarStatusPillViewTests.swift */; };
+		CF27B265338D61CF4BC44777 /* OnePasswordPromptFocusCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C571DADB3493CD047A35125 /* OnePasswordPromptFocusCoordinatorTests.swift */; };
 		D089F5366F16515499AD92E4 /* TmuxFormatRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8595DD2E83A66FAD57B960 /* TmuxFormatRendererTests.swift */; };
 		D11DCA299BC0C937EAED0001 /* PaneSplitBehaviorOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7137F467A63630BC5D08A61 /* PaneSplitBehaviorOptionView.swift */; };
 		D1563C751D1009F259B1BB08 /* PaneLayoutMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F4CE288A07931095E26D13 /* PaneLayoutMenuCoordinator.swift */; };
@@ -514,6 +518,7 @@
 		D33E6B305950A8E1822AA404 /* HookCanonicalReEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0FDE2EFAFDF416D3D66490 /* HookCanonicalReEmitter.swift */; };
 		D3987EA55548B9FB2FAF2535 /* SidebarDropHitTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C88D5D3BFE9433DCC2E7090 /* SidebarDropHitTestingTests.swift */; };
 		D3B45C25D1794724A766C6DA /* WorklaneStoreGitContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78A6A6B85882097AFFAE3EE /* WorklaneStoreGitContextTests.swift */; };
+		D40E4EAA6007BCDC4EAE77EC /* OnePasswordPromptAttributorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F71980F96DC3B2B50A8482 /* OnePasswordPromptAttributorTests.swift */; };
 		D44B2E46DBB0E3EC6205B148 /* WorkspaceTemplateImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D167BBBE4C7B3318C151C7 /* WorkspaceTemplateImporter.swift */; };
 		D4A63F03ECDA1CF35971F9DE /* NotificationPopoverViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C771F4DD0F6077D2E72754D0 /* NotificationPopoverViewModelTests.swift */; };
 		D4BCC2534353020759FDD8E5 /* WindowChromeTitlebarGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E79D08B6C98B3D5E9870E1 /* WindowChromeTitlebarGesture.swift */; };
@@ -605,6 +610,7 @@
 		F69010DBD19B9F9CB87D21AE /* TaskManagerProcessSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65672683D929537DA2ACF986 /* TaskManagerProcessSampler.swift */; };
 		F7341AA3719ED1FB2D7B3739 /* TerminalScrollFrameSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFCA2B8C7CCCEF9A040B1D1 /* TerminalScrollFrameSampler.swift */; };
 		F75C8D5EDC0772F56DE54C52 /* PaneStripStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB4690A6E06FB3FC4C1909E /* PaneStripStoreTests.swift */; };
+		F773918385D26D62A343E77D /* ProcessInspectionUnixSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED8CC8942CC80500B98FD3D /* ProcessInspectionUnixSocketTests.swift */; };
 		F79914E37499F5FE7297C009 /* PresentationPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB40B6883D6232A52132FA30 /* PresentationPipeline.swift */; };
 		F816A0603E61CBBC198F657B /* WorklaneSidebarCustomTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFDC162D1B103A8097293EB /* WorklaneSidebarCustomTitleTests.swift */; };
 		F8250CEECD7700EA54A9687B /* AmpPluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */; };
@@ -714,6 +720,7 @@
 		1950AE3041C1DC410E2DCD11 /* SidebarGlobalSearchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarGlobalSearchButton.swift; sourceTree = "<group>"; };
 		1973D41434D3540DC3A5D582 /* SidebarWorklaneRowStyleResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorklaneRowStyleResolver.swift; sourceTree = "<group>"; };
 		19801FEA1E31AE1665776372 /* OpenWithCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenWithCatalog.swift; sourceTree = "<group>"; };
+		19DEA0732CC16A0ED51E2FF2 /* OnePasswordPromptFocusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordPromptFocusCoordinator.swift; sourceTree = "<group>"; };
 		1A86E5437CA5FE9BF64605D3 /* WorklaneRenameIPCParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneRenameIPCParserTests.swift; sourceTree = "<group>"; };
 		1AB0C0B38C36D85DBCBACF25 /* MenuBarFleetState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarFleetState.swift; sourceTree = "<group>"; };
 		1AB93DE6432DD894D0CA2C72 /* SidebarBookmarksButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarBookmarksButton.swift; sourceTree = "<group>"; };
@@ -723,6 +730,7 @@
 		1BCA77C435DCC7E4F338789C /* DroidTaskStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidTaskStore.swift; sourceTree = "<group>"; };
 		1CF5DDE2F06EB5CBE4C2E0B9 /* WorklaneState+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneState+Testing.swift"; sourceTree = "<group>"; };
 		1D603FA3B4BCDFE0AC7C4342 /* SidebarBookmarkRowAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarBookmarkRowAction.swift; sourceTree = "<group>"; };
+		1ED8CC8942CC80500B98FD3D /* ProcessInspectionUnixSocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInspectionUnixSocketTests.swift; sourceTree = "<group>"; };
 		1FF2752BE0368370555A776C /* SidebarDropPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDropPlaceholderView.swift; sourceTree = "<group>"; };
 		20147088C6EEA07145EA0961 /* ShellEscaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEscaping.swift; sourceTree = "<group>"; };
 		201F759D378A9A4EC12F40A7 /* WorklaneStore+Reordering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneStore+Reordering.swift"; sourceTree = "<group>"; };
@@ -830,6 +838,7 @@
 		4B83CC56F8834AA75E2315BC /* ZenttyBreadcrumbs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenttyBreadcrumbs.swift; sourceTree = "<group>"; };
 		4C07D99A780805BBF2EC8E2C /* SidebarResizeHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeHandleView.swift; sourceTree = "<group>"; };
 		4C4740E3F7FBB64DB5815643 /* AppCanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCanvasView.swift; sourceTree = "<group>"; };
+		4C571DADB3493CD047A35125 /* OnePasswordPromptFocusCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordPromptFocusCoordinatorTests.swift; sourceTree = "<group>"; };
 		4C88D5D3BFE9433DCC2E7090 /* SidebarDropHitTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDropHitTestingTests.swift; sourceTree = "<group>"; };
 		4CA937E13903E6F4629AE7AA /* ThirdPartyLicenseCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyLicenseCatalogTests.swift; sourceTree = "<group>"; };
 		4D4F4075E849631130D781E1 /* ZenttyCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenttyCLI.swift; sourceTree = "<group>"; };
@@ -879,6 +888,7 @@
 		6036CEA3DA007CEA2955C180 /* SidebarWorklaneRowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorklaneRowButton.swift; sourceTree = "<group>"; };
 		609771315B7DE1068E588518 /* AppActionRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActionRouter.swift; sourceTree = "<group>"; };
 		60B3AD9AA8F799603B573B28 /* ServerWatchRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerWatchRunner.swift; sourceTree = "<group>"; };
+		60F71980F96DC3B2B50A8482 /* OnePasswordPromptAttributorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordPromptAttributorTests.swift; sourceTree = "<group>"; };
 		61A8FD7688E72C2B2A8099EE /* PaneCommandExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCommandExecutorTests.swift; sourceTree = "<group>"; };
 		61F7BA09CEEB123D53CB10C4 /* ServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRegistry.swift; sourceTree = "<group>"; };
 		630B5B3D8685C9D8A186AC9B /* WorklaneStoreServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreServerTests.swift; sourceTree = "<group>"; };
@@ -1016,8 +1026,10 @@
 		97BCD869C25CE3A03966E138 /* MenuBarStatusIconRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusIconRendererTests.swift; sourceTree = "<group>"; };
 		97D22B5BDA360AE3F6A96AE3 /* WorklaneColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneColorTests.swift; sourceTree = "<group>"; };
 		994F524FDC5F10D6A7A96354 /* AboutMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutMetadata.swift; sourceTree = "<group>"; };
+		9A877F28C926381BDC394539 /* OnePasswordPromptDarwinProcessProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordPromptDarwinProcessProvider.swift; sourceTree = "<group>"; };
 		9B314CBC82EBD530AEDF0330 /* ClaudeApprovalResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeApprovalResumeTests.swift; sourceTree = "<group>"; };
 		9B4AE87CC3F4EB591D08B9A7 /* WorkspaceTemplateExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTemplateExporterTests.swift; sourceTree = "<group>"; };
+		9B7F7BF9DF753AEB2FC16031 /* OnePasswordPromptAttributor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordPromptAttributor.swift; sourceTree = "<group>"; };
 		9B89A97084B5AF5AFF873E2C /* BookmarkRestoreLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRestoreLogger.swift; sourceTree = "<group>"; };
 		9C0FDE2EFAFDF416D3D66490 /* HookCanonicalReEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCanonicalReEmitter.swift; sourceTree = "<group>"; };
 		9C60A209D61BAD91EDFF14CF /* DroidEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidEventAdapter.swift; sourceTree = "<group>"; };
@@ -1504,6 +1516,7 @@
 			isa = PBXGroup;
 			children = (
 				E0B5C0E6A8057294C72424F6 /* NotificationChromeCoordinator.swift */,
+				19DEA0732CC16A0ED51E2FF2 /* OnePasswordPromptFocusCoordinator.swift */,
 				07F4CE288A07931095E26D13 /* PaneLayoutMenuCoordinator.swift */,
 			);
 			path = Coordinators;
@@ -1849,6 +1862,8 @@
 				50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */,
 				E85888C3C5FE4E110531EBC8 /* MarkdownReformatter.swift */,
 				765B5594B1CFDD53C4A7C00B /* MockTerminalAdapter.swift */,
+				9B7F7BF9DF753AEB2FC16031 /* OnePasswordPromptAttributor.swift */,
+				9A877F28C926381BDC394539 /* OnePasswordPromptDarwinProcessProvider.swift */,
 				4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */,
 				D7B504722337DBCB03722FD8 /* RemoteFileUploadRequest.swift */,
 				457C3E3EB1160148D4CA02E7 /* RemoteImagePasteDecision.swift */,
@@ -2134,6 +2149,8 @@
 				C771F4DD0F6077D2E72754D0 /* NotificationPopoverViewModelTests.swift */,
 				9D4B42ADBF99ECA847C27E19 /* NotificationSoundManagerTests.swift */,
 				859E02462A30A35800CA0123 /* NotificationStoreTests.swift */,
+				60F71980F96DC3B2B50A8482 /* OnePasswordPromptAttributorTests.swift */,
+				4C571DADB3493CD047A35125 /* OnePasswordPromptFocusCoordinatorTests.swift */,
 				11E538276A60D58C85CD53E0 /* OpenCodeLiveThemeSyncTests.swift */,
 				C675B0F7ABA617674B6D9A82 /* OpenCodeThemeSyncTests.swift */,
 				572BB2FACCFA8A236D880F28 /* OpenWithCatalogTests.swift */,
@@ -2160,6 +2177,7 @@
 				94042661C850159F74FC9F69 /* PaneStripViewTests.swift */,
 				F2C9219C7C69529A79AE9EED /* PassiveServerDetectionTests.swift */,
 				7D7F1086D671D36900F2EF2F /* PathCopiedToastViewProgressTests.swift */,
+				1ED8CC8942CC80500B98FD3D /* ProcessInspectionUnixSocketTests.swift */,
 				7D19D665B0C99E8725E1E7AC /* ProjectIconResolverTests.swift */,
 				5BB5D7EB3C3C6F4CA6325492 /* RemoteFileUploadRequestResolverTests.swift */,
 				DE6082DFE772670E457EB1F4 /* RemoteImagePasteDecisionTests.swift */,
@@ -2578,6 +2596,8 @@
 				D4A63F03ECDA1CF35971F9DE /* NotificationPopoverViewModelTests.swift in Sources */,
 				5FA8FA00D8D061136E09373B /* NotificationSoundManagerTests.swift in Sources */,
 				F326460BA08B4AB927FD355F /* NotificationStoreTests.swift in Sources */,
+				D40E4EAA6007BCDC4EAE77EC /* OnePasswordPromptAttributorTests.swift in Sources */,
+				CF27B265338D61CF4BC44777 /* OnePasswordPromptFocusCoordinatorTests.swift in Sources */,
 				03C2B5400305B015742248E2 /* OpenCodeLiveThemeSyncTests.swift in Sources */,
 				D5977945BCFB04E468408EC3 /* OpenCodeThemeSyncTests.swift in Sources */,
 				F246DE4E17B65DFEA465BF98 /* OpenWithCatalogTests.swift in Sources */,
@@ -2604,6 +2624,7 @@
 				53C04E574AF84DBCF050718B /* PaneStripViewTests.swift in Sources */,
 				9714DA808EA42C0AB29CF840 /* PassiveServerDetectionTests.swift in Sources */,
 				80C1EA098B400A4A8C8E3D6F /* PathCopiedToastViewProgressTests.swift in Sources */,
+				F773918385D26D62A343E77D /* ProcessInspectionUnixSocketTests.swift in Sources */,
 				998FF66C07DB3D9D4BF99784 /* ProjectIconResolverTests.swift in Sources */,
 				30CB07863C026E27D0FF2BB9 /* RemoteFileUploadRequestResolverTests.swift in Sources */,
 				948FF3321AF5D47C542A2297 /* RemoteImagePasteDecisionTests.swift in Sources */,
@@ -2866,6 +2887,9 @@
 				EE2D32723FAD470779B8D7F9 /* NotificationSoundManager.swift in Sources */,
 				AF800D9AC1461F47A82F6214 /* NotificationStore.swift in Sources */,
 				22A5ED0A03EBCBB3248944C3 /* NotificationsSettingsSectionViewController.swift in Sources */,
+				7C7C9956FEE2B693F3D176C7 /* OnePasswordPromptAttributor.swift in Sources */,
+				2B3520C9D571691FB2D09616 /* OnePasswordPromptDarwinProcessProvider.swift in Sources */,
+				7050E94B6C4AEDD28D22A2E3 /* OnePasswordPromptFocusCoordinator.swift in Sources */,
 				AA1411A91AE771850C12A19B /* OpenCodeLiveThemeSync.swift in Sources */,
 				7DD2CFCE524E07DC28C237AA /* OpenCodeOverlayLayout.swift in Sources */,
 				E63C4CB2283E7156688DB16C /* OpenCodeThemeSync.swift in Sources */,

--- a/Zentty/AppDelegate.swift
+++ b/Zentty/AppDelegate.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         configStore: configStore
     )
     private var windowControllers: [ObjectIdentifier: MainWindowController] = [:]
+    private var onePasswordPromptFocusCoordinator: OnePasswordPromptFocusCoordinator?
     private var aboutWindowController: AboutWindowController?
     private var licensesWindowController: LicensesWindowController?
     private var taskManagerWindowController: TaskManagerWindowController?
@@ -116,6 +117,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         UNUserNotificationCenter.current().delegate = self
         applyMenuBarStatusConfig(configStore.current)
+        onePasswordPromptFocusCoordinator = makeOnePasswordPromptFocusCoordinator()
+        onePasswordPromptFocusCoordinator?.start()
 
         // Grandfather existing on-disk hook installs into the consent model
         // before any restore spawns agents, so upgrading users are not prompted
@@ -783,6 +786,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 worklaneStore: controller.worklaneStore
             )
         })
+    }
+
+    private func makeOnePasswordPromptFocusCoordinator() -> OnePasswordPromptFocusCoordinator {
+        OnePasswordPromptFocusCoordinator(
+            hooks: .init(
+                isEnabled: { [weak self] in
+                    self?.configStore.current.panes.focusOnOnePasswordPrompt ?? false
+                },
+                sources: { [weak self] in
+                    self?.onePasswordPromptPaneSources() ?? []
+                },
+                isPaneFocused: { [weak self] source in
+                    self?.windowControllers.values
+                        .first(where: { $0.windowID == source.windowID })?
+                        .isPaneFocused(worklaneID: source.worklaneID, paneID: source.paneID) ?? false
+                },
+                reveal: { [weak self] candidate in
+                    self?.revealPaneForOnePasswordPrompt(candidate)
+                }
+            )
+        )
+    }
+
+    private func onePasswordPromptPaneSources() -> [OnePasswordPromptPaneSource] {
+        orderedWindowControllers.flatMap { controller in
+            controller.worklaneStore.worklanes.flatMap { worklane in
+                worklane.paneStripState.panes.map { pane in
+                    OnePasswordPromptPaneSource(
+                        windowID: controller.windowID,
+                        worklaneID: worklane.id,
+                        paneID: pane.id,
+                        rootPID: worklane.auxiliaryStateByPaneID[pane.id]?.raw.paneRootPID
+                    )
+                }
+            }
+        }
+    }
+
+    private func revealPaneForOnePasswordPrompt(_ candidate: OnePasswordPromptCandidate) {
+        guard let controller = windowControllers.values.first(where: { $0.windowID == candidate.source.windowID }),
+              controller.containsPane(worklaneID: candidate.source.worklaneID, paneID: candidate.source.paneID) else {
+            return
+        }
+        controller.revealPaneForOnePasswordPrompt(
+            worklaneID: candidate.source.worklaneID,
+            paneID: candidate.source.paneID,
+            processName: candidate.processName
+        )
     }
 
     private func focusPaneFromMenuBar(windowID: WindowID, worklaneID: WorklaneID, paneID: PaneID) {

--- a/Zentty/Config/AppConfig.swift
+++ b/Zentty/Config/AppConfig.swift
@@ -145,6 +145,8 @@ struct AppConfig: Equatable, Sendable {
         var smoothScrollingEnabled: Bool
         var focusFollowsMouse: Bool
         var focusFollowsMouseDelay: FocusFollowsMouseDelay
+        /// Jump to the pane whose process made 1Password prompt for approval.
+        var focusOnOnePasswordPrompt: Bool
 
         static let minimumInactiveOpacity: CGFloat = 0.6
         static let maximumInactiveOpacity: CGFloat = 1.0
@@ -156,7 +158,8 @@ struct AppConfig: Equatable, Sendable {
             showProjectIcons: Bool,
             smoothScrollingEnabled: Bool = false,
             focusFollowsMouse: Bool = false,
-            focusFollowsMouseDelay: FocusFollowsMouseDelay = .short
+            focusFollowsMouseDelay: FocusFollowsMouseDelay = .short,
+            focusOnOnePasswordPrompt: Bool = true
         ) {
             self.showLabels = showLabels
             self.showBorders = showBorders
@@ -165,6 +168,7 @@ struct AppConfig: Equatable, Sendable {
             self.smoothScrollingEnabled = smoothScrollingEnabled
             self.focusFollowsMouse = focusFollowsMouse
             self.focusFollowsMouseDelay = focusFollowsMouseDelay
+            self.focusOnOnePasswordPrompt = focusOnOnePasswordPrompt
         }
 
         static let `default` = Panes(
@@ -174,7 +178,8 @@ struct AppConfig: Equatable, Sendable {
             showProjectIcons: true,
             smoothScrollingEnabled: false,
             focusFollowsMouse: false,
-            focusFollowsMouseDelay: .short
+            focusFollowsMouseDelay: .short,
+            focusOnOnePasswordPrompt: true
         )
     }
 
@@ -558,7 +563,8 @@ extension AppConfig.Panes {
             showProjectIcons: showProjectIcons,
             smoothScrollingEnabled: smoothScrollingEnabled,
             focusFollowsMouse: focusFollowsMouse,
-            focusFollowsMouseDelay: focusFollowsMouseDelay
+            focusFollowsMouseDelay: focusFollowsMouseDelay,
+            focusOnOnePasswordPrompt: focusOnOnePasswordPrompt
         )
     }
 }

--- a/Zentty/Config/AppConfigTOML.swift
+++ b/Zentty/Config/AppConfigTOML.swift
@@ -55,6 +55,7 @@ enum AppConfigTOML {
         lines.append("smooth_scroll_enabled = \(config.panes.smoothScrollingEnabled)")
         lines.append("focus_follows_mouse = \(config.panes.focusFollowsMouse)")
         lines.append("focus_follows_mouse_delay = \(encode(string: config.panes.focusFollowsMouseDelay.rawValue))")
+        lines.append("focus_on_1password_prompt = \(config.panes.focusOnOnePasswordPrompt)")
         lines.append("")
 
         if config.appearance != .default {
@@ -655,6 +656,11 @@ enum AppConfigTOML {
                 return false
             }
             config.panes.focusFollowsMouseDelay = delay
+        case "focus_on_1password_prompt":
+            guard let value = decodeBool(assignment.value) else {
+                return false
+            }
+            config.panes.focusOnOnePasswordPrompt = value
         default:
             return true
         }

--- a/Zentty/MainWindowController.swift
+++ b/Zentty/MainWindowController.swift
@@ -848,12 +848,33 @@ final class MainWindowController: NSObject, NSWindowDelegate {
         rootViewController.navigateToPane(worklaneID: worklaneID, paneID: paneID)
     }
 
+    /// Selects a pane without activating Zentty or stealing key status. Used
+    /// when another app (1Password) legitimately holds focus and we only want
+    /// the right pane waiting when the user returns.
+    func revealPaneForOnePasswordPrompt(worklaneID: WorklaneID, paneID: PaneID, processName: String) {
+        if !window.isVisible || window.isMiniaturized {
+            return
+        }
+        if !window.isKeyWindow {
+            window.orderFront(nil)
+        }
+        rootViewController.revealPaneForOnePasswordPrompt(
+            worklaneID: worklaneID,
+            paneID: paneID,
+            processName: processName
+        )
+    }
+
     func containsWorklane(_ worklaneID: WorklaneID) -> Bool {
         rootViewController.containsWorklane(worklaneID)
     }
 
     func containsPane(worklaneID: WorklaneID, paneID: PaneID) -> Bool {
         rootViewController.containsPane(worklaneID: worklaneID, paneID: paneID)
+    }
+
+    func isPaneFocused(worklaneID: WorklaneID, paneID: PaneID) -> Bool {
+        rootViewController.isPaneFocused(worklaneID: worklaneID, paneID: paneID)
     }
 
     func containsPane(_ paneID: PaneID) -> Bool {

--- a/Zentty/Servers/ProcessInspection.swift
+++ b/Zentty/Servers/ProcessInspection.swift
@@ -75,6 +75,59 @@ struct DarwinProcessInspector: ProcessInspecting {
         return kill(pid, 0) == 0 || errno == EPERM
     }
 
+    /// Peer paths of every connected AF_UNIX socket `pid` holds. Lets callers
+    /// tell which local daemon a process is talking to (e.g. an SSH agent).
+    func unixSocketPeerPaths(of pid: pid_t) -> [String] {
+        socketFDs(of: pid).compactMap { fd in
+            var info = socket_fdinfo()
+            let size = MemoryLayout<socket_fdinfo>.size
+            let result = proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, &info, Int32(size))
+            guard result == Int32(size), info.psi.soi_kind == SOCKINFO_UN else {
+                return nil
+            }
+            let path = Self.sunPath(info.psi.soi_proto.pri_un.unsi_caddr.ua_sun)
+            return path.isEmpty ? nil : path
+        }
+    }
+
+    private static func sunPath(_ address: sockaddr_un) -> String {
+        withUnsafeBytes(of: address.sun_path) { rawBuffer in
+            let bytes = rawBuffer.prefix { $0 != 0 }
+            return String(decoding: bytes, as: UTF8.self)
+        }
+    }
+
+    private func socketFDs(of pid: pid_t) -> [Int32] {
+        guard pid > 0 else {
+            return []
+        }
+
+        let byteCount = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        guard byteCount > 0 else {
+            return []
+        }
+
+        let capacity = Int(byteCount) / MemoryLayout<proc_fdinfo>.stride
+        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: capacity)
+        let usedByteCount = fds.withUnsafeMutableBufferPointer { buffer in
+            proc_pidinfo(
+                pid,
+                PROC_PIDLISTFDS,
+                0,
+                buffer.baseAddress,
+                Int32(buffer.count * MemoryLayout<proc_fdinfo>.stride)
+            )
+        }
+        guard usedByteCount > 0 else {
+            return []
+        }
+
+        return fds
+            .prefix(Int(usedByteCount) / MemoryLayout<proc_fdinfo>.stride)
+            .filter { $0.proc_fdtype == UInt32(PROX_FDTYPE_SOCKET) }
+            .map(\.proc_fd)
+    }
+
     private func processIDs() -> [pid_t] {
         let byteCount = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
         guard byteCount > 0 else {
@@ -102,39 +155,7 @@ struct DarwinProcessInspector: ProcessInspecting {
     }
 
     private func listeningTCPSockets(for pid: pid_t) -> [ListeningSocket] {
-        guard pid > 0 else {
-            return []
-        }
-
-        let byteCount = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
-        guard byteCount > 0 else {
-            return []
-        }
-
-        let capacity = Int(byteCount) / MemoryLayout<proc_fdinfo>.stride
-        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: capacity)
-        let usedByteCount = fds.withUnsafeMutableBufferPointer { buffer in
-            proc_pidinfo(
-                pid,
-                PROC_PIDLISTFDS,
-                0,
-                buffer.baseAddress,
-                Int32(buffer.count * MemoryLayout<proc_fdinfo>.stride)
-            )
-        }
-        guard usedByteCount > 0 else {
-            return []
-        }
-
-        return fds
-            .prefix(Int(usedByteCount) / MemoryLayout<proc_fdinfo>.stride)
-            .compactMap { fd -> ListeningSocket? in
-                guard fd.proc_fdtype == UInt32(PROX_FDTYPE_SOCKET) else {
-                    return nil
-                }
-
-                return listeningTCPSocket(pid: pid, fd: fd.proc_fd)
-            }
+        socketFDs(of: pid).compactMap { listeningTCPSocket(pid: pid, fd: $0) }
     }
 
     private func listeningTCPSocket(pid: pid_t, fd: Int32) -> ListeningSocket? {

--- a/Zentty/Terminal/OnePasswordPromptAttributor.swift
+++ b/Zentty/Terminal/OnePasswordPromptAttributor.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// One pane that may have triggered a 1Password authorization prompt.
+struct OnePasswordPromptPaneSource: Equatable, Sendable {
+    let windowID: WindowID
+    let worklaneID: WorklaneID
+    let paneID: PaneID
+    let rootPID: Int32?
+}
+
+/// A pane whose process tree contains a live 1Password request.
+struct OnePasswordPromptCandidate: Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        /// The `op` CLI (talks to the 1Password app or its daemon).
+        case cli
+        /// An SSH-family process holding a connection to the 1Password SSH agent.
+        case sshAgent
+    }
+
+    let source: OnePasswordPromptPaneSource
+    let kind: Kind
+    let pid: Int32
+    let processName: String
+    /// Unix epoch seconds when the requesting process started. Used to pick the
+    /// most recent request when several panes qualify.
+    let startedAt: TimeInterval?
+}
+
+protocol OnePasswordPromptProcessProviding: Sendable {
+    func treePIDs(rootPID: Int32) -> [Int32]
+    func processName(pid: Int32) -> String?
+    func argv(pid: Int32) -> [String]?
+    func startTime(pid: Int32) -> TimeInterval?
+    /// Paths of Unix-domain sockets this process is connected to (peer side).
+    func unixSocketPeerPaths(pid: Int32) -> [String]
+}
+
+/// Answers "which pane made 1Password prompt?" by inspecting pane process
+/// trees. 1Password itself only knows the requesting PID, so this inference is
+/// the only bridge back to a pane.
+struct OnePasswordPromptAttributor: Sendable {
+    static let onePasswordGroupContainerMarker = "2BUA8C4S2C.com.1password"
+    static let sshAgentSocketName = "agent.sock"
+    static let cliProcessName = "op"
+    static let sshProcessNames: Set<String> = ["ssh", "scp", "sftp", "ssh-add", "git", "rsync"]
+
+    private let processProvider: any OnePasswordPromptProcessProviding
+
+    init(processProvider: any OnePasswordPromptProcessProviding) {
+        self.processProvider = processProvider
+    }
+
+    /// Scans every source and returns the candidates, most recently started first.
+    /// Each pane contributes at most one candidate (its newest request).
+    func candidates(in sources: [OnePasswordPromptPaneSource]) -> [OnePasswordPromptCandidate] {
+        var results: [OnePasswordPromptCandidate] = []
+        for source in sources {
+            guard let rootPID = source.rootPID, rootPID > 0 else {
+                continue
+            }
+            let paneCandidates = processProvider.treePIDs(rootPID: rootPID)
+                .compactMap { candidate(for: $0, in: source) }
+            if let newest = Self.sortedByRecency(paneCandidates).first {
+                results.append(newest)
+            }
+        }
+        return Self.sortedByRecency(results)
+    }
+
+    /// The single pane to jump to, or nil when nothing qualifies.
+    func bestCandidate(in sources: [OnePasswordPromptPaneSource]) -> OnePasswordPromptCandidate? {
+        candidates(in: sources).first
+    }
+
+    private func candidate(for pid: Int32, in source: OnePasswordPromptPaneSource) -> OnePasswordPromptCandidate? {
+        guard let name = processProvider.processName(pid: pid), !name.isEmpty else {
+            return nil
+        }
+
+        if name == Self.cliProcessName {
+            guard Self.isCLIClient(argv: processProvider.argv(pid: pid)) else {
+                return nil
+            }
+            return OnePasswordPromptCandidate(
+                source: source,
+                kind: .cli,
+                pid: pid,
+                processName: name,
+                startedAt: processProvider.startTime(pid: pid)
+            )
+        }
+
+        if Self.sshProcessNames.contains(name),
+           processProvider.unixSocketPeerPaths(pid: pid).contains(where: Self.isOnePasswordAgentSocket) {
+            return OnePasswordPromptCandidate(
+                source: source,
+                kind: .sshAgent,
+                pid: pid,
+                processName: name,
+                startedAt: processProvider.startTime(pid: pid)
+            )
+        }
+
+        return nil
+    }
+
+    /// `op daemon` is a detached helper (parent PID 1) that never prompts on its
+    /// own; only real client invocations count.
+    static func isCLIClient(argv: [String]?) -> Bool {
+        guard let argv, argv.count > 1 else {
+            return true
+        }
+        return argv[1] != "daemon" && argv[1] != "cleanup"
+    }
+
+    static func isOnePasswordAgentSocket(_ path: String) -> Bool {
+        path.contains(onePasswordGroupContainerMarker) && path.hasSuffix("/" + sshAgentSocketName)
+    }
+
+    private static func sortedByRecency(_ candidates: [OnePasswordPromptCandidate]) -> [OnePasswordPromptCandidate] {
+        candidates.sorted { lhs, rhs in
+            switch (lhs.startedAt, rhs.startedAt) {
+            case let (l?, r?) where l != r:
+                return l > r
+            case (nil, .some):
+                return false
+            case (.some, nil):
+                return true
+            default:
+                return lhs.pid > rhs.pid
+            }
+        }
+    }
+}

--- a/Zentty/Terminal/OnePasswordPromptDarwinProcessProvider.swift
+++ b/Zentty/Terminal/OnePasswordPromptDarwinProcessProvider.swift
@@ -1,0 +1,34 @@
+import Darwin
+import Foundation
+
+/// Real `proc_*` backed provider for `OnePasswordPromptAttributor`.
+struct OnePasswordPromptDarwinProcessProvider: OnePasswordPromptProcessProviding {
+    private let treeProvider = DarwinPaneSSHProcessTreeProvider()
+    private let argvProvider = DarwinPaneSSHProcessArgvProvider()
+
+    func treePIDs(rootPID: Int32) -> [Int32] {
+        treeProvider.treePIDs(rootPID: rootPID)
+    }
+
+    func processName(pid: Int32) -> String? {
+        treeProvider.processName(pid: pid)
+    }
+
+    func argv(pid: Int32) -> [String]? {
+        argvProvider.argv(pid: pid)
+    }
+
+    func startTime(pid: Int32) -> TimeInterval? {
+        var info = proc_bsdinfo()
+        let size = MemoryLayout<proc_bsdinfo>.stride
+        let result = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(size))
+        guard result == Int32(size) else {
+            return nil
+        }
+        return TimeInterval(info.pbi_start_tvsec) + TimeInterval(info.pbi_start_tvusec) / 1_000_000
+    }
+
+    func unixSocketPeerPaths(pid: Int32) -> [String] {
+        DarwinProcessInspector().unixSocketPeerPaths(of: pid)
+    }
+}

--- a/Zentty/UI/Coordinators/OnePasswordPromptFocusCoordinator.swift
+++ b/Zentty/UI/Coordinators/OnePasswordPromptFocusCoordinator.swift
@@ -1,0 +1,208 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import os
+
+/// One on-screen window, as much as we need to spot a 1Password prompt.
+struct OnePasswordPromptWindow: Hashable, Sendable {
+    let id: Int
+    let ownerName: String
+}
+
+protocol OnePasswordPromptWindowSnapshotting: Sendable {
+    func onScreenWindows() -> [OnePasswordPromptWindow]
+}
+
+/// Reads the on-screen window list. Owner names come back without any
+/// screen-recording entitlement; window titles would not, so we never rely on them.
+struct DarwinOnePasswordPromptWindowSnapshotter: OnePasswordPromptWindowSnapshotting {
+    func onScreenWindows() -> [OnePasswordPromptWindow] {
+        guard let list = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+        return list.compactMap { info in
+            guard let id = info[kCGWindowNumber as String] as? Int,
+                  let owner = info[kCGWindowOwnerName as String] as? String else {
+                return nil
+            }
+            return OnePasswordPromptWindow(id: id, ownerName: owner)
+        }
+    }
+}
+
+/// Jumps to the pane that made 1Password prompt for approval.
+///
+/// 1Password's approval prompt is a floating panel that never activates the
+/// app, so there is no activation notification to hook. Instead this polls the
+/// on-screen window list a few times a second and, when a new window from
+/// 1Password (or from the system Touch ID sheet host) appears, scans every
+/// pane's process tree for a live `op` or SSH-agent request. The matching pane
+/// is revealed inside Zentty without activating Zentty, so the prompt keeps
+/// focus and the right pane is already selected when the user returns.
+///
+/// Every trigger is gated by attribution: a new window only causes a jump when
+/// some pane really holds a live 1Password request, so the generic Touch ID
+/// host is a safe trigger too.
+@MainActor
+final class OnePasswordPromptFocusCoordinator {
+    struct Hooks {
+        let isEnabled: () -> Bool
+        let sources: () -> [OnePasswordPromptPaneSource]
+        /// Whether the pane is already the focused pane of its own window.
+        let isPaneFocused: (OnePasswordPromptPaneSource) -> Bool
+        let reveal: (OnePasswordPromptCandidate) -> Void
+    }
+
+    /// Window owners whose new windows can be an approval prompt.
+    static let promptWindowOwners: Set<String> = ["1Password", "UserNotificationCenter"]
+    static let onePasswordBundleIdentifier = "com.1password.1password"
+    /// Ticks between checks whether 1Password is running at all.
+    private static let presenceCheckTicks = 20
+    private static let logger = Logger(subsystem: "be.zenjoy.zentty", category: "OnePasswordPromptFocus")
+
+    private let hooks: Hooks
+    private let attributor: OnePasswordPromptAttributor
+    private let snapshotter: any OnePasswordPromptWindowSnapshotting
+    private let pollInterval: TimeInterval
+    private let minimumInterval: TimeInterval
+    private let scanExecutor: (@escaping @Sendable () -> Void) -> Void
+    private let now: () -> Date
+    private let isOnePasswordRunning: () -> Bool
+    private var timer: Timer?
+    private var knownWindowIDs: Set<Int>?
+    private var ticksUntilPresenceCheck = 0
+    private var onePasswordPresent = false
+    private var lastHandledAt: Date?
+    private var scanGeneration = 0
+
+    init(
+        hooks: Hooks,
+        attributor: OnePasswordPromptAttributor = OnePasswordPromptAttributor(
+            processProvider: OnePasswordPromptDarwinProcessProvider()
+        ),
+        snapshotter: any OnePasswordPromptWindowSnapshotting = DarwinOnePasswordPromptWindowSnapshotter(),
+        pollInterval: TimeInterval = 0.25,
+        minimumInterval: TimeInterval = 0.75,
+        isOnePasswordRunning: @escaping () -> Bool = {
+            !NSRunningApplication.runningApplications(
+                withBundleIdentifier: OnePasswordPromptFocusCoordinator.onePasswordBundleIdentifier
+            ).isEmpty
+        },
+        scanExecutor: @escaping (@escaping @Sendable () -> Void) -> Void = { work in
+            DispatchQueue.global(qos: .userInitiated).async(execute: work)
+        },
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.hooks = hooks
+        self.attributor = attributor
+        self.snapshotter = snapshotter
+        self.pollInterval = pollInterval
+        self.minimumInterval = minimumInterval
+        self.isOnePasswordRunning = isOnePasswordRunning
+        self.scanExecutor = scanExecutor
+        self.now = now
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        let timer = Timer(timeInterval: pollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.poll()
+            }
+        }
+        timer.tolerance = pollInterval / 4
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        knownWindowIDs = nil
+        ticksUntilPresenceCheck = 0
+    }
+
+    private func poll() {
+        guard hooks.isEnabled() else {
+            knownWindowIDs = nil
+            return
+        }
+        if ticksUntilPresenceCheck == 0 {
+            onePasswordPresent = isOnePasswordRunning()
+            ticksUntilPresenceCheck = Self.presenceCheckTicks
+        }
+        ticksUntilPresenceCheck -= 1
+        guard onePasswordPresent else {
+            knownWindowIDs = nil
+            return
+        }
+        handleWindowSnapshot(snapshotter.onScreenWindows())
+    }
+
+    /// Feeds one window-list sample. Returns true when a scan was started.
+    /// The first sample after (re)start only seeds the baseline.
+    @discardableResult
+    func handleWindowSnapshot(_ windows: [OnePasswordPromptWindow]) -> Bool {
+        let currentIDs = Set(windows.map(\.id))
+        defer { knownWindowIDs = currentIDs }
+        guard let knownWindowIDs else {
+            return false
+        }
+
+        let newPromptWindows = windows.filter {
+            !knownWindowIDs.contains($0.id) && Self.promptWindowOwners.contains($0.ownerName)
+        }
+        guard let trigger = newPromptWindows.first else {
+            return false
+        }
+        return startScan(reason: trigger.ownerName)
+    }
+
+    private func startScan(reason: String) -> Bool {
+        let timestamp = now()
+        if let lastHandledAt, timestamp.timeIntervalSince(lastHandledAt) < minimumInterval {
+            Self.logger.debug("New \(reason, privacy: .public) window within the debounce window; ignoring")
+            return false
+        }
+        lastHandledAt = timestamp
+
+        let sources = hooks.sources()
+        let scannable = sources.filter { $0.rootPID != nil }
+        guard !scannable.isEmpty else {
+            Self.logger.info(
+                "New \(reason, privacy: .public) window but no pane reports a root PID (\(sources.count, privacy: .public) panes)"
+            )
+            return false
+        }
+        Self.logger.debug(
+            "New \(reason, privacy: .public) window; scanning \(scannable.count, privacy: .public) of \(sources.count, privacy: .public) panes"
+        )
+
+        scanGeneration += 1
+        let generation = scanGeneration
+        let attributor = self.attributor
+        scanExecutor { [weak self] in
+            let candidate = attributor.bestCandidate(in: scannable)
+            Task { @MainActor in
+                self?.finishScan(generation: generation, candidate: candidate)
+            }
+        }
+        return true
+    }
+
+    private func finishScan(generation: Int, candidate: OnePasswordPromptCandidate?) {
+        guard generation == scanGeneration else { return }
+        guard let candidate else {
+            Self.logger.debug("No pane holds a live 1Password request")
+            return
+        }
+        if hooks.isPaneFocused(candidate.source) {
+            Self.logger.debug("1Password request pane already focused pid=\(candidate.pid, privacy: .public)")
+            return
+        }
+        Self.logger.info(
+            "Revealing pane for 1Password request process=\(candidate.processName, privacy: .public) pid=\(candidate.pid, privacy: .public)"
+        )
+        hooks.reveal(candidate)
+    }
+}

--- a/Zentty/UI/RootViewController.swift
+++ b/Zentty/UI/RootViewController.swift
@@ -1598,6 +1598,15 @@ final class RootViewController: NSViewController {
             windowID: windowID, worklaneID: worklaneID, paneID: paneID)
     }
 
+    /// Like `navigateToPane` but without resolving pane notifications: the user
+    /// has not seen this pane yet, 1Password merely pointed us at it.
+    func revealPaneForOnePasswordPrompt(worklaneID: WorklaneID, paneID: PaneID, processName: String) {
+        worklaneStore.selectWorklaneAndFocusPane(worklaneID: worklaneID, paneID: paneID)
+        view.layoutSubtreeIfNeeded()
+        runtimeRegistry.runtime(for: paneID)?.forceViewportSync()
+        showToast(message: "1Password request from \(processName) in this pane", duration: 4)
+    }
+
     private func navigateToNotification(_ notification: AppNotification) {
         if notification.windowID == windowID {
             navigateToPane(worklaneID: notification.worklaneID, paneID: notification.paneID)
@@ -2446,6 +2455,13 @@ final class RootViewController: NSViewController {
 
     func focusedPaneID(in worklaneID: WorklaneID) -> PaneID? {
         worklaneStore.worklanes.first { $0.id == worklaneID }?.paneStripState.focusedPaneID
+    }
+
+    func isPaneFocused(worklaneID: WorklaneID, paneID: PaneID) -> Bool {
+        guard let active = worklaneStore.activeWorklane, active.id == worklaneID else {
+            return false
+        }
+        return active.paneStripState.focusedPaneID == paneID
     }
 
     func containsPane(worklaneID: WorklaneID, paneID: PaneID) -> Bool {

--- a/Zentty/UI/Settings/SettingsSectionViewControllers.swift
+++ b/Zentty/UI/Settings/SettingsSectionViewControllers.swift
@@ -187,6 +187,7 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
     private let showProjectIconsSwitch = NSSwitch()
     private let smoothScrollingSwitch = NSSwitch()
     private let focusFollowsMouseSwitch = NSSwitch()
+    private let focusOnOnePasswordPromptSwitch = NSSwitch()
     private let focusFollowsMouseDelayControl = NSSegmentedControl(
         labels: AppConfig.Panes.FocusFollowsMouseDelay.allCases.map(\.title),
         trackingMode: .selectOne,
@@ -341,6 +342,7 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         showProjectIconsSwitch.state = panes.showProjectIcons ? .on : .off
         smoothScrollingSwitch.state = panes.smoothScrollingEnabled ? .on : .off
         focusFollowsMouseSwitch.state = panes.focusFollowsMouse ? .on : .off
+        focusOnOnePasswordPromptSwitch.state = panes.focusOnOnePasswordPrompt ? .on : .off
         let selectedDelaySegment = AppConfig.Panes.FocusFollowsMouseDelay.allCases.firstIndex(of: panes.focusFollowsMouseDelay)
         assert(selectedDelaySegment != nil, "Focus-follows-mouse delay must have a matching segment")
         focusFollowsMouseDelayControl.selectedSegment = selectedDelaySegment ?? 0
@@ -540,6 +542,15 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         let focusFollowsMouseRow = makeFocusFollowsMouseRow()
         contentStack.addArrangedSubview(focusFollowsMouseRow)
         focusFollowsMouseRow.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+
+        let onePasswordRow = makeSwitchRow(
+            title: "Jump to pane on 1Password prompt",
+            subtitle: "When 1Password asks to approve a CLI or SSH request, select the pane that made it.",
+            toggle: focusOnOnePasswordPromptSwitch,
+            action: #selector(handleFocusOnOnePasswordPromptChanged(_:))
+        )
+        contentStack.addArrangedSubview(onePasswordRow)
+        onePasswordRow.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
 
         SettingsFormBuilder.separator(addedTo: contentStack)
 
@@ -838,6 +849,14 @@ final class PaneLayoutSettingsSectionViewController: SettingsScrollableSectionVi
         guard !isApplyingPanes else { return }
         try? configStore.update {
             $0.panes.focusFollowsMouse = updatedPanes.focusFollowsMouse
+        }
+    }
+
+    @objc
+    private func handleFocusOnOnePasswordPromptChanged(_ sender: NSSwitch) {
+        guard !isApplyingPanes else { return }
+        try? configStore.update {
+            $0.panes.focusOnOnePasswordPrompt = sender.state == .on
         }
     }
 

--- a/ZenttyLogicTests/AppConfigStoreTests.swift
+++ b/ZenttyLogicTests/AppConfigStoreTests.swift
@@ -78,6 +78,7 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertTrue(persisted.contains("smooth_scroll_enabled = false"))
         XCTAssertTrue(persisted.contains("focus_follows_mouse = false"))
         XCTAssertTrue(persisted.contains("focus_follows_mouse_delay = \"short\""))
+        XCTAssertTrue(persisted.contains("focus_on_1password_prompt = true"))
         XCTAssertTrue(persisted.contains("[open_with]"))
         XCTAssertTrue(persisted.contains("enabled_target_ids = [\"finder\", \"vscode\", \"cursor\", \"xcode\"]"))
         XCTAssertTrue(persisted.contains("[error_reporting]"))
@@ -96,6 +97,7 @@ final class AppConfigStoreTests: XCTestCase {
             smooth_scroll_enabled = true
             focus_follows_mouse = true
             focus_follows_mouse_delay = "immediate"
+            focus_on_1password_prompt = false
             """.write(to: fileURL, atomically: true, encoding: .utf8)
 
         let store = AppConfigStore(
@@ -111,6 +113,7 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertTrue(store.current.panes.smoothScrollingEnabled)
         XCTAssertTrue(store.current.panes.focusFollowsMouse)
         XCTAssertEqual(store.current.panes.focusFollowsMouseDelay, .immediate)
+        XCTAssertFalse(store.current.panes.focusOnOnePasswordPrompt)
     }
 
     func test_store_reads_worklane_placement_from_config_file() throws {
@@ -279,6 +282,7 @@ final class AppConfigStoreTests: XCTestCase {
             config.panes.smoothScrollingEnabled = true
             config.panes.focusFollowsMouse = true
             config.panes.focusFollowsMouseDelay = .immediate
+            config.panes.focusOnOnePasswordPrompt = false
             config.openWith.primaryTargetID = "cursor"
             config.openWith.enabledTargetIDs = ["cursor", "finder"]
             config.errorReporting.enabled = false
@@ -298,6 +302,7 @@ final class AppConfigStoreTests: XCTestCase {
         XCTAssertTrue(persisted.contains("smooth_scroll_enabled = true"))
         XCTAssertTrue(persisted.contains("focus_follows_mouse = true"))
         XCTAssertTrue(persisted.contains("focus_follows_mouse_delay = \"immediate\""))
+        XCTAssertTrue(persisted.contains("focus_on_1password_prompt = false"))
         XCTAssertTrue(persisted.contains("primary_target_id = \"cursor\""))
         XCTAssertTrue(persisted.contains("[error_reporting]"))
         XCTAssertTrue(persisted.contains("enabled = false"))

--- a/ZenttyLogicTests/OnePasswordPromptAttributorTests.swift
+++ b/ZenttyLogicTests/OnePasswordPromptAttributorTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Zentty
+
+final class OnePasswordPromptAttributorTests: XCTestCase {
+    private let agentSocket = "/Users/peter/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+
+    func test_finds_pane_running_op_cli() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101, 102]],
+            names: [100: "zsh", 101: "claude", 102: "op"],
+            argv: [102: ["op", "read", "op://vault/item"]],
+            startTimes: [102: 50]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        let candidate = attributor.bestCandidate(in: [source(pane: "a", rootPID: 100)])
+
+        XCTAssertEqual(candidate?.source.paneID, PaneID("a"))
+        XCTAssertEqual(candidate?.kind, .cli)
+        XCTAssertEqual(candidate?.pid, 102)
+    }
+
+    func test_ignores_op_daemon_and_panes_without_requests() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101], 200: [200]],
+            names: [100: "zsh", 101: "op", 200: "zsh"],
+            argv: [101: ["op", "daemon", "--background"]]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        XCTAssertNil(attributor.bestCandidate(in: [source(pane: "a", rootPID: 100), source(pane: "b", rootPID: 200)]))
+    }
+
+    func test_finds_ssh_connected_to_one_password_agent_only() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101], 200: [200, 201]],
+            names: [100: "zsh", 101: "ssh", 200: "zsh", 201: "ssh"],
+            peerPaths: [101: ["/tmp/other.sock"], 201: [agentSocket]]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        let candidates = attributor.candidates(in: [source(pane: "a", rootPID: 100), source(pane: "b", rootPID: 200)])
+
+        XCTAssertEqual(candidates.map(\.source.paneID), [PaneID("b")])
+        XCTAssertEqual(candidates.first?.kind, .sshAgent)
+    }
+
+    func test_git_using_agent_counts_as_ssh_request() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101, 102]],
+            names: [100: "zsh", 101: "git", 102: "ssh"],
+            peerPaths: [102: [agentSocket]]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        XCTAssertEqual(attributor.bestCandidate(in: [source(pane: "a", rootPID: 100)])?.pid, 102)
+    }
+
+    func test_prefers_most_recently_started_request_across_panes() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101], 200: [200, 201]],
+            names: [100: "zsh", 101: "op", 200: "zsh", 201: "op"],
+            startTimes: [101: 10, 201: 20]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        let candidates = attributor.candidates(in: [source(pane: "a", rootPID: 100), source(pane: "b", rootPID: 200)])
+
+        XCTAssertEqual(candidates.map(\.source.paneID), [PaneID("b"), PaneID("a")])
+    }
+
+    func test_pane_contributes_only_its_newest_request() {
+        let provider = FakeOnePasswordProcessProvider(
+            trees: [100: [100, 101, 102]],
+            names: [100: "zsh", 101: "op", 102: "op"],
+            startTimes: [101: 5, 102: 9]
+        )
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        let candidates = attributor.candidates(in: [source(pane: "a", rootPID: 100)])
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.pid, 102)
+    }
+
+    func test_skips_sources_without_root_pid() {
+        let provider = FakeOnePasswordProcessProvider(trees: [:], names: [:])
+        let attributor = OnePasswordPromptAttributor(processProvider: provider)
+
+        XCTAssertNil(attributor.bestCandidate(in: [source(pane: "a", rootPID: nil)]))
+        XCTAssertTrue(provider.requestedRoots.isEmpty)
+    }
+
+    func test_agent_socket_matcher_requires_one_password_container() {
+        XCTAssertTrue(OnePasswordPromptAttributor.isOnePasswordAgentSocket(agentSocket))
+        XCTAssertFalse(OnePasswordPromptAttributor.isOnePasswordAgentSocket("/tmp/ssh-XXXX/agent.sock"))
+        XCTAssertFalse(OnePasswordPromptAttributor.isOnePasswordAgentSocket(
+            "/Users/peter/Library/Group Containers/2BUA8C4S2C.com.1password/t/s.sock"
+        ))
+    }
+
+    private func source(pane: String, rootPID: Int32?) -> OnePasswordPromptPaneSource {
+        OnePasswordPromptPaneSource(
+            windowID: WindowID("w"),
+            worklaneID: WorklaneID("l"),
+            paneID: PaneID(pane),
+            rootPID: rootPID
+        )
+    }
+}
+
+private final class FakeOnePasswordProcessProvider: OnePasswordPromptProcessProviding, @unchecked Sendable {
+    private let trees: [Int32: [Int32]]
+    private let names: [Int32: String]
+    private let argvByPID: [Int32: [String]]
+    private let startTimes: [Int32: TimeInterval]
+    private let peerPaths: [Int32: [String]]
+    private(set) var requestedRoots: [Int32] = []
+
+    init(
+        trees: [Int32: [Int32]],
+        names: [Int32: String],
+        argv: [Int32: [String]] = [:],
+        startTimes: [Int32: TimeInterval] = [:],
+        peerPaths: [Int32: [String]] = [:]
+    ) {
+        self.trees = trees
+        self.names = names
+        self.argvByPID = argv
+        self.startTimes = startTimes
+        self.peerPaths = peerPaths
+    }
+
+    func treePIDs(rootPID: Int32) -> [Int32] {
+        requestedRoots.append(rootPID)
+        return trees[rootPID] ?? []
+    }
+
+    func processName(pid: Int32) -> String? { names[pid] }
+    func argv(pid: Int32) -> [String]? { argvByPID[pid] }
+    func startTime(pid: Int32) -> TimeInterval? { startTimes[pid] }
+    func unixSocketPeerPaths(pid: Int32) -> [String] { peerPaths[pid] ?? [] }
+}

--- a/ZenttyLogicTests/OnePasswordPromptFocusCoordinatorTests.swift
+++ b/ZenttyLogicTests/OnePasswordPromptFocusCoordinatorTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import Zentty
+
+@MainActor
+final class OnePasswordPromptFocusCoordinatorTests: XCTestCase {
+    private var revealed: [OnePasswordPromptCandidate] = []
+    private var focusedPaneID: PaneID?
+    private var clock = Date(timeIntervalSince1970: 1_000)
+
+    private let baseline = [
+        OnePasswordPromptWindow(id: 1, ownerName: "Finder"),
+        OnePasswordPromptWindow(id: 2, ownerName: "1Password"),
+    ]
+
+    func test_first_snapshot_only_seeds_baseline() {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+
+        XCTAssertFalse(coordinator.handleWindowSnapshot(baseline))
+        XCTAssertFalse(coordinator.handleWindowSnapshot(baseline))
+    }
+
+    func test_new_one_password_window_reveals_pane_running_op() async {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "1Password")]))
+        await Task.yield()
+
+        XCTAssertEqual(revealed.map(\.source.paneID), [PaneID("a")])
+    }
+
+    func test_new_touch_id_host_window_also_triggers_scan() {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "UserNotificationCenter")]))
+    }
+
+    func test_new_windows_from_other_apps_are_ignored() async {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertFalse(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "Raycast")]))
+        await Task.yield()
+
+        XCTAssertTrue(revealed.isEmpty)
+    }
+
+    func test_windows_that_disappear_and_return_count_as_new() {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+        XCTAssertFalse(coordinator.handleWindowSnapshot([baseline[0]]))
+        clock = clock.addingTimeInterval(2)
+
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline))
+    }
+
+    func test_debounces_rapid_triggers() {
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "1Password")]))
+        clock = clock.addingTimeInterval(0.2)
+        XCTAssertFalse(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 10, ownerName: "1Password")]))
+        clock = clock.addingTimeInterval(2)
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 11, ownerName: "1Password")]))
+    }
+
+    func test_skips_reveal_when_request_pane_is_already_focused() async {
+        focusedPaneID = PaneID("a")
+        let coordinator = makeCoordinator(opPIDs: [100: 101])
+        coordinator.handleWindowSnapshot(baseline)
+
+        coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "1Password")])
+        await Task.yield()
+
+        XCTAssertTrue(revealed.isEmpty)
+    }
+
+    func test_no_reveal_when_no_pane_holds_a_request() async {
+        let coordinator = makeCoordinator(opPIDs: [:], sources: [
+            OnePasswordPromptPaneSource(windowID: WindowID("w"), worklaneID: WorklaneID("l"), paneID: PaneID("a"), rootPID: 100)
+        ])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "1Password")]))
+        await Task.yield()
+
+        XCTAssertTrue(revealed.isEmpty)
+    }
+
+    func test_does_not_scan_when_no_pane_has_a_root_pid() {
+        let coordinator = makeCoordinator(opPIDs: [:], sources: [
+            OnePasswordPromptPaneSource(windowID: WindowID("w"), worklaneID: WorklaneID("l"), paneID: PaneID("a"), rootPID: nil)
+        ])
+        coordinator.handleWindowSnapshot(baseline)
+
+        XCTAssertFalse(coordinator.handleWindowSnapshot(baseline + [OnePasswordPromptWindow(id: 9, ownerName: "1Password")]))
+    }
+
+    private func makeCoordinator(
+        opPIDs: [Int32: Int32],
+        sources: [OnePasswordPromptPaneSource]? = nil
+    ) -> OnePasswordPromptFocusCoordinator {
+        let provider = StubProvider(opPIDs: opPIDs)
+        let defaultSources = opPIDs.keys.sorted().enumerated().map { index, rootPID in
+            OnePasswordPromptPaneSource(
+                windowID: WindowID("w"),
+                worklaneID: WorklaneID("l"),
+                paneID: PaneID(String(UnicodeScalar(UInt8(97 + index)))),
+                rootPID: rootPID
+            )
+        }
+        return OnePasswordPromptFocusCoordinator(
+            hooks: .init(
+                isEnabled: { true },
+                sources: { sources ?? defaultSources },
+                isPaneFocused: { [unowned self] source in source.paneID == focusedPaneID },
+                reveal: { [unowned self] in revealed.append($0) }
+            ),
+            attributor: OnePasswordPromptAttributor(processProvider: provider),
+            snapshotter: StubSnapshotter(),
+            scanExecutor: { $0() },
+            now: { [unowned self] in clock }
+        )
+    }
+}
+
+private struct StubSnapshotter: OnePasswordPromptWindowSnapshotting {
+    func onScreenWindows() -> [OnePasswordPromptWindow] { [] }
+}
+
+private struct StubProvider: OnePasswordPromptProcessProviding {
+    /// root pid -> pid of an `op` child
+    let opPIDs: [Int32: Int32]
+
+    func treePIDs(rootPID: Int32) -> [Int32] { [rootPID] + (opPIDs[rootPID].map { [$0] } ?? []) }
+    func processName(pid: Int32) -> String? { opPIDs.values.contains(pid) ? "op" : "zsh" }
+    func argv(pid: Int32) -> [String]? { ["op", "read"] }
+    func startTime(pid: Int32) -> TimeInterval? { TimeInterval(pid) }
+    func unixSocketPeerPaths(pid: Int32) -> [String] { [] }
+}

--- a/ZenttyLogicTests/ProcessInspectionUnixSocketTests.swift
+++ b/ZenttyLogicTests/ProcessInspectionUnixSocketTests.swift
@@ -1,0 +1,53 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import Zentty
+
+final class ProcessInspectionUnixSocketTests: XCTestCase {
+    func test_unix_socket_peer_paths_reports_connected_server_path() throws {
+        // Short path: sockaddr_un.sun_path is 104 bytes.
+        let path = "/tmp/zentty-\(getpid())-\(UInt32.random(in: 0...9999)).sock"
+        unlink(path)
+        defer { unlink(path) }
+
+        let server = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(server, 0)
+        defer { close(server) }
+        var address = try Self.makeAddress(path)
+        let addressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.bind(server, $0, addressLength) }
+        }
+        XCTAssertEqual(bound, 0, "bind failed errno=\(errno)")
+        XCTAssertEqual(listen(server, 1), 0)
+
+        let client = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(client, 0)
+        defer { close(client) }
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.connect(client, $0, addressLength) }
+        }
+        XCTAssertEqual(connected, 0, "connect failed errno=\(errno)")
+
+        let peers = DarwinProcessInspector().unixSocketPeerPaths(of: getpid())
+
+        XCTAssertTrue(peers.contains(path), "peers=\(peers)")
+    }
+
+    private static func makeAddress(_ path: String) throws -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard bytes.count < capacity else {
+            throw XCTSkip("socket path too long")
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            for (index, byte) in bytes.enumerated() {
+                buffer[index] = byte
+            }
+            buffer[bytes.count] = 0
+        }
+        return address
+    }
+}


### PR DESCRIPTION
When an agent runs `op` or pushes over the 1Password SSH agent, the Touch ID prompt shows up with no hint of which pane asked for it. This makes Zentty jump to that pane.

## How it works

1Password gives no API for "PID X is waiting", and its approval prompt is a floating panel that never activates the app, so there is no activation notification to hook. What does exist: the prompt is a new on-screen window owned by the `1Password` process (layer 101), preceded a few seconds earlier by a small window from `UserNotificationCenter`, the Touch ID sheet host. Owner names come back from `CGWindowListCopyWindowInfo` without any screen-recording permission.

So the coordinator polls the on-screen window list four times a second while 1Password is running. When a new window from either owner appears, it walks every pane's process tree looking for:

- an `op` client (the detached `op daemon` that op 2.30+ spawns is skipped), or
- an ssh-family process holding a Unix socket whose peer is 1Password's `agent.sock`.

If it finds one, it selects that pane inside its window without activating Zentty, so the prompt keeps focus and the right pane is waiting when you come back. A short toast names the process. Nothing happens when the pane is already focused, when no pane has a live request, or on repeated windows within 750 ms. Because every trigger is gated by attribution, a `sudo` Touch ID prompt with no `op` around does nothing.

Off switch: Panes settings, "Jump to pane on 1Password prompt" (`focus_on_1password_prompt`, on by default).

## Verified

Live on my machine: both triggers fired within milliseconds of the prompt, the scan covered 43 panes and found the `op` process. Logic suite: 3902 tests, 0 failures, including a test that binds and connects a real Unix socket and checks the kernel reports the peer path.

## Notes

- Root PIDs come from the zsh and bash shell integration. Panes on fish or nushell are skipped for now; the log says so.
- The TCP listener path in `ProcessInspection` now shares the fd listing with the new AF_UNIX lookup, which is why that diff looks bigger than it is.
