### PR TITLE
feat(sidebar): show running subagents per pane with their models

### DIFF
--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		1DE4C3C91E5770CB8CE1E3A4 /* SidebarDragCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69983960CBA87599B87355C /* SidebarDragCoordinator.swift */; };
 		1F8E1A9AF4D6D24D2C324242 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC138BE273ED92291124633 /* main.swift */; };
 		20459CEE51A96AF170ED7492 /* WorklanePeekLaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D88D88BD41402ADB9A63D5 /* WorklanePeekLaneViewTests.swift */; };
+		20CA0CB311BED0EA2DD31AED /* AgentSubagentRegistryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507367AFCFE0B79C370223A5 /* AgentSubagentRegistryStore.swift */; };
 		2163AD9630BB1A6A2413CFA2 /* PaneDragInsertionLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470B2E9611ABBDDD841438E9 /* PaneDragInsertionLineView.swift */; };
 		21B5B2D8D083E4D952FD9E03 /* TerminalClipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB1561FD9C602B6D306155C /* TerminalClipboard.swift */; };
 		21E006D9ECF19B42A661D6C1 /* AppConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C491850BAA79B14AE9C4FF56 /* AppConfigStore.swift */; };
@@ -226,6 +227,7 @@
 		5EC6012DA9430BE8D4B3346C /* VibeHooksInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A456B5C222F30C2DB528E0 /* VibeHooksInstaller.swift */; };
 		5F94EB5F5A6F59AD32F605CD /* MainActorShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E46B2946B1B85B846A487F /* MainActorShim.swift */; };
 		5FA8FA00D8D061136E09373B /* NotificationSoundManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4B42ADBF99ECA847C27E19 /* NotificationSoundManagerTests.swift */; };
+		5FDBD0983E309C2444F4A2C7 /* AgentSubagentTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FED3179D3B717E218F78E4C /* AgentSubagentTrackingTests.swift */; };
 		60BEB8CBA618C6A4DD0A69C5 /* ProcessSignaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5382921BB166EEA584F3E6 /* ProcessSignaling.swift */; };
 		60F13E1D9931F1321C002362 /* ServerRelevance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66E9360C107E9A7D3F05652 /* ServerRelevance.swift */; };
 		617C88C4ED936D565FD635F7 /* WorklaneReviewStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FE17A010577717370EFBCB /* WorklaneReviewStateResolver.swift */; };
@@ -253,6 +255,7 @@
 		6763F2DC7655B039F55D08F4 /* JSONKeyAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58B814CCB50A93D946D971E /* JSONKeyAccess.swift */; };
 		67EA47F52A1B60F0F570A8DE /* AgentLaunchBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF50EC996DD0097909E99875 /* AgentLaunchBootstrap.swift */; };
 		68068C5699D9E8997BC39256 /* PaneDragSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A60B6840D10C04CE85782D /* PaneDragSession.swift */; };
+		680D33AB51963CC0808D55BD /* PaneAgentSubagents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE33F9E1A5D8E7A8BE5A995 /* PaneAgentSubagents.swift */; };
 		68542C40B0F24B31DDB1E9A2 /* PaneLayoutSettingsWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F435FA119C97C5F497FBD9 /* PaneLayoutSettingsWindowControllerTests.swift */; };
 		68971AE9A84508C3E111C8E7 /* GhosttyThemeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32F85F7274DE278E845FF4A /* GhosttyThemeResolverTests.swift */; };
 		68E3A02B546C3A1943743AB6 /* WorklaneColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB77B77BCACDE8C2DDA5E0E /* WorklaneColor.swift */; };
@@ -294,6 +297,7 @@
 		78745CFB14EA8F2045B37F7F /* PaneDropResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D48FA0772881220D4EFED /* PaneDropResolver.swift */; };
 		7A24BF7408FCE71A5C374E01 /* CodexToolStatusResolver+Idle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5913BFE1B4340F85B718B784 /* CodexToolStatusResolver+Idle.swift */; };
 		7AB05C23149C9A7980629EC9 /* SidebarResizeHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07D99A780805BBF2EC8E2C /* SidebarResizeHandleView.swift */; };
+		7B37802F6E37BC28DCB65112 /* AgentSubagentModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F67A943B86B86D34F76CDD3 /* AgentSubagentModelResolver.swift */; };
 		7BA18192A8FAB5678935564C /* CodexNotifyEventAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16413FC0363A393599D36E7 /* CodexNotifyEventAdapter.swift */; };
 		7BD9A95F9A5AB07D78784765 /* ServerURLNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1353BE5798B0D53E409EEEB /* ServerURLNormalizer.swift */; };
 		7BDCC1EDF0CCD7C439A086D5 /* SidebarGlobalSearchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1950AE3041C1DC410E2DCD11 /* SidebarGlobalSearchButton.swift */; };
@@ -759,6 +763,7 @@
 		2E587274DB966B186941A95A /* SidebarDropHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDropHitTesting.swift; sourceTree = "<group>"; };
 		2ED06A38FD1C326AD764C2ED /* CodexToolStatusResolver+Predicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodexToolStatusResolver+Predicates.swift"; sourceTree = "<group>"; };
 		2F241BC22C876707D98F1182 /* SidebarToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarToggleButton.swift; sourceTree = "<group>"; };
+		2FED3179D3B717E218F78E4C /* AgentSubagentTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSubagentTrackingTests.swift; sourceTree = "<group>"; };
 		3075B4E64F400647941D17F8 /* CommandPaletteResultsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteResultsResolver.swift; sourceTree = "<group>"; };
 		30875D0008390C471D920F6E /* NotificationsSettingsSectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsSectionViewController.swift; sourceTree = "<group>"; };
 		312AF7E528937EA1BA1B5D84 /* BundledGhosttyThemeResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledGhosttyThemeResourcesTests.swift; sourceTree = "<group>"; };
@@ -824,6 +829,7 @@
 		4A6979D10B68F312A3007DEC /* AmpResumeArgumentSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpResumeArgumentSanitizer.swift; sourceTree = "<group>"; };
 		4AB3C0ACB087A96811645CE3 /* AppMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMenuBuilder.swift; sourceTree = "<group>"; };
 		4ABED86877FD29F83E4196E0 /* TmuxCompatCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatCommand.swift; sourceTree = "<group>"; };
+		4AE33F9E1A5D8E7A8BE5A995 /* PaneAgentSubagents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentSubagents.swift; sourceTree = "<group>"; };
 		4B409385EC57C8C7A65441BD /* TmuxFormatRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxFormatRenderer.swift; sourceTree = "<group>"; };
 		4B681E0E2004A0AECC6C405B /* PaneSSHProcessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSSHProcessProbe.swift; sourceTree = "<group>"; };
 		4B6F06FD570B9740CE7008CB /* SettingsSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarTests.swift; sourceTree = "<group>"; };
@@ -838,6 +844,7 @@
 		4FC57F7F2820EB37AFC135C5 /* WindowChromeTitlebarGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeTitlebarGestureTests.swift; sourceTree = "<group>"; };
 		4FDD4F837A7EA056A5A555B9 /* GhosttySeededColorHealer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySeededColorHealer.swift; sourceTree = "<group>"; };
 		501FF089FC36AA3200A6A1A1 /* PaneNavigationButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneNavigationButtons.swift; sourceTree = "<group>"; };
+		507367AFCFE0B79C370223A5 /* AgentSubagentRegistryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSubagentRegistryStore.swift; sourceTree = "<group>"; };
 		50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibghosttyView.swift; sourceTree = "<group>"; };
 		50DA878894E21F6369AF06B9 /* PaneDragOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragOutcome.swift; sourceTree = "<group>"; };
 		51BFAD9337055E61275E0F7D /* ThemeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -992,6 +999,7 @@
 		8E8595DD2E83A66FAD57B960 /* TmuxFormatRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxFormatRendererTests.swift; sourceTree = "<group>"; };
 		8ED6DB175BCF8A6E62E5BAAF /* ClosedPaneCWDResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedPaneCWDResolverTests.swift; sourceTree = "<group>"; };
 		8EF1C35E3E3441C4C57051CA /* TmuxCompatArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatArguments.swift; sourceTree = "<group>"; };
+		8F67A943B86B86D34F76CDD3 /* AgentSubagentModelResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSubagentModelResolver.swift; sourceTree = "<group>"; };
 		8F82AEDB8F3C8B3C5F014D8D /* TerminalPaneHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneHostView.swift; sourceTree = "<group>"; };
 		905DD9FD69FFEA7991390EA4 /* ScrollSwitchGestureHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollSwitchGestureHandler.swift; sourceTree = "<group>"; };
 		90B6319AEE176E7AFF088AA8 /* AgentStatusReconciliation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatusReconciliation.swift; sourceTree = "<group>"; };
@@ -1647,6 +1655,8 @@
 				D1DB0F3E90C5CCF115A2E27B /* AgentStatusCommand.swift */,
 				10C70E68528914C7BDC3B755 /* AgentStatusHelper.swift */,
 				B79972CCAB3361277D4E949C /* AgentStatusPayload.swift */,
+				8F67A943B86B86D34F76CDD3 /* AgentSubagentModelResolver.swift */,
+				507367AFCFE0B79C370223A5 /* AgentSubagentRegistryStore.swift */,
 				AE8E072C80D640FFB3D8E022 /* AgyCanonicalReEmitter.swift */,
 				93AEBD7620888C77CB6FE423 /* AgyHooksInstaller.swift */,
 				E455660542BED764C4FCF49E /* AmpPluginInstaller.swift */,
@@ -1671,6 +1681,7 @@
 				D52DE33FBF1E4C9F22B1E569 /* OpenCodeThemeSync.swift */,
 				EB869749410CBF86B97FA142 /* PaneAgentReducer.swift */,
 				8552E3232235804F4AB8FB80 /* PaneAgentReducerState+Codex.swift */,
+				4AE33F9E1A5D8E7A8BE5A995 /* PaneAgentSubagents.swift */,
 				C5A65B5FE282DD307A732E81 /* PaneIPCHandler.swift */,
 				EA24EE3B2294AADC4A0C3E82 /* PiFamilyLaunchPolicy.swift */,
 				B3D36140C30599601062D9BF /* ProcessCWDResolver.swift */,
@@ -2070,6 +2081,7 @@
 				C44EC40C277824843955668D /* AgentResumeCommandBuilderTests.swift */,
 				63B1DE306FB0DE066A552C2D /* AgentsSettingsSectionViewControllerTests.swift */,
 				003771A9512A8005B0DCF7DE /* AgentStatusSupportTests.swift */,
+				2FED3179D3B717E218F78E4C /* AgentSubagentTrackingTests.swift */,
 				A2EE42F8FEB23D0CF10CA377 /* AgyHooksInstallerTests.swift */,
 				7050471CCD4F04FFCCAE4F47 /* AppActionRouterTests.swift */,
 				288F2452125BCCDB961229C9 /* AppConfigAgentIntegrationsTOMLTests.swift */,
@@ -2514,6 +2526,7 @@
 				50E494B39C06F67983331C3B /* AgentIntegrationGrandfatherTests.swift in Sources */,
 				28E673F10881B25E277F61A6 /* AgentResumeCommandBuilderTests.swift in Sources */,
 				55C1CC506BD2F0613AD94835 /* AgentStatusSupportTests.swift in Sources */,
+				5FDBD0983E309C2444F4A2C7 /* AgentSubagentTrackingTests.swift in Sources */,
 				D2BD827625AC63F83A22C7E8 /* AgentsSettingsSectionViewControllerTests.swift in Sources */,
 				73DF3F48A4FDC64C88FCBE2E /* AgyHooksInstallerTests.swift in Sources */,
 				FE4B04996B50503CD36CC954 /* AppActionRouterTests.swift in Sources */,
@@ -2733,6 +2746,8 @@
 				7564C7F11282A9CD3B3D0CC0 /* AgentStatusHelper.swift in Sources */,
 				04F27F3F3AE18FF0B4F78B44 /* AgentStatusPayload.swift in Sources */,
 				B2BBDE3B8D864756BB8708DF /* AgentStatusReconciliation.swift in Sources */,
+				7B37802F6E37BC28DCB65112 /* AgentSubagentModelResolver.swift in Sources */,
+				20CA0CB311BED0EA2DD31AED /* AgentSubagentRegistryStore.swift in Sources */,
 				4009C50481B0344CD379E28C /* AgyCanonicalReEmitter.swift in Sources */,
 				AA082E49508FE2C0E08338E6 /* AgyEventAdapter.swift in Sources */,
 				431F20BE5D3B0B049221ADCC /* AgyHooksInstaller.swift in Sources */,
@@ -2873,6 +2888,7 @@
 				858BC8739A32EF3A0240EF81 /* OpenWithService.swift in Sources */,
 				96C8DAEB457704BB7D4DEC7D /* PaneAgentReducer.swift in Sources */,
 				DF1048E3F1F45A233C595280 /* PaneAgentReducerState+Codex.swift in Sources */,
+				680D33AB51963CC0808D55BD /* PaneAgentSubagents.swift in Sources */,
 				840FDF34FA89D7BA5649AF0C /* PaneAuxiliaryState.swift in Sources */,
 				4777880E60AB7C29B7CD2E12 /* PaneCommand.swift in Sources */,
 				C5472B502864FDAF36E08684 /* PaneCommandExecutor.swift in Sources */,

--- a/Zentty.xcodeproj/project.pbxproj
+++ b/Zentty.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		1139F5A8823B615631F1616C /* LibghosttyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D5CEB5E915AE3FBE158512 /* LibghosttyView.swift */; };
 		11CC53B8D7E88E79372476A5 /* SidebarStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CCAA96572EBEF62BF5C4C0 /* SidebarStatusResolverTests.swift */; };
 		1216C817399FFC2FF0A5D3AB /* ProjectIconResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60BF59A63F7D5CD79FD024A /* ProjectIconResolver.swift */; };
+		121A626AFC6C29E96A895194 /* SidebarPaneSubagentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A3C790DA15F7823D4C5551 /* SidebarPaneSubagentViews.swift */; };
 		1221C29E07DBDEFBD68427E3 /* WorklaneStore+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431577B93D9FBB4CC61ADC41 /* WorklaneStore+Color.swift */; };
 		124231906DDF6523846A59ED /* ServerPortRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D79ED218E7EC24A67B6C7C /* ServerPortRule.swift */; };
 		13A456B3644AB1AA586D10E9 /* PaneShellContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE28087CB8A8A0F579745CA /* PaneShellContext.swift */; };
@@ -574,6 +575,7 @@
 		EBA82B93B865F768A59C3FB5 /* CommandPaletteItemBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1927429EEB90A74961D30D /* CommandPaletteItemBuilderTests.swift */; };
 		EBAB412B1DBC55EC0D896F9F /* SettingsSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F06FD570B9740CE7008CB /* SettingsSidebarTests.swift */; };
 		EC0DFEE3FDB6728B8FB6E6B6 /* SidebarDropHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E587274DB966B186941A95A /* SidebarDropHitTesting.swift */; };
+		EC760F2AC110EFF612B58E4B /* SidebarSubagentBadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F65940ED0F93690BAF103D /* SidebarSubagentBadgeTests.swift */; };
 		ED27476E195CD5905EA8FE99 /* CleanCopyPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9147BE310A4C4D3D61638835 /* CleanCopyPipeline.swift */; };
 		ED97F9FB42E05ECE3179E60D /* PaneStripState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D36706DB3DF677FA13DC722 /* PaneStripState.swift */; };
 		EDDA5E4E1273F0E81FBBE882 /* SettingsNavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29DBB882ABDF747B9DDA76 /* SettingsNavigationHistory.swift */; };
@@ -678,6 +680,7 @@
 		08406A303FAF5F5CC9447272 /* ThirdPartyLicenseCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyLicenseCatalog.swift; sourceTree = "<group>"; };
 		087C2ACC1BD5F24FD8F5A39F /* ServerOutputURLDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOutputURLDetector.swift; sourceTree = "<group>"; };
 		08CB7FE3B87F05DE3D6B4426 /* ThemeCatalogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCatalogService.swift; sourceTree = "<group>"; };
+		08F65940ED0F93690BAF103D /* SidebarSubagentBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSubagentBadgeTests.swift; sourceTree = "<group>"; };
 		0985A47CE1D3B2023DCD7265 /* WorklaneStoreColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreColorTests.swift; sourceTree = "<group>"; };
 		0AD3FFBDDBB1362295BD5207 /* SettingsFormBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFormBuilder.swift; sourceTree = "<group>"; };
 		0AF5B9241156382C39C53043 /* WorklaneStoreCodexWriteBackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorklaneStoreCodexWriteBackTests.swift; sourceTree = "<group>"; };
@@ -1133,6 +1136,7 @@
 		C5A65B5FE282DD307A732E81 /* PaneIPCHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneIPCHandler.swift; sourceTree = "<group>"; };
 		C675B0F7ABA617674B6D9A82 /* OpenCodeThemeSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeThemeSyncTests.swift; sourceTree = "<group>"; };
 		C67EAA92DF59DD9D42DF7FE4 /* WorklaneStore+AgentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorklaneStore+AgentStatus.swift"; sourceTree = "<group>"; };
+		C6A3C790DA15F7823D4C5551 /* SidebarPaneSubagentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPaneSubagentViews.swift; sourceTree = "<group>"; };
 		C70D781663BFAF38E678D72F /* CodexToolStatusResolver+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodexToolStatusResolver+Title.swift"; sourceTree = "<group>"; };
 		C771F4DD0F6077D2E72754D0 /* NotificationPopoverViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPopoverViewModelTests.swift; sourceTree = "<group>"; };
 		C7DDB5C51065221110FF22C3 /* TaskManagerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerModels.swift; sourceTree = "<group>"; };
@@ -1973,6 +1977,7 @@
 				DEC764BCDC589B75DA78F658 /* SidebarPaneRowButton.swift */,
 				5D34EEFF128BAD9A9DEE0371 /* SidebarPaneRowRenderer.swift */,
 				C9407DEA6B0DE6363B46DE0A /* SidebarPaneRowViews.swift */,
+				C6A3C790DA15F7823D4C5551 /* SidebarPaneSubagentViews.swift */,
 				4C07D99A780805BBF2EC8E2C /* SidebarResizeHandleView.swift */,
 				11072AE049C3591BEAFABAE0 /* SidebarRowDiff.swift */,
 				3D7F2B3A458136A7651CA4BA /* SidebarShimmerColorResolver.swift */,
@@ -2207,6 +2212,7 @@
 				B308B03F54BFA5F3812B101D /* SidebarRowDiffTests.swift */,
 				BE256725D568E7583890592B /* SidebarShimmerCoordinatorTests.swift */,
 				15CCAA96572EBEF62BF5C4C0 /* SidebarStatusResolverTests.swift */,
+				08F65940ED0F93690BAF103D /* SidebarSubagentBadgeTests.swift */,
 				C2DAA76C6247F60AA55ACB5D /* SidebarUpdateRowTests.swift */,
 				33A862FA7C8BA94CEE8A5237 /* SidebarViewRenderTests.swift */,
 				25A34A831CA0E3FE65355578 /* SidebarVisibilityControllerTests.swift */,
@@ -2652,6 +2658,7 @@
 				996B3F52A55E43059D1727A6 /* SidebarRowDiffTests.swift in Sources */,
 				BE30B813EC32158B648F52B1 /* SidebarShimmerCoordinatorTests.swift in Sources */,
 				11CC53B8D7E88E79372476A5 /* SidebarStatusResolverTests.swift in Sources */,
+				EC760F2AC110EFF612B58E4B /* SidebarSubagentBadgeTests.swift in Sources */,
 				D1911336945EA3268771D96A /* SidebarUpdateRowTests.swift in Sources */,
 				865B982474BFB184B68A8544 /* SidebarViewRenderTests.swift in Sources */,
 				26D68604F3403C3BC9299DEC /* SidebarVisibilityControllerTests.swift in Sources */,
@@ -2988,6 +2995,7 @@
 				1B0F281C77EAD3FADCED1BED /* SidebarPaneRowButton.swift in Sources */,
 				4F0ED39B5CA865D6EC1B520F /* SidebarPaneRowRenderer.swift in Sources */,
 				CBA82B1C9557F98AD04A8672 /* SidebarPaneRowViews.swift in Sources */,
+				121A626AFC6C29E96A895194 /* SidebarPaneSubagentViews.swift in Sources */,
 				7AB05C23149C9A7980629EC9 /* SidebarResizeHandleView.swift in Sources */,
 				0889B047795F8D959B7EC555 /* SidebarRowDiff.swift in Sources */,
 				6AA84BEE902A5824442396CF /* SidebarSelectionEmphasisOptionView.swift in Sources */,

--- a/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
+++ b/Zentty/AppState/Agent/AgentLaunchBootstrap.swift
@@ -840,6 +840,8 @@ enum AgentLaunchBootstrap {
                 "PostCompact": claudeHookEntries(command: hookCommand, timeout: 10),
                 "TaskCreated": claudeHookEntries(command: hookCommand, timeout: 5),
                 "TaskCompleted": claudeHookEntries(command: hookCommand, timeout: 5),
+                "SubagentStart": claudeHookEntries(command: hookCommand, timeout: 5),
+                "SubagentStop": claudeHookEntries(command: hookCommand, timeout: 5),
             ],
         ])
 
@@ -1473,6 +1475,8 @@ enum AgentLaunchBootstrap {
             CodexHookSpec(eventName: "UserPromptSubmit", eventKey: "user_prompt_submit", eventArgument: "prompt-submit", timeout: 10),
             CodexHookSpec(eventName: "PreCompact", eventKey: "pre_compact", eventArgument: "pre-compact", timeout: 10),
             CodexHookSpec(eventName: "PostCompact", eventKey: "post_compact", eventArgument: "post-compact", timeout: 10),
+            CodexHookSpec(eventName: "SubagentStart", eventKey: "subagent_start", eventArgument: "subagent-start", timeout: 10),
+            CodexHookSpec(eventName: "SubagentStop", eventKey: "subagent_stop", eventArgument: "subagent-stop", timeout: 10),
             CodexHookSpec(eventName: "Stop", eventKey: "stop", eventArgument: "stop", timeout: 10),
         ]
     }

--- a/Zentty/AppState/Agent/AgentStatus.swift
+++ b/Zentty/AppState/Agent/AgentStatus.swift
@@ -405,6 +405,7 @@ struct PaneAgentStatus: Equatable, Sendable {
     var parentSessionID: String?
     var agentLaunchSnapshot: AgentLaunchSnapshot?
     var taskProgress: PaneAgentTaskProgress?
+    var subagents: PaneAgentSubagentSummary?
 
     init(
         tool: AgentTool,
@@ -424,7 +425,8 @@ struct PaneAgentStatus: Equatable, Sendable {
         sessionID: String? = nil,
         parentSessionID: String? = nil,
         agentLaunchSnapshot: AgentLaunchSnapshot? = nil,
-        taskProgress: PaneAgentTaskProgress? = nil
+        taskProgress: PaneAgentTaskProgress? = nil,
+        subagents: PaneAgentSubagentSummary? = nil
     ) {
         self.tool = tool
         self.state = state
@@ -445,6 +447,7 @@ struct PaneAgentStatus: Equatable, Sendable {
         self.parentSessionID = parentSessionID
         self.agentLaunchSnapshot = agentLaunchSnapshot
         self.taskProgress = taskProgress
+        self.subagents = subagents
     }
 
     init(

--- a/Zentty/AppState/Agent/AgentStatusPayload.swift
+++ b/Zentty/AppState/Agent/AgentStatusPayload.swift
@@ -54,6 +54,9 @@ struct AgentStatusPayload: Equatable, Sendable {
     let sessionID: String?
     let parentSessionID: String?
     let taskProgress: PaneAgentTaskProgress?
+    /// Authoritative set of live subagents. `nil` leaves the pane's current set
+    /// untouched; an empty summary clears it.
+    let subagents: PaneAgentSubagentSummary?
     let artifactKind: WorklaneArtifactKind?
     let artifactLabel: String?
     let artifactURL: URL?
@@ -137,6 +140,9 @@ struct AgentStatusPayload: Equatable, Sendable {
             userInfo["taskProgressDoneCount"] = NSNumber(value: taskProgress.doneCount)
             userInfo["taskProgressTotalCount"] = NSNumber(value: taskProgress.totalCount)
         }
+        if let subagents, let json = subagents.transportJSON {
+            userInfo["subagents"] = json
+        }
         if let artifactKind {
             userInfo["artifactKind"] = artifactKind.rawValue
         }
@@ -180,6 +186,7 @@ struct AgentStatusPayload: Equatable, Sendable {
         sessionID: String? = nil,
         parentSessionID: String? = nil,
         taskProgress: PaneAgentTaskProgress? = nil,
+        subagents: PaneAgentSubagentSummary? = nil,
         artifactKind: WorklaneArtifactKind?,
         artifactLabel: String?,
         artifactURL: URL?,
@@ -206,6 +213,7 @@ struct AgentStatusPayload: Equatable, Sendable {
         self.sessionID = sessionID
         self.parentSessionID = parentSessionID
         self.taskProgress = taskProgress
+        self.subagents = subagents
         self.artifactKind = artifactKind
         self.artifactLabel = artifactLabel
         self.artifactURL = artifactURL
@@ -270,11 +278,46 @@ struct AgentStatusPayload: Equatable, Sendable {
             sessionID: userInfo["sessionID"] as? String,
             parentSessionID: userInfo["parentSessionID"] as? String,
             taskProgress: taskProgress,
+            subagents: PaneAgentSubagentSummary(transportJSON: userInfo["subagents"] as? String),
             artifactKind: (userInfo["artifactKind"] as? String).flatMap(WorklaneArtifactKind.init(rawValue:)),
             artifactLabel: userInfo["artifactLabel"] as? String,
             artifactURL: artifactURL,
             agentWorkingDirectory: userInfo["agentWorkingDirectory"] as? String,
             agentTranscriptPath: userInfo["agentTranscriptPath"] as? String,
+            agentLaunchSnapshot: agentLaunchSnapshot
+        )
+    }
+}
+
+extension AgentStatusPayload {
+    /// Copy of the payload carrying an authoritative subagent snapshot.
+    func with(subagents: PaneAgentSubagentSummary?) -> AgentStatusPayload {
+        AgentStatusPayload(
+            windowID: windowID,
+            worklaneID: worklaneID,
+            paneID: paneID,
+            signalKind: signalKind,
+            state: state,
+            shellActivityState: shellActivityState,
+            shellCommand: shellCommand,
+            pid: pid,
+            pidEvent: pidEvent,
+            paneContext: paneContext,
+            origin: origin,
+            toolName: toolName,
+            text: text,
+            lifecycleEvent: lifecycleEvent,
+            interactionKind: interactionKind,
+            confidence: confidence,
+            sessionID: sessionID,
+            parentSessionID: parentSessionID,
+            taskProgress: taskProgress,
+            subagents: subagents,
+            artifactKind: artifactKind,
+            artifactLabel: artifactLabel,
+            artifactURL: artifactURL,
+            agentWorkingDirectory: agentWorkingDirectory,
+            agentTranscriptPath: agentTranscriptPath,
             agentLaunchSnapshot: agentLaunchSnapshot
         )
     }

--- a/Zentty/AppState/Agent/AgentSubagentModelResolver.swift
+++ b/Zentty/AppState/Agent/AgentSubagentModelResolver.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Best-effort lookup of the model a subagent runs on. No agent CLI puts the
+/// model in its hook payload, so this reads the small sidecar files each CLI
+/// leaves next to the subagent transcript:
+///
+/// - Claude Code: `agent-<id>.meta.json` next to the transcript (written at
+///   spawn, carries `model` only when the parent chose one explicitly), else
+///   the first assistant line of the subagent transcript (`message.model`).
+/// - Codex: the sub-thread rollout's `session_meta` (nickname, role) and its
+///   first `turn_context` (`model`).
+///
+/// All reads are bounded to the head of the file and fail soft to `nil`.
+enum AgentSubagentModelResolver {
+    struct CodexThreadInfo: Equatable {
+        var model: String?
+        var nickname: String?
+        var role: String?
+    }
+
+    static let maxHeadBytes = 256 * 1024
+
+    // MARK: - Claude
+
+    static func claudeModel(agentTranscriptPath: String?) -> String? {
+        guard let agentTranscriptPath, !agentTranscriptPath.isEmpty else { return nil }
+        if let model = claudeMetaModel(agentTranscriptPath: agentTranscriptPath) {
+            return model
+        }
+        return claudeTranscriptModel(transcriptPath: agentTranscriptPath)
+    }
+
+    /// `…/subagents/agent-<id>.jsonl` → `…/subagents/agent-<id>.meta.json`.
+    static func claudeMetaPath(agentTranscriptPath: String) -> String {
+        guard agentTranscriptPath.hasSuffix(".jsonl") else {
+            return agentTranscriptPath + ".meta.json"
+        }
+        return String(agentTranscriptPath.dropLast(".jsonl".count)) + ".meta.json"
+    }
+
+    /// Derives the subagent transcript path from the parent transcript and the
+    /// agent id when the hook does not provide `agent_transcript_path`.
+    static func claudeAgentTranscriptPath(sessionTranscriptPath: String?, agentID: String?) -> String? {
+        guard let sessionTranscriptPath, let agentID, !agentID.isEmpty,
+              sessionTranscriptPath.hasSuffix(".jsonl") else {
+            return nil
+        }
+        let sessionDirectory = String(sessionTranscriptPath.dropLast(".jsonl".count))
+        let fileName = agentID.hasPrefix("agent-") ? "\(agentID).jsonl" : "agent-\(agentID).jsonl"
+        return sessionDirectory + "/subagents/" + fileName
+    }
+
+    static func claudeMetaModel(agentTranscriptPath: String) -> String? {
+        let metaPath = claudeMetaPath(agentTranscriptPath: agentTranscriptPath)
+        guard let data = readHead(path: metaPath, maxBytes: 64 * 1024),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return nonEmpty(object["model"] as? String)
+    }
+
+    static func claudeTranscriptModel(transcriptPath: String) -> String? {
+        guard let text = readHeadText(path: transcriptPath) else { return nil }
+        return claudeTranscriptModel(transcriptText: text)
+    }
+
+    static func claudeTranscriptModel(transcriptText: String) -> String? {
+        for line in text(transcriptText) {
+            guard line.contains("\"model\""), let object = jsonObject(from: line) else { continue }
+            if let message = object["message"] as? [String: Any], let model = nonEmpty(message["model"] as? String) {
+                return model
+            }
+            if let model = nonEmpty(object["model"] as? String) {
+                return model
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Codex
+
+    static func codexThreadInfo(rolloutPath: String?) -> CodexThreadInfo? {
+        guard let rolloutPath, !rolloutPath.isEmpty, let text = readHeadText(path: rolloutPath) else { return nil }
+        return codexThreadInfo(rolloutText: text)
+    }
+
+    static func codexThreadInfo(rolloutText: String) -> CodexThreadInfo? {
+        var info = CodexThreadInfo()
+        var sawAnything = false
+        for line in text(rolloutText) {
+            guard let object = jsonObject(from: line),
+                  let type = object["type"] as? String,
+                  let payload = object["payload"] as? [String: Any] else { continue }
+            switch type {
+            case "session_meta":
+                sawAnything = true
+                if let source = payload["source"] as? [String: Any],
+                   let subagent = source["subagent"] as? [String: Any],
+                   let spawn = subagent["thread_spawn"] as? [String: Any] {
+                    info.nickname = nonEmpty(spawn["agent_nickname"] as? String)
+                    info.role = nonEmpty(spawn["agent_role"] as? String)
+                }
+            case "turn_context":
+                sawAnything = true
+                if info.model == nil, let model = nonEmpty(payload["model"] as? String) {
+                    info.model = model
+                }
+            default:
+                continue
+            }
+            if info.model != nil, info.nickname != nil {
+                break
+            }
+        }
+        return sawAnything ? info : nil
+    }
+
+    // MARK: - IO
+
+    private static func readHead(path: String, maxBytes: Int = maxHeadBytes) -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        return try? handle.read(upToCount: maxBytes)
+    }
+
+    private static func readHeadText(path: String) -> String? {
+        guard let data = readHead(path: path), !data.isEmpty else { return nil }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func text(_ value: String) -> [Substring] {
+        value.split(separator: "\n", omittingEmptySubsequences: true)
+    }
+
+    private static func jsonObject(from line: Substring) -> [String: Any]? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Zentty/AppState/Agent/AgentSubagentRegistryStore.swift
+++ b/Zentty/AppState/Agent/AgentSubagentRegistryStore.swift
@@ -1,0 +1,264 @@
+import Darwin
+import Foundation
+
+/// File-backed registry of live subagents per pane, shared by the Claude,
+/// Codex, and Grok hook adapters.
+///
+/// Hook invocations are short-lived processes, so the set of running
+/// subagents has to survive between `SubagentStart` and `SubagentStop`. The
+/// registry is keyed by pane (tool + worklane + pane) rather than by session
+/// id because Codex sub-threads report their own thread ids, and only the
+/// pane is stable across parent and child hooks.
+final class AgentSubagentRegistryStore {
+    struct Key: Equatable {
+        let tool: String
+        let worklaneID: WorklaneID
+        let paneID: PaneID
+
+        var rawValue: String {
+            "\(tool)|\(worklaneID.rawValue)|\(paneID.rawValue)"
+        }
+    }
+
+    /// Entries older than this are dropped on read: a `SubagentStop` that never
+    /// arrived should not pin a badge to the sidebar forever.
+    static let staleEntryWindow: TimeInterval = 6 * 60 * 60
+
+    private let stateURL: URL
+    private let lockURL: URL
+    private let fileManager: FileManager
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let now: () -> Date
+
+    init(
+        stateURL: URL,
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.stateURL = stateURL
+        self.lockURL = stateURL.appendingPathExtension("lock")
+        self.fileManager = fileManager
+        self.now = now
+        self.encoder.outputFormatting = [.sortedKeys]
+    }
+
+    convenience init(
+        processInfo: ProcessInfo = .processInfo,
+        fileManager: FileManager = .default
+    ) {
+        let env = processInfo.environment
+        if let overridePath = env["ZENTTY_SUBAGENT_STATE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridePath.isEmpty {
+            self.init(stateURL: URL(fileURLWithPath: NSString(string: overridePath).expandingTildeInPath), fileManager: fileManager)
+            return
+        }
+
+        let stateURL: URL
+        if let appSupportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            stateURL = appSupportDirectory
+                .appendingPathComponent("Zentty", isDirectory: true)
+                .appendingPathComponent("agent-subagent-sessions.json", isDirectory: false)
+        } else {
+            stateURL = fileManager.temporaryDirectory.appendingPathComponent("zentty-agent-subagent-sessions.json")
+        }
+        self.init(stateURL: stateURL, fileManager: fileManager)
+    }
+
+    // MARK: - Root session
+
+    /// Remember the parent session id for a pane so subagent payloads can be
+    /// attributed to it even when the hook carries a child thread id.
+    func recordRootSession(key: Key, sessionID: String?) throws {
+        guard let sessionID = normalizedOptional(sessionID) else { return }
+        try withLockedState { state in
+            var entry = state.panes[key.rawValue] ?? PaneEntry()
+            entry.rootSessionID = sessionID
+            entry.updatedAt = now().timeIntervalSince1970
+            state.panes[key.rawValue] = entry
+        }
+    }
+
+    func rootSessionID(key: Key) throws -> String? {
+        try withLockedState { state in
+            state.panes[key.rawValue]?.rootSessionID
+        }
+    }
+
+    // MARK: - Subagents
+
+    @discardableResult
+    func start(key: Key, entry subagent: PaneAgentSubagentEntry) throws -> PaneAgentSubagentSummary {
+        try withLockedState { state in
+            var entry = state.panes[key.rawValue] ?? PaneEntry()
+            entry.prune(before: now().timeIntervalSince1970 - Self.staleEntryWindow)
+            let existing = entry.subagentsByID[subagent.id]
+            entry.subagentsByID[subagent.id] = SubagentRecord(
+                entry: Self.merged(existing?.entry, with: subagent),
+                startedAt: existing?.startedAt ?? now().timeIntervalSince1970
+            )
+            entry.updatedAt = now().timeIntervalSince1970
+            state.panes[key.rawValue] = entry
+            return entry.summary
+        }
+    }
+
+    @discardableResult
+    func stop(key: Key, subagentID: String?) throws -> PaneAgentSubagentSummary {
+        try withLockedState { state in
+            var entry = state.panes[key.rawValue] ?? PaneEntry()
+            entry.prune(before: now().timeIntervalSince1970 - Self.staleEntryWindow)
+            if let subagentID = normalizedOptional(subagentID) {
+                entry.subagentsByID.removeValue(forKey: subagentID)
+            } else if let oldest = entry.subagentsByID.min(by: { $0.value.startedAt < $1.value.startedAt }) {
+                // No id on the stop hook: retire the longest-running subagent.
+                entry.subagentsByID.removeValue(forKey: oldest.key)
+            }
+            entry.updatedAt = now().timeIntervalSince1970
+            state.panes[key.rawValue] = entry
+            return entry.summary
+        }
+    }
+
+    /// Current snapshot, or `nil` when nothing was ever recorded for the pane
+    /// so callers can leave the payload field untouched.
+    func summary(key: Key) throws -> PaneAgentSubagentSummary? {
+        try withLockedState { state in
+            guard var entry = state.panes[key.rawValue] else { return nil }
+            let pruned = entry.prune(before: now().timeIntervalSince1970 - Self.staleEntryWindow)
+            if pruned {
+                state.panes[key.rawValue] = entry
+            }
+            return entry.summary
+        }
+    }
+
+    /// Fill in models (and nicknames) that were unknown at start time. The
+    /// resolver runs only for entries still missing a model, so this stays
+    /// cheap to call from every hook.
+    @discardableResult
+    func refreshMissingModels(
+        key: Key,
+        resolver: (PaneAgentSubagentEntry) -> PaneAgentSubagentEntry?
+    ) throws -> PaneAgentSubagentSummary? {
+        try withLockedState { state in
+            guard var entry = state.panes[key.rawValue], !entry.subagentsByID.isEmpty else { return nil }
+            var changed = false
+            for (id, record) in entry.subagentsByID where record.entry.model == nil {
+                guard let resolved = resolver(record.entry), resolved.model != nil else { continue }
+                entry.subagentsByID[id] = SubagentRecord(
+                    entry: Self.merged(record.entry, with: resolved),
+                    startedAt: record.startedAt
+                )
+                changed = true
+            }
+            if changed {
+                entry.updatedAt = now().timeIntervalSince1970
+                state.panes[key.rawValue] = entry
+            }
+            return entry.summary
+        }
+    }
+
+    /// Drop every subagent for the pane (parent turn ended) and return the
+    /// explicit empty summary to broadcast.
+    @discardableResult
+    func clear(key: Key) throws -> PaneAgentSubagentSummary {
+        try withLockedState { state in
+            var entry = state.panes[key.rawValue] ?? PaneEntry()
+            entry.subagentsByID.removeAll()
+            entry.updatedAt = now().timeIntervalSince1970
+            state.panes[key.rawValue] = entry
+            return .empty
+        }
+    }
+
+    /// Forget the pane entirely (session ended).
+    func remove(key: Key) throws {
+        try withLockedState { state in
+            state.panes.removeValue(forKey: key.rawValue)
+        }
+    }
+
+    // MARK: - Internals
+
+    private struct SubagentRecord: Codable {
+        var entry: PaneAgentSubagentEntry
+        var startedAt: TimeInterval
+    }
+
+    private struct PaneEntry: Codable {
+        var rootSessionID: String?
+        var subagentsByID: [String: SubagentRecord] = [:]
+        var updatedAt: TimeInterval = 0
+
+        var summary: PaneAgentSubagentSummary {
+            PaneAgentSubagentSummary(entries: subagentsByID.values.map(\.entry))
+        }
+
+        @discardableResult
+        mutating func prune(before cutoff: TimeInterval) -> Bool {
+            let stale = subagentsByID.filter { $0.value.startedAt < cutoff }.map(\.key)
+            guard !stale.isEmpty else { return false }
+            stale.forEach { subagentsByID.removeValue(forKey: $0) }
+            return true
+        }
+    }
+
+    private struct StoreFile: Codable {
+        var version: Int = 1
+        var panes: [String: PaneEntry] = [:]
+    }
+
+    private static func merged(_ existing: PaneAgentSubagentEntry?, with update: PaneAgentSubagentEntry) -> PaneAgentSubagentEntry {
+        PaneAgentSubagentEntry(
+            id: update.id,
+            agentType: update.agentType ?? existing?.agentType,
+            model: update.model ?? existing?.model,
+            nickname: update.nickname ?? existing?.nickname,
+            transcriptPath: update.transcriptPath ?? existing?.transcriptPath
+        )
+    }
+
+    private func withLockedState<T>(_ body: (inout StoreFile) throws -> T) throws -> T {
+        try fileManager.createDirectory(at: stateURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if !fileManager.fileExists(atPath: lockURL.path) {
+            fileManager.createFile(atPath: lockURL.path, contents: Data())
+        }
+
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
+        guard descriptor >= 0 else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+        defer { close(descriptor) }
+
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw AgentStatusPayloadError.invalidHookPayload
+        }
+        defer { flock(descriptor, LOCK_UN) }
+
+        var state = loadState()
+        let result = try body(&state)
+        try saveState(state)
+        return result
+    }
+
+    private func loadState() -> StoreFile {
+        guard let data = try? Data(contentsOf: stateURL) else {
+            return StoreFile()
+        }
+        return (try? decoder.decode(StoreFile.self, from: data)) ?? StoreFile()
+    }
+
+    private func saveState(_ state: StoreFile) throws {
+        let data = try encoder.encode(state)
+        try data.write(to: stateURL, options: .atomic)
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Zentty/AppState/Agent/EventAdapters/AgentEventAdapters+Shared.swift
+++ b/Zentty/AppState/Agent/EventAdapters/AgentEventAdapters+Shared.swift
@@ -32,6 +32,7 @@ extension AgentEventBridge {
         sessionID: String? = nil,
         cwd: String? = nil,
         taskProgress: PaneAgentTaskProgress? = nil,
+        subagents: PaneAgentSubagentSummary? = nil,
         transcriptPath: String? = nil
     ) -> AgentStatusPayload {
         AgentStatusPayload(
@@ -47,6 +48,7 @@ extension AgentEventBridge {
             confidence: .explicit,
             sessionID: sessionID,
             taskProgress: taskProgress,
+            subagents: subagents,
             artifactKind: nil,
             artifactLabel: nil,
             artifactURL: nil,
@@ -160,6 +162,32 @@ extension AgentEventBridge {
             return true
         default:
             return false
+        }
+    }
+}
+
+// MARK: - Subagent enrichment
+
+extension AgentEventBridge {
+    /// Attaches the pane's current subagent set to outgoing lifecycle payloads
+    /// that do not carry one yet, resolving models that were unknown at
+    /// `SubagentStart` (the subagent transcript only reveals its model after
+    /// the first response). No-op while the pane has no subagents recorded.
+    static func attachSubagents(
+        to payloads: [AgentStatusPayload],
+        key: AgentSubagentRegistryStore.Key,
+        subagentStore: AgentSubagentRegistryStore,
+        resolver: (PaneAgentSubagentEntry) -> PaneAgentSubagentEntry?
+    ) throws -> [AgentStatusPayload] {
+        guard let current = try subagentStore.summary(key: key), !current.isEmpty else {
+            return payloads
+        }
+        let refreshed = try subagentStore.refreshMissingModels(key: key, resolver: resolver) ?? current
+        return payloads.map { payload in
+            guard payload.signalKind == .lifecycle, payload.state != nil, payload.subagents == nil else {
+                return payload
+            }
+            return payload.with(subagents: refreshed)
         }
     }
 }

--- a/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
@@ -9,7 +9,12 @@ extension AgentEventBridge {
     ) throws -> [AgentStatusPayload] {
         let input = try claudeParseInput(data)
         let sessionStore = ClaudeHookSessionStore()
-        return try claudeMakePayloads(from: input, environment: environment, sessionStore: sessionStore)
+        return try claudeMakePayloads(
+            from: input,
+            environment: environment,
+            sessionStore: sessionStore,
+            subagentStore: AgentSubagentRegistryStore()
+        )
     }
 }
 
@@ -27,6 +32,43 @@ struct ClaudeAdapterInput {
     let toolUseID: String?
     let taskID: String?
     let taskSubject: String?
+    /// Present on `SubagentStart` / `SubagentStop` and on every hook fired
+    /// from inside a subagent.
+    let agentID: String?
+    let agentType: String?
+    let agentTranscriptPath: String?
+
+    init(
+        hookEventName: String,
+        sessionID: String?,
+        message: String?,
+        notificationType: String?,
+        cwd: String?,
+        transcriptPath: String?,
+        toolName: String?,
+        toolInput: [String: Any],
+        toolUseID: String?,
+        taskID: String?,
+        taskSubject: String?,
+        agentID: String? = nil,
+        agentType: String? = nil,
+        agentTranscriptPath: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.sessionID = sessionID
+        self.message = message
+        self.notificationType = notificationType
+        self.cwd = cwd
+        self.transcriptPath = transcriptPath
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.toolUseID = toolUseID
+        self.taskID = taskID
+        self.taskSubject = taskSubject
+        self.agentID = agentID
+        self.agentType = agentType
+        self.agentTranscriptPath = agentTranscriptPath
+    }
 }
 
 extension AgentEventBridge {
@@ -49,14 +91,33 @@ extension AgentEventBridge {
             toolInput: (json["tool_input"] as? [String: Any]) ?? [:],
             toolUseID: JSONKeyAccess.firstString(in: json, keys: ["tool_use_id", "toolUseId"]),
             taskID: JSONKeyAccess.firstString(in: json, keys: ["task_id", "taskId"]),
-            taskSubject: JSONKeyAccess.firstString(in: json, keys: ["task", "task_subject", "taskSubject", "title"])
+            taskSubject: JSONKeyAccess.firstString(in: json, keys: ["task", "task_subject", "taskSubject", "title"]),
+            agentID: JSONKeyAccess.firstString(in: json, keys: ["agent_id", "agentId"]),
+            agentType: JSONKeyAccess.firstString(in: json, keys: ["agent_type", "agentType", "agent_name", "agentName"]),
+            agentTranscriptPath: JSONKeyAccess.firstString(in: json, keys: ["agent_transcript_path", "agentTranscriptPath"])
         )
     }
 
     static func claudeMakePayloads(
         from input: ClaudeAdapterInput,
         environment: [String: String],
-        sessionStore: ClaudeHookSessionStore
+        sessionStore: ClaudeHookSessionStore,
+        subagentStore: AgentSubagentRegistryStore = AgentSubagentRegistryStore()
+    ) throws -> [AgentStatusPayload] {
+        let payloads = try claudeMakeLifecyclePayloads(
+            from: input,
+            environment: environment,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        return try claudeAttachSubagents(to: payloads, input: input, subagentStore: subagentStore)
+    }
+
+    private static func claudeMakeLifecyclePayloads(
+        from input: ClaudeAdapterInput,
+        environment: [String: String],
+        sessionStore: ClaudeHookSessionStore,
+        subagentStore: AgentSubagentRegistryStore
     ) throws -> [AgentStatusPayload] {
         let toolName = AgentTool.claudeCode.displayName
 
@@ -81,7 +142,8 @@ extension AgentEventBridge {
         case "Notification":
             if input.notificationType == "idle_prompt" {
                 let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
-                return [claudeLifecyclePayload(target: target, state: .idle, confidence: .explicit, sessionID: input.sessionID)]
+                let subagents = try subagentStore.clear(key: claudeSubagentKey(target))
+                return [claudeLifecyclePayload(target: target, state: .idle, confidence: .explicit, sessionID: input.sessionID, subagents: subagents)]
             }
             let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
             let sessionRecord = try claudeLookupRecord(for: input, sessionStore: sessionStore)
@@ -204,7 +266,7 @@ extension AgentEventBridge {
                 taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID)
             )]
 
-        case "UserPromptSubmit", "SubagentStart":
+        case "UserPromptSubmit":
             let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
             if let sessionID = input.sessionID {
                 try sessionStore.clearInteractionContext(sessionID: sessionID)
@@ -214,6 +276,21 @@ extension AgentEventBridge {
                 target: target, state: .running, cwd: input.cwd ?? promptExisting?.cwd,
                 interactionKind: .none, confidence: .explicit, sessionID: input.sessionID,
                 taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID)
+            )]
+
+        case "SubagentStart":
+            let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
+            if let sessionID = input.sessionID {
+                try sessionStore.clearInteractionContext(sessionID: sessionID)
+            }
+            let existing = try claudeLookupRecord(for: input, sessionStore: sessionStore)
+            let entry = claudeSubagentEntry(for: input, sessionTranscriptPath: existing?.transcriptPath)
+            let subagents = try subagentStore.start(key: claudeSubagentKey(target), entry: entry)
+            return [claudeLifecyclePayload(
+                target: target, state: .running, cwd: input.cwd ?? existing?.cwd,
+                interactionKind: .none, confidence: .explicit, sessionID: input.sessionID,
+                taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID),
+                subagents: subagents
             )]
 
         case "PreCompact":
@@ -258,14 +335,29 @@ extension AgentEventBridge {
             if let sessionID = input.sessionID {
                 try sessionStore.clearInteractionContext(sessionID: sessionID)
             }
-            return [claudeLifecyclePayload(target: target, state: .idle, confidence: .explicit, sessionID: input.sessionID)]
+            // The main agent finished its turn, so no subagent can still be
+            // running under it: broadcast the explicit empty set.
+            let subagents = try subagentStore.clear(key: claudeSubagentKey(target))
+            return [claudeLifecyclePayload(target: target, state: .idle, confidence: .explicit, sessionID: input.sessionID, subagents: subagents)]
 
         case "SubagentStop":
             let target = try claudeResolvedTarget(for: input, environment: environment, sessionStore: sessionStore)
             if let sessionID = input.sessionID {
                 try sessionStore.clearInteractionContext(sessionID: sessionID)
             }
-            return [claudeLifecyclePayload(target: target, state: .idle, confidence: .explicit, sessionID: input.sessionID)]
+            // The parent keeps working (it still has to read the subagent's
+            // result), so this is a running update, not an idle transition.
+            let existing = try claudeLookupRecord(for: input, sessionStore: sessionStore)
+            let subagents = try subagentStore.stop(
+                key: claudeSubagentKey(target),
+                subagentID: claudeSubagentID(for: input, sessionTranscriptPath: existing?.transcriptPath)
+            )
+            return [claudeLifecyclePayload(
+                target: target, state: .running, cwd: input.cwd ?? existing?.cwd,
+                interactionKind: .none, confidence: .explicit, sessionID: input.sessionID,
+                taskProgress: try sessionStore.taskProgress(sessionID: input.sessionID),
+                subagents: subagents
+            )]
 
         case "SessionEnd":
             let current = currentTargetIfAvailable(from: environment)
@@ -277,6 +369,7 @@ extension AgentEventBridge {
             )
             guard let record else { return [] }
             let target = (record.windowID, record.worklaneID, record.paneID)
+            try subagentStore.remove(key: claudeSubagentKey((record.windowID, record.worklaneID, record.paneID)))
             return [
                 AgentStatusPayload(
                     windowID: target.0, worklaneID: target.1, paneID: target.2,
@@ -288,6 +381,71 @@ extension AgentEventBridge {
 
         default:
             return []
+        }
+    }
+
+    // MARK: - Claude Subagents
+
+    static func claudeSubagentKey(
+        _ target: (windowID: WindowID?, worklaneID: WorklaneID, paneID: PaneID)
+    ) -> AgentSubagentRegistryStore.Key {
+        AgentSubagentRegistryStore.Key(tool: "claude", worklaneID: target.worklaneID, paneID: target.paneID)
+    }
+
+    static func claudeSubagentID(for input: ClaudeAdapterInput, sessionTranscriptPath: String?) -> String? {
+        if let agentID = AgentInteractionClassifier.trimmed(input.agentID) {
+            return agentID
+        }
+        if let path = AgentInteractionClassifier.trimmed(input.agentTranscriptPath) {
+            return path
+        }
+        return nil
+    }
+
+    static func claudeSubagentEntry(for input: ClaudeAdapterInput, sessionTranscriptPath: String?) -> PaneAgentSubagentEntry {
+        let transcriptPath = AgentInteractionClassifier.trimmed(input.agentTranscriptPath)
+            ?? AgentSubagentModelResolver.claudeAgentTranscriptPath(
+                sessionTranscriptPath: sessionTranscriptPath,
+                agentID: input.agentID
+            )
+        let id = claudeSubagentID(for: input, sessionTranscriptPath: sessionTranscriptPath)
+            ?? transcriptPath
+            ?? UUID().uuidString
+        return PaneAgentSubagentEntry(
+            id: id,
+            agentType: AgentInteractionClassifier.trimmed(input.agentType),
+            model: AgentSubagentModelResolver.claudeModel(agentTranscriptPath: transcriptPath),
+            nickname: nil,
+            transcriptPath: transcriptPath
+        )
+    }
+
+    /// Hooks fired from inside a subagent (`PreToolUse`, `PostToolUse`, …)
+    /// arrive after the subagent's first model response, which is the moment
+    /// its transcript reveals the model. Fill in what `SubagentStart` could
+    /// not know yet and carry the current set on the outgoing payload.
+    private static func claudeAttachSubagents(
+        to payloads: [AgentStatusPayload],
+        input: ClaudeAdapterInput,
+        subagentStore: AgentSubagentRegistryStore
+    ) throws -> [AgentStatusPayload] {
+        switch input.hookEventName {
+        case "SubagentStart", "SubagentStop", "Stop", "SessionEnd", "SessionStart":
+            return payloads
+        default:
+            break
+        }
+        guard let first = payloads.first(where: { $0.signalKind == .lifecycle }) else {
+            return payloads
+        }
+        let key = AgentSubagentRegistryStore.Key(tool: "claude", worklaneID: first.worklaneID, paneID: first.paneID)
+        return try attachSubagents(to: payloads, key: key, subagentStore: subagentStore) { entry in
+            let transcriptPath = entry.transcriptPath
+                ?? (input.agentID == entry.id ? AgentInteractionClassifier.trimmed(input.agentTranscriptPath) : nil)
+            guard let model = AgentSubagentModelResolver.claudeModel(agentTranscriptPath: transcriptPath) else {
+                return nil
+            }
+            return entry.with(model: model)
         }
     }
 
@@ -404,7 +562,8 @@ extension AgentEventBridge {
         interactionKind: PaneAgentInteractionKind? = nil,
         confidence: AgentSignalConfidence? = nil,
         sessionID: String? = nil,
-        taskProgress: PaneAgentTaskProgress? = nil
+        taskProgress: PaneAgentTaskProgress? = nil,
+        subagents: PaneAgentSubagentSummary? = nil
     ) -> AgentStatusPayload {
         AgentStatusPayload(
             windowID: target.windowID,
@@ -419,6 +578,7 @@ extension AgentEventBridge {
             confidence: confidence,
             sessionID: sessionID,
             taskProgress: taskProgress,
+            subagents: subagents,
             artifactKind: nil,
             artifactLabel: nil,
             artifactURL: nil,

--- a/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/ClaudeEventAdapter.swift
@@ -284,7 +284,10 @@ extension AgentEventBridge {
                 try sessionStore.clearInteractionContext(sessionID: sessionID)
             }
             let existing = try claudeLookupRecord(for: input, sessionStore: sessionStore)
-            let entry = claudeSubagentEntry(for: input, sessionTranscriptPath: existing?.transcriptPath)
+            let entry = claudeSubagentEntry(
+                for: input,
+                sessionTranscriptPath: input.transcriptPath ?? existing?.transcriptPath
+            )
             let subagents = try subagentStore.start(key: claudeSubagentKey(target), entry: entry)
             return [claudeLifecyclePayload(
                 target: target, state: .running, cwd: input.cwd ?? existing?.cwd,

--- a/Zentty/AppState/Agent/EventAdapters/CodexEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/CodexEventAdapter.swift
@@ -191,11 +191,17 @@ extension AgentEventBridge {
 
     // MARK: - Codex Subagents
 
+    /// Codex 0.153 sends `agent_id` (the sub-thread id) on both hooks but the
+    /// rollout path only on `SubagentStop`, so the id is the stable key and the
+    /// rollout file name is the fallback for older payloads.
     static func codexSubagentID(from jsonObject: [String: Any]) -> String? {
+        if let agentID = JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_id", "agentId", "thread_id", "threadId"]) {
+            return agentID
+        }
         if let path = JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_transcript_path", "agentTranscriptPath"]) {
             return codexThreadID(fromRolloutPath: path) ?? path
         }
-        return JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_id", "agentId", "thread_id", "threadId", "turn_id", "turnId"])
+        return JSONKeyAccess.firstString(in: jsonObject, keys: ["turn_id", "turnId"])
     }
 
     /// `rollout-2026-09-05T12-52-37-01a07132-eb9a-7222-ad53-819ccda4db3c.jsonl` → the trailing UUID.

--- a/Zentty/AppState/Agent/EventAdapters/CodexEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/CodexEventAdapter.swift
@@ -6,7 +6,8 @@ extension AgentEventBridge {
     static func codexAdapter(
         data: Data,
         defaultEventName: String?,
-        environment: [String: String]
+        environment: [String: String],
+        subagentStore: AgentSubagentRegistryStore = AgentSubagentRegistryStore()
     ) throws -> [AgentStatusPayload] {
         let jsonObject = data.isEmpty ? [:] : (try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:])
         let hookEventName = JSONKeyAccess.firstString(in: jsonObject, keys: ["hook_event_name", "hookEventName"])
@@ -26,9 +27,31 @@ extension AgentEventBridge {
         let transcriptPath = JSONKeyAccess.firstString(in: jsonObject, keys: ["transcript_path", "transcriptPath"])
         let pid = parseAgentPID(from: environment, key: "ZENTTY_CODEX_PID")
         let toolName = AgentTool.codex.displayName
+        let subagentKey = AgentSubagentRegistryStore.Key(tool: "codex", worklaneID: target.worklaneID, paneID: target.paneID)
 
         switch hookEventName {
+        case "SubagentStart", "SubagentStop":
+            // Sub-threads report their own thread id; attribute the update to
+            // the parent session the pane already knows about.
+            let rootSessionID = try subagentStore.rootSessionID(key: subagentKey) ?? sessionID
+            let subagents: PaneAgentSubagentSummary
+            if hookEventName == "SubagentStart" {
+                subagents = try subagentStore.start(key: subagentKey, entry: codexSubagentEntry(from: jsonObject))
+            } else {
+                subagents = try subagentStore.stop(key: subagentKey, subagentID: codexSubagentID(from: jsonObject))
+            }
+            return [lifecyclePayload(
+                target: target,
+                toolName: toolName,
+                state: .running,
+                lifecycleEvent: .toolActivity,
+                sessionID: rootSessionID,
+                cwd: cwd,
+                subagents: subagents,
+                transcriptPath: transcriptPath
+            )]
         case "SessionStart":
+            try subagentStore.recordRootSession(key: subagentKey, sessionID: sessionID)
             var payloads: [AgentStatusPayload] = []
             if let pid {
                 payloads.append(pidPayload(target: target, toolName: toolName, pid: pid, event: .attach, sessionID: sessionID))
@@ -67,6 +90,7 @@ extension AgentEventBridge {
             )]
         case "PreToolUse", "PostToolUse":
             if hookEventName == "PreToolUse" {
+                try subagentStore.recordRootSession(key: subagentKey, sessionID: sessionID)
                 let requestedToolName = JSONKeyAccess.firstString(in: jsonObject, keys: ["tool_name", "toolName", "tool"])
                 if codexPermissionRequestIsUserInput(requestedToolName),
                    let prompt = codexQuestionPrompt(from: jsonObject) {
@@ -90,16 +114,27 @@ extension AgentEventBridge {
                     )]
                 }
             }
-            return [lifecyclePayload(
-                target: target,
-                toolName: toolName,
-                state: .running,
-                lifecycleEvent: .toolActivity,
-                sessionID: sessionID,
-                cwd: cwd,
-                transcriptPath: transcriptPath
-            )]
+            return try attachSubagents(
+                to: [lifecyclePayload(
+                    target: target,
+                    toolName: toolName,
+                    state: .running,
+                    lifecycleEvent: .toolActivity,
+                    sessionID: sessionID,
+                    cwd: cwd,
+                    transcriptPath: transcriptPath
+                )],
+                key: subagentKey,
+                subagentStore: subagentStore
+            ) { entry in
+                guard let info = AgentSubagentModelResolver.codexThreadInfo(rolloutPath: entry.transcriptPath),
+                      info.model != nil else {
+                    return nil
+                }
+                return entry.with(model: info.model, nickname: info.nickname)
+            }
         case "UserPromptSubmit":
+            try subagentStore.recordRootSession(key: subagentKey, sessionID: sessionID)
             return [lifecyclePayload(
                 target: target,
                 toolName: toolName,
@@ -133,6 +168,12 @@ extension AgentEventBridge {
                 transcriptPath: transcriptPath
             )]
         case "Stop":
+            // Only the parent's turn end retires the subagent set; a sub-thread
+            // reporting its own Stop must not blank the badge mid-run.
+            let rootSessionID = try subagentStore.rootSessionID(key: subagentKey)
+            let subagents: PaneAgentSubagentSummary? = (rootSessionID == nil || rootSessionID == sessionID)
+                ? try subagentStore.clear(key: subagentKey)
+                : nil
             return [lifecyclePayload(
                 target: target,
                 toolName: toolName,
@@ -140,11 +181,45 @@ extension AgentEventBridge {
                 lifecycleEvent: .turnComplete,
                 sessionID: sessionID,
                 cwd: cwd,
+                subagents: subagents,
                 transcriptPath: transcriptPath
             )]
         default:
             return []
         }
+    }
+
+    // MARK: - Codex Subagents
+
+    static func codexSubagentID(from jsonObject: [String: Any]) -> String? {
+        if let path = JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_transcript_path", "agentTranscriptPath"]) {
+            return codexThreadID(fromRolloutPath: path) ?? path
+        }
+        return JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_id", "agentId", "thread_id", "threadId", "turn_id", "turnId"])
+    }
+
+    /// `rollout-2026-09-05T12-52-37-01a07132-eb9a-7222-ad53-819ccda4db3c.jsonl` → the trailing UUID.
+    static func codexThreadID(fromRolloutPath path: String) -> String? {
+        let name = (path as NSString).lastPathComponent
+        let stem = name.hasSuffix(".jsonl") ? String(name.dropLast(".jsonl".count)) : name
+        let parts = stem.split(separator: "-")
+        guard parts.count >= 5 else { return nil }
+        let candidate = parts.suffix(5).joined(separator: "-")
+        return UUID(uuidString: candidate) != nil ? candidate : nil
+    }
+
+    static func codexSubagentEntry(from jsonObject: [String: Any]) -> PaneAgentSubagentEntry {
+        let rolloutPath = JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_transcript_path", "agentTranscriptPath"])
+        let info = AgentSubagentModelResolver.codexThreadInfo(rolloutPath: rolloutPath)
+        let agentType = JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_type", "agentType", "agent_role", "agentRole"])
+            ?? info?.role
+        return PaneAgentSubagentEntry(
+            id: codexSubagentID(from: jsonObject) ?? UUID().uuidString,
+            agentType: agentType,
+            model: info?.model ?? JSONKeyAccess.firstString(in: jsonObject, keys: ["model"]),
+            nickname: JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_nickname", "agentNickname"]) ?? info?.nickname,
+            transcriptPath: rolloutPath
+        )
     }
 
     static func smallHarnessAdapter(
@@ -414,6 +489,8 @@ extension AgentEventBridge {
         case "prompt-submit": return "UserPromptSubmit"
         case "pre-compact": return "PreCompact"
         case "post-compact": return "PostCompact"
+        case "subagent-start": return "SubagentStart"
+        case "subagent-stop": return "SubagentStop"
         case "stop": return "Stop"
         default: return nil
         }

--- a/Zentty/AppState/Agent/EventAdapters/GrokEventAdapter.swift
+++ b/Zentty/AppState/Agent/EventAdapters/GrokEventAdapter.swift
@@ -17,7 +17,8 @@ extension AgentEventBridge {
     /// the single source of truth so detection logic lives in one place.
     static func grokAdapter(
         data: Data,
-        environment: [String: String]
+        environment: [String: String],
+        subagentStore: AgentSubagentRegistryStore = AgentSubagentRegistryStore()
     ) throws -> [AgentStatusPayload] {
         let jsonObject = data.isEmpty ? [:] : (try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:])
 
@@ -31,6 +32,7 @@ extension AgentEventBridge {
         let cwd = JSONKeyAccess.firstString(in: jsonObject, keys: ["cwd", "working_directory", "workingDirectory", "project_dir", "projectDir"])
         let hookEventName = JSONKeyAccess.firstString(in: jsonObject, keys: ["hook_event_name", "hookEventName", "event", "type"])
         let pid = parseAgentPID(from: environment, key: "ZENTTY_GROK_PID")
+        let subagentKey = AgentSubagentRegistryStore.Key(tool: "grok", worklaneID: target.worklaneID, paneID: target.paneID)
 
         // Fast path: if this is already a canonical Agent Status Protocol payload, defer to
         // the shared makePayloads. The tool label resolves to "Grok" either because the hook
@@ -57,9 +59,24 @@ extension AgentEventBridge {
             return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd)]
 
         case "stop", "turncomplete", "turn_complete":
-            return [lifecyclePayload(target: target, toolName: toolName, state: .idle, sessionID: sessionID, cwd: cwd)]
+            let subagents = try subagentStore.clear(key: subagentKey)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .idle, sessionID: sessionID, cwd: cwd, subagents: subagents)]
+
+        case "subagentstart", "subagent_start":
+            let entry = grokSubagentEntry(from: jsonObject)
+            let subagents = try subagentStore.start(key: subagentKey, entry: entry)
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, subagents: subagents)]
+
+        case "subagentstop", "subagent_stop", "subagentend", "subagent_end":
+            let subagents = try subagentStore.stop(key: subagentKey, subagentID: grokSubagentID(from: jsonObject))
+            return [lifecyclePayload(target: target, toolName: toolName, state: .running, sessionID: sessionID, cwd: cwd, subagents: subagents)]
 
         case "sessionend", "session_end", "end":
+            // A child session's teardown carries `subagentType`; only the
+            // parent's end forgets the pane's subagent registry.
+            if JSONKeyAccess.firstString(in: jsonObject, keys: ["subagentType", "subagent_type", "agent_type", "agentType"]) == nil {
+                try subagentStore.remove(key: subagentKey)
+            }
             return [
                 AgentStatusPayload(
                     windowID: target.windowID,
@@ -101,6 +118,27 @@ extension AgentEventBridge {
         default:
             return []
         }
+    }
+}
+
+// MARK: - Grok Subagents
+
+extension AgentEventBridge {
+    static func grokSubagentID(from jsonObject: [String: Any]) -> String? {
+        JSONKeyAccess.firstString(in: jsonObject, keys: [
+            "agent_id", "agentId", "subagent_id", "subagentId", "subagent_session_id", "subagentSessionId",
+            "agent_transcript_path", "agentTranscriptPath",
+        ])
+    }
+
+    static func grokSubagentEntry(from jsonObject: [String: Any]) -> PaneAgentSubagentEntry {
+        PaneAgentSubagentEntry(
+            id: grokSubagentID(from: jsonObject) ?? UUID().uuidString,
+            agentType: JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_type", "agentType", "subagent_type", "subagentType", "agent_name", "agentName"]),
+            model: JSONKeyAccess.firstString(in: jsonObject, keys: ["model", "model_id", "modelId"]),
+            nickname: JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_nickname", "agentNickname", "nickname"]),
+            transcriptPath: JSONKeyAccess.firstString(in: jsonObject, keys: ["agent_transcript_path", "agentTranscriptPath"])
+        )
     }
 }
 

--- a/Zentty/AppState/Agent/GrokHooksInstaller.swift
+++ b/Zentty/AppState/Agent/GrokHooksInstaller.swift
@@ -38,6 +38,8 @@ enum GrokHooksInstaller {
         "UserPromptSubmit",
         "Stop",
         "Notification",
+        "SubagentStart",
+        "SubagentStop",
         "BeforeAgent",
         "AfterAgent",
     ]

--- a/Zentty/AppState/Agent/PaneAgentReducer.swift
+++ b/Zentty/AppState/Agent/PaneAgentReducer.swift
@@ -20,6 +20,7 @@ struct PaneAgentSessionState: Equatable, Sendable {
     var trackedPID: Int32?
     var hasObservedRunning: Bool
     var taskProgress: PaneAgentTaskProgress? = nil
+    var subagents: PaneAgentSubagentSummary? = nil
     var completionCandidateDeadline: Date?
     var idleVisibleUntil: Date?
     var unresolvedStopVisibleUntil: Date?
@@ -394,7 +395,8 @@ struct PaneAgentReducerState: Equatable, Sendable {
             sessionID: session.sessionID,
             parentSessionID: session.parentSessionID,
             agentLaunchSnapshot: session.agentLaunchSnapshot,
-            taskProgress: session.taskProgress
+            taskProgress: session.taskProgress,
+            subagents: session.subagents
         )
     }
 
@@ -439,6 +441,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             trackedPID: nil,
             hasObservedRunning: false,
             taskProgress: payload.taskProgress,
+            subagents: payload.subagents,
             completionCandidateDeadline: nil,
             idleVisibleUntil: nil,
             unresolvedStopVisibleUntil: nil,
@@ -475,6 +478,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
         session.idleVisibleUntil = nil
         session.unresolvedStopVisibleUntil = nil
         session.taskProgress = payload.taskProgress ?? session.taskProgress
+        session.subagents = payload.subagents ?? session.subagents
 
         if payload.lifecycleEvent == .stopCandidate {
             session.state = .running
@@ -580,6 +584,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
             session.text = session.text ?? inferredSession.text
             session.transientTextVisibleUntil = session.transientTextVisibleUntil ?? inferredSession.transientTextVisibleUntil
             session.taskProgress = session.taskProgress ?? inferredSession.taskProgress
+            session.subagents = session.subagents ?? inferredSession.subagents
             session.agentLaunchSnapshot = session.agentLaunchSnapshot ?? inferredSession.agentLaunchSnapshot
             if inferredSession.updatedAt > session.updatedAt {
                 session.updatedAt = inferredSession.updatedAt
@@ -607,6 +612,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
         session.transientTextVisibleUntil = session.transientTextVisibleUntil ?? fallbackSession.transientTextVisibleUntil
         session.trackedPID = session.trackedPID ?? fallbackSession.trackedPID
         session.taskProgress = session.taskProgress ?? fallbackSession.taskProgress
+        session.subagents = session.subagents ?? fallbackSession.subagents
         session.agentLaunchSnapshot = session.agentLaunchSnapshot ?? fallbackSession.agentLaunchSnapshot
         if session.shellActivityState == .unknown {
             session.shellActivityState = fallbackSession.shellActivityState
@@ -642,6 +648,7 @@ struct PaneAgentReducerState: Equatable, Sendable {
                 trackedPID: nil,
                 hasObservedRunning: false,
                 taskProgress: payload.taskProgress,
+                subagents: payload.subagents,
                 completionCandidateDeadline: nil,
                 idleVisibleUntil: nil,
                 unresolvedStopVisibleUntil: nil,

--- a/Zentty/AppState/Agent/PaneAgentSubagents.swift
+++ b/Zentty/AppState/Agent/PaneAgentSubagents.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// One live subagent spawned by an agent session (Claude `Agent` tool, Codex
+/// `spawn_agent`, Grok `spawn_subagent`, …).
+struct PaneAgentSubagentEntry: Codable, Equatable, Hashable, Sendable {
+    /// Stable id for the subagent lifetime (`agent_id`, sub-thread id, or the
+    /// transcript path when the agent CLI provides nothing better).
+    let id: String
+    /// Agent kind as the CLI names it: `general-purpose`, `Explore`, `worker`, `guardian`, …
+    let agentType: String?
+    /// Raw model id as reported by the agent CLI (`claude-opus-5`, `gpt-6-astra`).
+    let model: String?
+    /// Codex assigns a nickname per spawned thread (`Noether`, `Dirac`).
+    let nickname: String?
+    /// Subagent transcript / rollout on disk, used to resolve the model lazily.
+    let transcriptPath: String?
+
+    init(id: String, agentType: String? = nil, model: String? = nil, nickname: String? = nil, transcriptPath: String? = nil) {
+        self.id = id
+        self.agentType = agentType
+        self.model = model
+        self.nickname = nickname
+        self.transcriptPath = transcriptPath
+    }
+
+    func with(model: String?, nickname: String? = nil) -> PaneAgentSubagentEntry {
+        PaneAgentSubagentEntry(
+            id: id,
+            agentType: agentType,
+            model: model ?? self.model,
+            nickname: nickname ?? self.nickname,
+            transcriptPath: transcriptPath
+        )
+    }
+
+    /// Short model label for the sidebar (`opus`, `astra`, `auto-review`).
+    var modelLabel: String? {
+        model.flatMap(AgentModelLabel.short(from:))
+    }
+}
+
+/// Rows of the expanded subagent list: `2 × opus  general-purpose`.
+struct PaneAgentSubagentGroup: Equatable, Sendable {
+    let count: Int
+    let modelLabel: String?
+    let agentType: String?
+    let nicknames: [String]
+
+    var leadingText: String {
+        "\(count) ×"
+    }
+
+    var modelText: String {
+        modelLabel ?? "model?"
+    }
+
+    var trailingText: String? {
+        let parts = [agentType, nicknames.isEmpty ? nil : nicknames.joined(separator: ", ")]
+            .compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+/// Authoritative snapshot of the subagents currently running under a pane's
+/// agent session. An empty summary is a deliberate "none running" signal, so
+/// payload consumers can distinguish it from `nil` ("unchanged").
+struct PaneAgentSubagentSummary: Equatable, Sendable {
+    let entries: [PaneAgentSubagentEntry]
+
+    static let empty = PaneAgentSubagentSummary(entries: [])
+
+    init(entries: [PaneAgentSubagentEntry]) {
+        self.entries = entries.sorted { $0.id < $1.id }
+    }
+
+    var count: Int { entries.count }
+    var isEmpty: Bool { entries.isEmpty }
+
+    /// Entries grouped by (model label, agent type), most numerous first, with a
+    /// stable alphabetical tie-break so the expanded list does not jitter.
+    var groups: [PaneAgentSubagentGroup] {
+        struct Key: Hashable {
+            let modelLabel: String?
+            let agentType: String?
+        }
+        var counts: [Key: (count: Int, nicknames: [String])] = [:]
+        for entry in entries {
+            let key = Key(modelLabel: entry.modelLabel, agentType: entry.agentType)
+            var bucket = counts[key] ?? (0, [])
+            bucket.count += 1
+            if let nickname = entry.nickname, !nickname.isEmpty {
+                bucket.nicknames.append(nickname)
+            }
+            counts[key] = bucket
+        }
+        return counts
+            .map { key, value in
+                PaneAgentSubagentGroup(
+                    count: value.count,
+                    modelLabel: key.modelLabel,
+                    agentType: key.agentType,
+                    nicknames: value.nicknames.sorted()
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count { return lhs.count > rhs.count }
+                if lhs.modelText != rhs.modelText { return lhs.modelText < rhs.modelText }
+                return (lhs.agentType ?? "") < (rhs.agentType ?? "")
+            }
+    }
+
+    var badgeText: String {
+        String(count)
+    }
+
+    var tooltipText: String {
+        let noun = count == 1 ? "subagent" : "subagents"
+        return "\(count) \(noun)\nClick for details"
+    }
+
+    var accessibilityText: String {
+        let noun = count == 1 ? "subagent" : "subagents"
+        return "\(count) \(noun)"
+    }
+
+    // MARK: - Transport
+
+    /// JSON array encoding used on the IPC / notification transport.
+    var transportJSON: String? {
+        guard let data = try? JSONEncoder.subagentTransport.encode(entries) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    init?(transportJSON: String?) {
+        guard let transportJSON, let data = transportJSON.data(using: .utf8),
+              let entries = try? JSONDecoder().decode([PaneAgentSubagentEntry].self, from: data) else {
+            return nil
+        }
+        self.init(entries: entries)
+    }
+}
+
+private extension JSONEncoder {
+    static let subagentTransport: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+}
+
+/// Turns raw model ids into the short names people use in conversation.
+enum AgentModelLabel {
+    /// `claude-opus-5` → `opus`, `claude-fable-5-1` → `fable`, `sonnet[1m]` → `sonnet`,
+    /// `gpt-6-astra` → `astra`, `gpt-5.6-sol` → `sol`, `codex-auto-review` → `auto-review`,
+    /// `gpt-5.5` → `gpt-5.5` (nothing to shorten), `gpt-5.4-mini` → `gpt-5.4-mini`.
+    static func short(from rawModel: String) -> String? {
+        var value = rawModel.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !value.isEmpty else { return nil }
+
+        // Bedrock / Vertex style prefixes and context-window suffixes.
+        if let slash = value.lastIndex(of: "/") {
+            value = String(value[value.index(after: slash)...])
+        }
+        if let bracket = value.firstIndex(of: "[") {
+            value = String(value[..<bracket])
+        }
+        if let claudeRange = value.range(of: "claude-") {
+            value = String(value[claudeRange.lowerBound...])
+        }
+        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        guard !value.isEmpty else { return nil }
+
+        let tokens = value.split(separator: "-").map(String.init)
+        guard tokens.count > 1 else { return value }
+
+        if tokens.first == "claude" {
+            // First purely alphabetic token after the vendor prefix is the family.
+            return tokens.dropFirst().first(where: isAlphabetic) ?? value
+        }
+
+        if tokens.first == "codex" {
+            return tokens.dropFirst().joined(separator: "-")
+        }
+
+        // OpenAI style: `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.3-codex-spark`.
+        // Everything after the version token forms the codename; a lone
+        // generic size word (`mini`, `nano`) is not a codename.
+        if let versionIndex = tokens.firstIndex(where: isVersion) {
+            let codename = Array(tokens[(versionIndex + 1)...])
+            if codename.isEmpty || codename.contains(where: { !isAlphabetic($0) }) {
+                return value
+            }
+            if codename.count == 1, genericSizeWords.contains(codename[0]) {
+                return value
+            }
+            return codename.joined(separator: "-")
+        }
+
+        return value
+    }
+
+    private static let genericSizeWords: Set<String> = ["mini", "nano", "small", "medium", "large", "pro", "max", "lite"]
+
+    private static func isAlphabetic(_ token: String) -> Bool {
+        !token.isEmpty && token.allSatisfy(\.isLetter)
+    }
+
+    private static func isVersion(_ token: String) -> Bool {
+        !token.isEmpty && token.allSatisfy { $0.isNumber || $0 == "." } && token.contains(where: \.isNumber)
+    }
+}

--- a/Zentty/AppState/Agent/Status/AgentStatusReconciliation.swift
+++ b/Zentty/AppState/Agent/Status/AgentStatusReconciliation.swift
@@ -37,6 +37,7 @@ enum AgentStatusReconciliation {
             trackedPID: existingStatus.trackedPID,
             hasObservedRunning: existingStatus.hasObservedRunning,
             taskProgress: existingStatus.taskProgress,
+            subagents: existingStatus.subagents,
             completionCandidateDeadline: nil,
             idleVisibleUntil: existingStatus.state == .idle
                 ? existingStatus.updatedAt.addingTimeInterval(PaneAgentReducerState.idleVisibilityWindow)

--- a/Zentty/AppState/Agent/Status/CodexToolStatusResolver+Idle.swift
+++ b/Zentty/AppState/Agent/Status/CodexToolStatusResolver+Idle.swift
@@ -70,7 +70,8 @@ extension CodexToolStatusResolver {
             hasObservedRunning: true,
             sessionID: existingStatus.sessionID,
             parentSessionID: existingStatus.parentSessionID,
-            taskProgress: existingStatus.taskProgress
+            taskProgress: existingStatus.taskProgress,
+            subagents: existingStatus.subagents
         )
         aux.agentStatus = newStatus
         aux.agentReducerState = AgentStatusReconciliation.seededReducerState(
@@ -192,7 +193,8 @@ extension CodexToolStatusResolver {
             hasObservedRunning: true,
             sessionID: existingStatus.sessionID,
             parentSessionID: existingStatus.parentSessionID,
-            taskProgress: existingStatus.taskProgress
+            taskProgress: existingStatus.taskProgress,
+            subagents: existingStatus.subagents
         )
         working.agentStatus = newStatus
         // Re-seed the reducer from the new idle status so the periodic

--- a/Zentty/AppState/Agent/Status/CodexToolStatusResolver+Title.swift
+++ b/Zentty/AppState/Agent/Status/CodexToolStatusResolver+Title.swift
@@ -126,7 +126,8 @@ extension CodexToolStatusResolver {
             hasObservedRunning: existingStatus?.hasObservedRunning == true,
             sessionID: existingStatus?.sessionID,
             parentSessionID: existingStatus?.parentSessionID,
-            taskProgress: existingStatus?.taskProgress
+            taskProgress: existingStatus?.taskProgress,
+            subagents: existingStatus?.subagents
         )
         return true
     }
@@ -304,7 +305,8 @@ extension CodexToolStatusResolver {
             hasObservedRunning: true,
             sessionID: working.agentStatus?.sessionID,
             parentSessionID: working.agentStatus?.parentSessionID,
-            taskProgress: working.agentStatus?.taskProgress
+            taskProgress: working.agentStatus?.taskProgress,
+            subagents: working.agentStatus?.subagents
         )
         working.agentStatus = newStatus
         // Keep the reducer in sync with the direct write so the periodic
@@ -371,7 +373,8 @@ extension CodexToolStatusResolver {
             hasObservedRunning: true,
             sessionID: existingStatus.sessionID,
             parentSessionID: existingStatus.parentSessionID,
-            taskProgress: existingStatus.taskProgress
+            taskProgress: existingStatus.taskProgress,
+            subagents: existingStatus.subagents
         )
     }
 

--- a/Zentty/AppState/PaneAuxiliaryState.swift
+++ b/Zentty/AppState/PaneAuxiliaryState.swift
@@ -143,6 +143,8 @@ struct PanePresentationState: Equatable, Sendable {
     var interactionLabel: String?
     var interactionSymbolName: String?
     var taskProgress: PaneAgentTaskProgress? = nil
+    /// Live subagents under this pane's agent session; `nil` or empty hides the badge.
+    var subagents: PaneAgentSubagentSummary? = nil
 
     var hasResolvedIdentity: Bool {
         identityText != nil || contextText != nil || rememberedTitle != nil
@@ -523,7 +525,8 @@ enum PanePresentationNormalizer {
             interactionKind: interactionKind,
             interactionLabel: interactionLabel,
             interactionSymbolName: interactionSymbolName,
-            taskProgress: taskProgress
+            taskProgress: taskProgress,
+            subagents: raw.agentStatus?.subagents.flatMap { $0.isEmpty ? nil : $0 }
         )
     }
 

--- a/Zentty/AppState/WorklaneStore+AgentStatus.swift
+++ b/Zentty/AppState/WorklaneStore+AgentStatus.swift
@@ -540,6 +540,7 @@ extension WorklaneStore {
                     sessionID: payload.sessionID,
                     parentSessionID: payload.parentSessionID,
                     taskProgress: payload.taskProgress,
+                    subagents: payload.subagents,
                     artifactKind: payload.artifactKind,
                     artifactLabel: payload.artifactLabel,
                     artifactURL: payload.artifactURL,

--- a/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowButton.swift
@@ -553,6 +553,8 @@ final class SidebarPaneRowButton: NSButton {
     var onWorklaneDragRequested: ((NSEvent) -> Bool)?
     weak var serverRowView: SidebarPaneServerRowView?
     var onServerPortSelected: ((String) -> Void)?
+    weak var statusRowView: SidebarPaneTextRowView?
+    var onSubagentBadgeClicked: ((PaneID) -> Void)?
     var onMoveWorklane: ((SidebarWorklaneMoveDirection) -> Void)?
     var worklaneMoveAvailability: SidebarWorklaneMoveAvailability = .none
     var rightPaneCommandPresentationProvider: (() -> PaneRightCommandPresentation)?
@@ -629,7 +631,7 @@ final class SidebarPaneRowButton: NSButton {
 
     override func mouseDown(with event: NSEvent) {
         let pointInSelf = convert(event.locationInWindow, from: nil)
-        if event.type == .leftMouseDown, openServerIfNeeded(at: pointInSelf) {
+        if event.type == .leftMouseDown, openServerIfNeeded(at: pointInSelf) || toggleSubagentDetailsIfNeeded(at: pointInSelf) {
             return
         }
 
@@ -653,7 +655,7 @@ final class SidebarPaneRowButton: NSButton {
 
     @discardableResult
     func performPrimaryClick(at point: NSPoint) -> Bool {
-        if openServerIfNeeded(at: point) {
+        if openServerIfNeeded(at: point) || toggleSubagentDetailsIfNeeded(at: point) {
             return true
         }
 
@@ -675,6 +677,20 @@ final class SidebarPaneRowButton: NSButton {
         }
 
         onServerPortSelected?(serverID)
+        return true
+    }
+
+    /// The subagent badge toggles its detail list instead of selecting the
+    /// pane, mirroring how server ports open without a pane switch.
+    private func toggleSubagentDetailsIfNeeded(at point: NSPoint) -> Bool {
+        guard let statusRowView,
+              let badgeFrame = statusRowView.subagentBadgeFrame(in: self),
+              badgeFrame.insetBy(dx: -2, dy: -2).contains(point)
+        else {
+            return false
+        }
+
+        onSubagentBadgeClicked?(paneID)
         return true
     }
 

--- a/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowRenderer.swift
@@ -41,12 +41,14 @@ final class SidebarPaneRowRenderer {
         var moveToWorklaneCatalogProvider: ((PaneID) -> WorklaneDestinationCatalog?)?
         var onServerPortSelected: ((String) -> Void)?
         var restoredRerunnableCommandProvider: ((PaneID) -> String?)?
+        var onToggleSubagentDetails: ((PaneID) -> Void)?
     }
 
     private(set) var panePrimaryRows: [SidebarPanePrimaryRowView] = []
     private(set) var paneDetailLabels: [SidebarStaticLabel] = []
     private(set) var paneStatusRows: [SidebarPaneTextRowView] = []
     private(set) var paneServerRows: [SidebarPaneServerRowView] = []
+    private(set) var paneSubagentRows: [SidebarPaneSubagentListView] = []
     private(set) var paneRowButtons: [SidebarPaneRowButton] = []
     private(set) var paneRowContainers: [SidebarInsetContainerView] = []
 
@@ -116,6 +118,8 @@ final class SidebarPaneRowRenderer {
                 text: panePresentation.statusDisplayText,
                 symbolName: panePresentation.statusSymbolName,
                 taskProgress: paneRow.taskProgress,
+                subagents: panePresentation.subagents,
+                subagentsExpanded: panePresentation.showsSubagentDetails,
                 trailingText: panePresentation.statusTrailingLayout.isVisible ? paneRow.trailingText : nil,
                 trailingWidth: panePresentation.statusTrailingLayout.width,
                 lineCount: panePresentation.statusLineCount,
@@ -123,6 +127,9 @@ final class SidebarPaneRowRenderer {
             )
             paneStatusRows[index].setShimmerPhaseOffset(panePhaseOffset)
             paneServerRows[index].configure(serverPorts: panePresentation.serverPorts)
+            paneSubagentRows[index].configure(
+                summary: panePresentation.showsSubagentDetails ? panePresentation.subagents : nil
+            )
 
             let button = paneRowButtons[index]
             button.paneID = paneRow.paneID
@@ -150,6 +157,8 @@ final class SidebarPaneRowRenderer {
             button.bookmarkNameLookup = callbacks.bookmarkNameLookup
             button.onWorklaneDragRequested = callbacks.onWorklaneDragRequested
             button.serverRowView = paneServerRows[index]
+            button.statusRowView = paneStatusRows[index]
+            button.onSubagentBadgeClicked = callbacks.onToggleSubagentDetails
             button.onServerPortSelected = callbacks.onServerPortSelected
             button.onHoverChanged = callbacks.onHoverChanged
             button.worklaneMoveAvailability = callbacks.worklaneMoveAvailability
@@ -186,6 +195,10 @@ final class SidebarPaneRowRenderer {
 
         while paneServerRows.count < count {
             paneServerRows.append(SidebarPaneServerRowView())
+        }
+
+        while paneSubagentRows.count < count {
+            paneSubagentRows.append(SidebarPaneSubagentListView())
         }
 
         while paneRowButtons.count < count {
@@ -232,6 +245,7 @@ final class SidebarWorklaneRowContentRenderer {
         let detailLabels: [NSView]
         let statusRows: [NSView]
         let serverRows: [NSView]
+        let subagentRows: [NSView]
         let buttons: [SidebarPaneRowButton]
         let containers: [NSView]
     }
@@ -282,6 +296,7 @@ final class SidebarWorklaneRowContentRenderer {
         views.append(contentsOf: [
             paneRows.statusRows[index],
             paneRows.serverRows[index],
+            paneRows.subagentRows[index],
         ])
         return views
     }
@@ -327,6 +342,8 @@ final class SidebarWorklaneRowContentRenderer {
             paneRows.statusRows[index]
         case .paneServer(let index):
             paneRows.serverRows[index]
+        case .paneSubagents(let index):
+            paneRows.subagentRows[index]
         case .context:
             labels.detailLabels.first ?? labels.overflowLabel
         case .detail(let index):

--- a/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
@@ -1087,7 +1087,6 @@ final class SidebarPaneTextRowView: NSView {
         textColor: NSColor,
         trailingTextColor: NSColor?,
         progressColor: NSColor,
-        subagentBadgeColor: NSColor? = nil,
         isShimmering: Bool,
         shimmerColor: NSColor,
         reducedMotion: Bool
@@ -1095,7 +1094,8 @@ final class SidebarPaneTextRowView: NSView {
         self.textColor = textColor
         self.trailingTextColor = trailingTextColor ?? .clear
         self.reducedMotion = reducedMotion
-        subagentBadgeView.applyFillColor(subagentBadgeColor ?? textColor)
+        // Same tint as the status icon and text so the line reads as one unit.
+        subagentBadgeView.applyFillColor(textColor)
         let dimmedColor = isShimmering
             ? textColor.withAlphaComponent(textColor.alphaComponent * 0.90)
             : textColor

--- a/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneRowViews.swift
@@ -362,6 +362,7 @@ final class SidebarTaskProgressRevealLineView: NSView {
 
     private var trackingAreaValue: NSTrackingArea?
     private weak var iconView: NSImageView?
+    private weak var subagentBadgeView: SidebarSubagentBadgeView?
     private weak var progressIndicator: SidebarTaskProgressIndicatorView?
     private weak var progressRevealView: SidebarTaskProgressRevealView?
     private weak var textContainer: NSView?
@@ -393,15 +394,17 @@ final class SidebarTaskProgressRevealLineView: NSView {
         progressIndicator: SidebarTaskProgressIndicatorView,
         progressRevealView: SidebarTaskProgressRevealView,
         textContainer: NSView,
-        trailingLabelView: SidebarStaticLabel? = nil
+        trailingLabelView: SidebarStaticLabel? = nil,
+        subagentBadgeView: SidebarSubagentBadgeView? = nil
     ) {
         self.iconView = iconView
+        self.subagentBadgeView = subagentBadgeView
         self.progressIndicator = progressIndicator
         self.progressRevealView = progressRevealView
         self.textContainer = textContainer
         self.trailingLabelView = trailingLabelView
 
-        [iconView, progressIndicator, progressRevealView, textContainer, trailingLabelView].forEach { view in
+        [iconView, subagentBadgeView, progressIndicator, progressRevealView, textContainer, trailingLabelView].forEach { view in
             guard let view else { return }
             view.translatesAutoresizingMaskIntoConstraints = false
             if view.superview !== self {
@@ -513,6 +516,17 @@ final class SidebarTaskProgressRevealLineView: NSView {
                 animated: animated
             )
             x += side + Layout.spacing
+        }
+
+        if let subagentBadgeView, subagentBadgeView.isHidden == false {
+            let badgeWidth = subagentBadgeView.preferredWidth
+            let badgeHeight = SidebarSubagentBadgeMetrics.height
+            setFrame(
+                NSRect(x: x, y: centeredY(for: badgeHeight, in: contentHeight, originY: originY), width: badgeWidth, height: badgeHeight),
+                for: subagentBadgeView,
+                animated: animated
+            )
+            x += badgeWidth + SidebarSubagentBadgeMetrics.spacing
         }
 
         if let progressIndicator, progressIndicator.isHidden == false {
@@ -903,6 +917,7 @@ final class SidebarPaneTextRowView: NSView {
     private static let symbolPointSize: CGFloat = 11
 
     private let iconView = NSImageView()
+    private let subagentBadgeView = SidebarSubagentBadgeView()
     private let progressIndicator = SidebarTaskProgressIndicatorView()
     private let progressRevealView = SidebarTaskProgressRevealView()
     private let textContainer = SidebarPrimaryTextContainerView()
@@ -917,6 +932,8 @@ final class SidebarPaneTextRowView: NSView {
     private(set) var trailingText: String?
     private(set) var trailingTextColor: NSColor = .secondaryLabelColor
     private(set) var taskProgress: PaneAgentTaskProgress?
+    private(set) var subagents: PaneAgentSubagentSummary?
+    private var subagentsExpanded = false
     private var rowLineHeight: CGFloat = ShellMetrics.sidebarStatusLineHeight
     private var heightConstraint: NSLayoutConstraint?
     private var trailingPreferredWidth: CGFloat = 0
@@ -951,7 +968,8 @@ final class SidebarPaneTextRowView: NSView {
             progressIndicator: progressIndicator,
             progressRevealView: progressRevealView,
             textContainer: textContainer,
-            trailingLabelView: trailingLabelView
+            trailingLabelView: trailingLabelView,
+            subagentBadgeView: subagentBadgeView
         )
         progressIndicator.onHoverEntered = { [weak self] in
             self?.setProgressRevealVisible(true, animated: true)
@@ -1022,6 +1040,8 @@ final class SidebarPaneTextRowView: NSView {
         text: String,
         symbolName: String?,
         taskProgress: PaneAgentTaskProgress?,
+        subagents: PaneAgentSubagentSummary? = nil,
+        subagentsExpanded: Bool = false,
         trailingText: String?,
         trailingWidth: CGFloat,
         lineCount: Int,
@@ -1031,8 +1051,14 @@ final class SidebarPaneTextRowView: NSView {
         self.symbolName = symbolName ?? ""
         self.trailingText = trailingText
         self.taskProgress = taskProgress
+        self.subagents = subagents
+        self.subagentsExpanded = subagentsExpanded
         animatesProgressUpdates = animated
         let showsTrailingTextInLeadingSlot = rendersTrailingTextInLeadingSlot
+        subagentBadgeView.configure(
+            summary: showsTrailingTextInLeadingSlot ? nil : subagents,
+            isExpanded: subagentsExpanded
+        )
         let leadingText = showsTrailingTextInLeadingSlot ? (trailingText ?? "") : text
 
         baseLabel.stringValue = leadingText
@@ -1061,6 +1087,7 @@ final class SidebarPaneTextRowView: NSView {
         textColor: NSColor,
         trailingTextColor: NSColor?,
         progressColor: NSColor,
+        subagentBadgeColor: NSColor? = nil,
         isShimmering: Bool,
         shimmerColor: NSColor,
         reducedMotion: Bool
@@ -1068,6 +1095,7 @@ final class SidebarPaneTextRowView: NSView {
         self.textColor = textColor
         self.trailingTextColor = trailingTextColor ?? .clear
         self.reducedMotion = reducedMotion
+        subagentBadgeView.applyFillColor(subagentBadgeColor ?? textColor)
         let dimmedColor = isShimmering
             ? textColor.withAlphaComponent(textColor.alphaComponent * 0.90)
             : textColor
@@ -1127,6 +1155,28 @@ final class SidebarPaneTextRowView: NSView {
 
     var progressIndicatorIsVisibleForTesting: Bool {
         progressIndicator.isHidden == false
+    }
+
+    var subagentBadgeIsVisibleForTesting: Bool {
+        subagentBadgeView.isHidden == false
+    }
+
+    var subagentBadgeTextForTesting: String {
+        subagentBadgeView.badgeTextForTesting
+    }
+
+    var subagentBadgeToolTipForTesting: String? {
+        subagentBadgeView.toolTip
+    }
+
+    var subagentBadgeFillColorForTesting: NSColor {
+        subagentBadgeView.fillColorForTesting
+    }
+
+    /// Badge frame in `view`'s coordinates, or `nil` while no badge is shown.
+    func subagentBadgeFrame(in view: NSView) -> NSRect? {
+        guard subagentBadgeView.isHidden == false, isHidden == false, alphaValue > 0 else { return nil }
+        return view.convert(subagentBadgeView.bounds, from: subagentBadgeView)
     }
 
     var progressFractionForTesting: CGFloat {
@@ -1215,6 +1265,7 @@ final class SidebarPaneTextRowView: NSView {
         if wraps || rendersTrailingTextInLeadingSlot || taskProgress == nil {
             setProgressRevealVisible(false, animated: false)
         }
+        subagentBadgeView.isHidden = wraps || rendersTrailingTextInLeadingSlot || (subagents?.isEmpty ?? true)
         trailingLabelView.isHidden = wraps || rendersTrailingTextInLeadingSlot || (trailingText?.isEmpty ?? true)
         heightConstraint?.constant = rowLineHeight * CGFloat(clampedLineCount)
         configureContentLine(taskProgressVisible: progressIndicator.isHidden == false)

--- a/Zentty/UI/Sidebar/SidebarPaneSubagentViews.swift
+++ b/Zentty/UI/Sidebar/SidebarPaneSubagentViews.swift
@@ -1,0 +1,255 @@
+import AppKit
+
+enum SidebarSubagentBadgeMetrics {
+    static let height: CGFloat = 12
+    static let minimumWidth: CGFloat = 12
+    static let horizontalPadding: CGFloat = 3.5
+    static let spacing: CGFloat = 4
+}
+
+/// Inbox-style count badge shown in the pane status line while subagents run.
+/// Hover uses the native tooltip; the click is routed by `SidebarPaneRowButton`
+/// (which owns hit testing for the whole pane row) through `subagentBadgeFrame`.
+@MainActor
+final class SidebarSubagentBadgeView: NSView {
+    private let label = SidebarStaticLabel()
+    private(set) var summary: PaneAgentSubagentSummary?
+    private(set) var fillColor: NSColor = .labelColor
+    private(set) var isExpanded = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: preferredWidth, height: SidebarSubagentBadgeMetrics.height)
+    }
+
+    var preferredWidth: CGFloat {
+        guard summary?.isEmpty == false else { return 0 }
+        let textWidth = SidebarTextMetrics.measuredWidth(for: label.stringValue, font: Self.font)
+        return max(SidebarSubagentBadgeMetrics.minimumWidth, ceil(textWidth) + SidebarSubagentBadgeMetrics.horizontalPadding * 2)
+    }
+
+    var badgeTextForTesting: String { label.stringValue }
+    var fillColorForTesting: NSColor { fillColor }
+
+    private static let font: NSFont = .monospacedDigitSystemFont(ofSize: 9, weight: .bold)
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerCurve = .continuous
+        translatesAutoresizingMaskIntoConstraints = false
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.font = Self.font
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -0.5),
+        ])
+        setAccessibilityRole(.button)
+        isHidden = true
+    }
+
+    override func layout() {
+        super.layout()
+        layer?.cornerRadius = bounds.height / 2
+    }
+
+    func configure(summary: PaneAgentSubagentSummary?, isExpanded: Bool) {
+        self.summary = summary
+        self.isExpanded = isExpanded
+        guard let summary, !summary.isEmpty else {
+            isHidden = true
+            toolTip = nil
+            label.stringValue = ""
+            setAccessibilityLabel("")
+            invalidateIntrinsicContentSize()
+            return
+        }
+
+        label.stringValue = summary.badgeText
+        toolTip = summary.tooltipText
+        setAccessibilityLabel(summary.accessibilityText)
+        isHidden = false
+        applyColors()
+        invalidateIntrinsicContentSize()
+    }
+
+    func applyFillColor(_ color: NSColor) {
+        fillColor = color
+        applyColors()
+    }
+
+    private func applyColors() {
+        layer?.backgroundColor = fillColor.cgColor
+        label.textColor = Self.contrastingTextColor(for: fillColor)
+        layer?.borderWidth = isExpanded ? 1.5 : 0
+        layer?.borderColor = fillColor.withAlphaComponent(0.35).cgColor
+    }
+
+    private static func contrastingTextColor(for fill: NSColor) -> NSColor {
+        guard let rgb = fill.usingColorSpace(.sRGB) else { return .white }
+        let luminance = 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
+        return luminance > 0.6 ? NSColor(white: 0.1, alpha: 1) : .white
+    }
+}
+
+/// Quote-style list of running subagents grouped by model and agent type,
+/// rendered under the pane status line once the badge is clicked.
+///
+///     │ 2 × opus   general-purpose
+///     │ 1 × sonnet codex-review
+@MainActor
+final class SidebarPaneSubagentListView: NSView {
+    private enum Layout {
+        static let ruleWidth: CGFloat = 2
+        static let ruleSpacing: CGFloat = 8
+        static let columnSpacing: CGFloat = 5
+    }
+
+    private struct LineViews {
+        let count: SidebarStaticLabel
+        let model: SidebarStaticLabel
+        let detail: SidebarStaticLabel
+    }
+
+    private let ruleView = NSView()
+    private var lines: [LineViews] = []
+    private(set) var groups: [PaneAgentSubagentGroup] = []
+    private var primaryColor: NSColor = .labelColor
+    private var secondaryColor: NSColor = .secondaryLabelColor
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    static func height(forGroupCount count: Int) -> CGFloat {
+        CGFloat(max(1, count)) * ShellMetrics.sidebarDetailLineHeight
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: Self.height(forGroupCount: groups.count))
+    }
+
+    override func layout() {
+        super.layout()
+        layoutLines()
+    }
+
+    var lineTextsForTesting: [String] {
+        lines.prefix(groups.count).map { line in
+            [line.count.stringValue, line.model.stringValue, line.detail.stringValue]
+                .filter { $0.isEmpty == false }
+                .joined(separator: " ")
+        }
+    }
+
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+        ruleView.wantsLayer = true
+        ruleView.layer?.cornerRadius = Layout.ruleWidth / 2
+        addSubview(ruleView)
+        isHidden = true
+    }
+
+    func configure(summary: PaneAgentSubagentSummary?) {
+        groups = summary?.groups ?? []
+        ensureCapacity(groups.count)
+        for (index, group) in groups.enumerated() {
+            let line = lines[index]
+            line.count.stringValue = group.leadingText
+            line.model.stringValue = group.modelText
+            line.detail.stringValue = group.trailingText ?? ""
+            line.count.isHidden = false
+            line.model.isHidden = false
+            line.detail.isHidden = line.detail.stringValue.isEmpty
+        }
+        for line in lines.dropFirst(groups.count) {
+            line.count.isHidden = true
+            line.model.isHidden = true
+            line.detail.isHidden = true
+        }
+        isHidden = groups.isEmpty
+        setAccessibilityLabel(summary?.accessibilityText ?? "")
+        applyColors()
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    func applyColors(primary: NSColor, secondary: NSColor) {
+        primaryColor = primary
+        secondaryColor = secondary
+        applyColors()
+    }
+
+    private func applyColors() {
+        ruleView.layer?.backgroundColor = secondaryColor.withAlphaComponent(0.35).cgColor
+        for line in lines {
+            line.count.textColor = primaryColor
+            line.model.textColor = primaryColor
+            line.detail.textColor = secondaryColor
+        }
+    }
+
+    private func ensureCapacity(_ count: Int) {
+        while lines.count < count {
+            let countLabel = makeLabel(font: .monospacedDigitSystemFont(ofSize: ShellMetrics.sidebarDetailFont().pointSize, weight: .medium))
+            let modelLabel = makeLabel(font: ShellMetrics.sidebarDetailFont())
+            let detailLabel = makeLabel(font: ShellMetrics.sidebarDetailFont())
+            detailLabel.lineBreakMode = .byTruncatingTail
+            lines.append(LineViews(count: countLabel, model: modelLabel, detail: detailLabel))
+        }
+    }
+
+    private func makeLabel(font: NSFont) -> SidebarStaticLabel {
+        let label = SidebarStaticLabel()
+        label.font = font
+        label.maximumNumberOfLines = 1
+        label.cell?.usesSingleLineMode = true
+        label.cell?.wraps = false
+        label.translatesAutoresizingMaskIntoConstraints = true
+        addSubview(label)
+        return label
+    }
+
+    private func layoutLines() {
+        let lineHeight = ShellMetrics.sidebarDetailLineHeight
+        ruleView.frame = NSRect(x: 0, y: 1, width: Layout.ruleWidth, height: max(0, bounds.height - 2))
+        let leading = Layout.ruleWidth + Layout.ruleSpacing
+        let countWidth = lines.prefix(groups.count)
+            .map { SidebarTextMetrics.measuredWidth(for: $0.count.stringValue, font: $0.count.font ?? ShellMetrics.sidebarDetailFont()) }
+            .max() ?? 0
+
+        for (index, line) in lines.prefix(groups.count).enumerated() {
+            // Flipped coordinates are not used here: first group sits at the top.
+            let y = bounds.height - lineHeight * CGFloat(index + 1)
+            var x = leading
+            line.count.frame = NSRect(x: x, y: y, width: ceil(countWidth), height: lineHeight)
+            x += ceil(countWidth) + Layout.columnSpacing
+            let modelWidth = ceil(SidebarTextMetrics.measuredWidth(for: line.model.stringValue, font: line.model.font ?? ShellMetrics.sidebarDetailFont()))
+            let availableModelWidth = max(0, bounds.width - x)
+            line.model.frame = NSRect(x: x, y: y, width: min(modelWidth, availableModelWidth), height: lineHeight)
+            x += min(modelWidth, availableModelWidth) + Layout.columnSpacing
+            line.detail.frame = NSRect(x: x, y: y, width: max(0, bounds.width - x), height: lineHeight)
+        }
+    }
+}

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -1102,7 +1102,6 @@ final class SidebarWorklaneRowButton: NSButton {
                 ),
                 trailingTextColor: presentationMode == .adaptive ? trailingColor : nil,
                 progressColor: currentTheme.statusRunning,
-                subagentBadgeColor: primaryColor,
                 isShimmering: paneRow.isWorking && paneRow.attentionState == .running,
                 shimmerColor: SidebarWorklaneRowStyleResolver.shimmerColor(
                     baseTextColor: SidebarWorklaneRowStyleResolver.statusShimmerBaseColor(

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowButton.swift
@@ -43,6 +43,12 @@ final class SidebarWorklaneRowButton: NSButton {
     private var paneDetailLabels: [SidebarStaticLabel] { paneRowRenderer.paneDetailLabels }
     private var paneStatusRows: [SidebarPaneTextRowView] { paneRowRenderer.paneStatusRows }
     private var paneServerRows: [SidebarPaneServerRowView] { paneRowRenderer.paneServerRows }
+    private var paneSubagentRows: [SidebarPaneSubagentListView] { paneRowRenderer.paneSubagentRows }
+    /// Panes whose subagent list is unfolded under the status line. UI-only
+    /// state: it lives with the row, is keyed by pane id so a recycled row
+    /// cannot inherit another worklane's choice, and collapses on its own
+    /// once the pane has no running subagents left.
+    private var expandedSubagentPaneIDs: Set<PaneID> = []
     private var paneRowButtons: [SidebarPaneRowButton] { paneRowRenderer.paneRowButtons }
     private var paneRowContainers: [SidebarInsetContainerView] { paneRowRenderer.paneRowContainers }
     private let chrome = SidebarWorklaneRowChrome()
@@ -597,7 +603,14 @@ final class SidebarWorklaneRowButton: NSButton {
         isApplyingResolvedSummary = true
         defer { isApplyingResolvedSummary = false }
 
-        let renderPlan = SidebarWorklaneRowRenderPlan(summary: summary, availableWidth: bounds.width)
+        expandedSubagentPaneIDs = expandedSubagentPaneIDs.filter { paneID in
+            summary.paneRows.contains { $0.paneID == paneID && $0.subagents?.isEmpty == false }
+        }
+        let renderPlan = SidebarWorklaneRowRenderPlan(
+            summary: summary,
+            availableWidth: bounds.width,
+            expandedSubagentPaneIDs: expandedSubagentPaneIDs
+        )
         currentRenderPlan = renderPlan
         applyTextStackVerticalInsets(renderPlan)
 
@@ -742,6 +755,19 @@ final class SidebarWorklaneRowButton: NSButton {
         }
     }
 
+    func toggleSubagentDetails(for paneID: PaneID) {
+        if expandedSubagentPaneIDs.contains(paneID) {
+            expandedSubagentPaneIDs.remove(paneID)
+        } else {
+            expandedSubagentPaneIDs.insert(paneID)
+        }
+        applyResolvedSummary(animated: true)
+    }
+
+    var expandedSubagentPaneIDsForTesting: Set<PaneID> {
+        expandedSubagentPaneIDs
+    }
+
     private func configurePaneRows(
         for panePresentations: [SidebarWorklaneRowRenderPlan.PaneRow],
         animated: Bool
@@ -816,7 +842,10 @@ final class SidebarWorklaneRowButton: NSButton {
                 onServerPortSelected: { [weak self] serverID in
                     self?.onServerPortSelected?(serverID)
                 },
-                restoredRerunnableCommandProvider: restoredRerunnableCommandProvider
+                restoredRerunnableCommandProvider: restoredRerunnableCommandProvider,
+                onToggleSubagentDetails: { [weak self] paneID in
+                    self?.toggleSubagentDetails(for: paneID)
+                }
             )
         )
     }
@@ -1012,7 +1041,8 @@ final class SidebarWorklaneRowButton: NSButton {
             guard panePrimaryRows.indices.contains(index),
                 paneDetailLabels.indices.contains(index),
                 paneStatusRows.indices.contains(index),
-                paneServerRows.indices.contains(index)
+                paneServerRows.indices.contains(index),
+                paneSubagentRows.indices.contains(index)
             else {
                 continue
             }
@@ -1055,7 +1085,7 @@ final class SidebarWorklaneRowButton: NSButton {
                 reducedMotion: reducedMotionProvider(),
                 animatesLocalCodexSpinner: paneRow.animatesLocalCodexSpinner
             )
-            paneDetailLabels[index].textColor = SidebarWorklaneRowStyleResolver.paneDetailTextColor(
+            let detailColor = SidebarWorklaneRowStyleResolver.paneDetailTextColor(
                 isFocused: paneRow.isFocused,
                 isWorking: paneRow.isWorking,
                 isActive: isActive,
@@ -1063,6 +1093,8 @@ final class SidebarWorklaneRowButton: NSButton {
                 inactiveTextColor: inactiveTextColor,
                 theme: currentTheme
             )
+            paneDetailLabels[index].textColor = detailColor
+            paneSubagentRows[index].applyColors(primary: primaryColor, secondary: detailColor)
             paneStatusRows[index].applyColors(
                 textColor: SidebarWorklaneRowStyleResolver.statusTextColor(
                     attentionState: paneRow.attentionState,
@@ -1070,6 +1102,7 @@ final class SidebarWorklaneRowButton: NSButton {
                 ),
                 trailingTextColor: presentationMode == .adaptive ? trailingColor : nil,
                 progressColor: currentTheme.statusRunning,
+                subagentBadgeColor: primaryColor,
                 isShimmering: paneRow.isWorking && paneRow.attentionState == .running,
                 shimmerColor: SidebarWorklaneRowStyleResolver.shimmerColor(
                     baseTextColor: SidebarWorklaneRowStyleResolver.statusShimmerBaseColor(
@@ -1166,6 +1199,7 @@ final class SidebarWorklaneRowButton: NSButton {
             detailLabels: paneDetailLabels,
             statusRows: paneStatusRows,
             serverRows: paneServerRows,
+            subagentRows: paneSubagentRows,
             buttons: paneRowButtons,
             containers: paneRowContainers
         )
@@ -1221,6 +1255,7 @@ final class SidebarWorklaneRowButton: NSButton {
             paneDetailLabels: paneDetailLabels,
             paneStatusRows: paneStatusRows,
             paneServerRows: paneServerRows,
+            paneSubagentRows: paneSubagentRows,
             paneRowButtons: paneRowButtons,
             paneRowContainers: paneRowContainers,
             tintLayer: chrome.tintLayer,

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowDebugging.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowDebugging.swift
@@ -51,6 +51,10 @@ struct SidebarWorklaneRowDebugSnapshot {
     let paneStatusSymbolNames: [String]
     let paneServerPortTexts: [[String]]
     let firstPaneServerIconIsVisible: Bool
+    let paneSubagentBadgeTexts: [String]
+    let firstPaneSubagentBadgeToolTip: String?
+    let firstPaneSubagentBadgeFillColor: NSColor?
+    let paneSubagentListTexts: [[String]]
     let paneStatusShimmerPhaseOffsets: [CGFloat]
     let firstPaneStatusTextColor: NSColor?
     let firstPaneStatusProgressIndicatorIsVisible: Bool
@@ -95,6 +99,7 @@ enum SidebarWorklaneRowDebugInteraction {
     case firstPaneStatusLineExit(pointerStillInsideLine: Bool)
     case firstPaneStatusLineHoverReconciliation(pointerInsideLine: Bool)
     case firstPaneServerPortClick(index: Int)
+    case firstPaneSubagentBadgeClick
 }
 
 enum SidebarWorklaneRowDebugMenuTarget {
@@ -128,6 +133,7 @@ struct SidebarWorklaneRowDebugAccess {
     let paneDetailLabels: [SidebarStaticLabel]
     let paneStatusRows: [SidebarPaneTextRowView]
     let paneServerRows: [SidebarPaneServerRowView]
+    let paneSubagentRows: [SidebarPaneSubagentListView]
     let paneRowButtons: [SidebarPaneRowButton]
     let paneRowContainers: [SidebarInsetContainerView]
     let tintLayer: CALayer
@@ -246,6 +252,12 @@ extension SidebarWorklaneRowButton {
                 .map(\.portTextsForTesting)
                 .filter { $0.isEmpty == false },
             firstPaneServerIconIsVisible: access.paneServerRows.first?.iconIsVisibleForTesting ?? false,
+            paneSubagentBadgeTexts: access.paneStatusRows.prefix(paneRowCount)
+                .map { $0.subagentBadgeIsVisibleForTesting ? $0.subagentBadgeTextForTesting : "" },
+            firstPaneSubagentBadgeToolTip: access.paneStatusRows.first?.subagentBadgeToolTipForTesting,
+            firstPaneSubagentBadgeFillColor: access.paneStatusRows.first?.subagentBadgeFillColorForTesting,
+            paneSubagentListTexts: access.paneSubagentRows.prefix(paneRowCount)
+                .map { $0.isHidden ? [] : $0.lineTextsForTesting },
             paneStatusShimmerPhaseOffsets: access.paneStatusRows.prefix(paneRowCount)
                 .map(\.shimmerPhaseOffsetForTesting),
             firstPaneStatusTextColor: access.paneStatusRows.first?.textColor,
@@ -323,6 +335,15 @@ extension SidebarWorklaneRowButton {
             }
 
             paneButton.performPrimaryClickForTesting(at: paneButton.convert(pointInServerRow, from: serverRow))
+        case .firstPaneSubagentBadgeClick:
+            guard let paneButton = access.paneRowButtons.first,
+                  let statusRow = access.paneStatusRows.first,
+                  let badgeFrame = statusRow.subagentBadgeFrame(in: paneButton)
+            else {
+                return
+            }
+
+            paneButton.performPrimaryClickForTesting(at: NSPoint(x: badgeFrame.midX, y: badgeFrame.midY))
         }
     }
 

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowLayout.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowLayout.swift
@@ -16,6 +16,7 @@ enum WorklaneRowTextRow: Equatable {
     case paneDetail(Int)
     case paneStatus(Int)
     case paneServer(Int)
+    case paneSubagents(Int)
     case context
     case detail(Int)
     case overflow
@@ -126,7 +127,7 @@ struct WorklaneRowLayoutMetrics: Equatable {
         var paneIndices = Set<Int>()
         for row in visibleRows {
             switch row {
-            case .panePrimary(let i), .paneDetail(let i), .paneStatus(let i), .paneServer(let i):
+            case .panePrimary(let i), .paneDetail(let i), .paneStatus(let i), .paneServer(let i), .paneSubagents(let i):
                 paneIndices.insert(i)
             default:
                 break
@@ -162,6 +163,8 @@ struct WorklaneRowLayoutMetrics: Equatable {
             return statusLineHeight
         case .paneServer:
             return statusLineHeight
+        case .paneSubagents:
+            return detailLineHeight
         case .context:
             return contextLineHeight
         case .detail:
@@ -181,9 +184,14 @@ struct SidebarWorklaneRowLayout: Equatable {
     init(
         summary: WorklaneSidebarSummary,
         availableWidth: CGFloat? = nil,
-        metrics: WorklaneRowLayoutMetrics = .sidebar
+        metrics: WorklaneRowLayoutMetrics = .sidebar,
+        expandedSubagentPaneIDs: Set<PaneID> = []
     ) {
-        let visibleTextRows = Self.visibleTextRows(for: summary, availableWidth: availableWidth)
+        let visibleTextRows = Self.visibleTextRows(
+            for: summary,
+            availableWidth: availableWidth,
+            expandedSubagentPaneIDs: expandedSubagentPaneIDs
+        )
         let mode = Self.mode(for: summary, availableWidth: availableWidth)
 
         self.mode = mode
@@ -232,9 +240,20 @@ struct SidebarWorklaneRowLayout: Equatable {
         visibleTextRows(for: summary, availableWidth: nil)
     }
 
+    /// A pane shows its subagent list under the status line only while the
+    /// user has expanded it (badge click) and subagents are still running.
+    static func paneRowShowsSubagentDetails(
+        _ paneRow: WorklaneSidebarPaneRow,
+        expandedSubagentPaneIDs: Set<PaneID>
+    ) -> Bool {
+        guard let subagents = paneRow.subagents, subagents.isEmpty == false else { return false }
+        return expandedSubagentPaneIDs.contains(paneRow.paneID)
+    }
+
     static func visibleTextRows(
         for summary: WorklaneSidebarSummary,
-        availableWidth: CGFloat?
+        availableWidth: CGFloat?,
+        expandedSubagentPaneIDs: Set<PaneID> = []
     ) -> [WorklaneRowTextRow] {
         if summary.paneRows.isEmpty == false {
             var rows: [WorklaneRowTextRow] = []
@@ -269,6 +288,10 @@ struct SidebarWorklaneRowLayout: Equatable {
 
                 if paneRow.serverPorts.isEmpty == false {
                     rows.append(.paneServer(index))
+                }
+
+                if paneRowShowsSubagentDetails(paneRow, expandedSubagentPaneIDs: expandedSubagentPaneIDs) {
+                    rows.append(.paneSubagents(index))
                 }
             }
 
@@ -654,13 +677,15 @@ struct SidebarWorklaneRowLayout: Equatable {
                             paneRows.append(.paneStatus(i))
                         case .paneServer(let i) where i == index:
                             paneRows.append(.paneServer(i))
+                        case .paneSubagents(let i) where i == index:
+                            paneRows.append(.paneSubagents(i))
                         default:
                             break
                         }
                     }
                     groups.append(.pane(index: index, rows: paneRows))
                 }
-            case .paneDetail, .paneStatus, .paneServer:
+            case .paneDetail, .paneStatus, .paneServer, .paneSubagents:
                 break
             case .contextPrefix:
                 if contextPrefixConsumed == false {
@@ -694,7 +719,7 @@ private extension WorklaneRowLayoutMetrics {
         var paneIndices = Set<Int>()
         for row in visibleRows {
             switch row {
-            case .panePrimary(let i), .paneDetail(let i), .paneStatus(let i), .paneServer(let i):
+            case .panePrimary(let i), .paneDetail(let i), .paneStatus(let i), .paneServer(let i), .paneSubagents(let i):
                 paneIndices.insert(i)
             default:
                 break
@@ -750,6 +775,11 @@ private extension WorklaneRowLayoutMetrics {
             )
         case .paneServer:
             return statusLineHeight
+        case .paneSubagents(let index):
+            guard summary.paneRows.indices.contains(index) else {
+                return detailLineHeight
+            }
+            return detailLineHeight * CGFloat(max(1, summary.paneRows[index].subagents?.groups.count ?? 1))
         default:
             return lineHeight(for: row)
         }

--- a/Zentty/UI/Sidebar/SidebarWorklaneRowPresentation.swift
+++ b/Zentty/UI/Sidebar/SidebarWorklaneRowPresentation.swift
@@ -11,6 +11,8 @@ struct SidebarWorklaneRowRenderPlan: Equatable {
         let serverPorts: [WorklaneSidebarServerPort]
         let isRemotePane: Bool
         let remotePaneLabel: String?
+        let subagents: PaneAgentSubagentSummary?
+        let showsSubagentDetails: Bool
     }
 
     let summary: WorklaneSidebarSummary
@@ -25,9 +27,13 @@ struct SidebarWorklaneRowRenderPlan: Equatable {
     let statusLineCount: Int
     let paneRows: [PaneRow]
 
-    init(summary: WorklaneSidebarSummary, availableWidth: CGFloat?) {
+    init(summary: WorklaneSidebarSummary, availableWidth: CGFloat?, expandedSubagentPaneIDs: Set<PaneID> = []) {
         self.summary = summary
-        let layout = SidebarWorklaneRowLayout(summary: summary, availableWidth: availableWidth)
+        let layout = SidebarWorklaneRowLayout(
+            summary: summary,
+            availableWidth: availableWidth,
+            expandedSubagentPaneIDs: expandedSubagentPaneIDs
+        )
         mode = layout.mode
         visibleTextRows = layout.visibleTextRows
         contentGroups = layout.contentGroups
@@ -88,7 +94,12 @@ struct SidebarWorklaneRowRenderPlan: Equatable {
                 ),
                 serverPorts: paneRow.serverPorts,
                 isRemotePane: paneRow.isRemotePane,
-                remotePaneLabel: paneRow.remotePaneLabel
+                remotePaneLabel: paneRow.remotePaneLabel,
+                subagents: (paneRow.subagents?.isEmpty ?? true) ? nil : paneRow.subagents,
+                showsSubagentDetails: SidebarWorklaneRowLayout.paneRowShowsSubagentDetails(
+                    paneRow,
+                    expandedSubagentPaneIDs: expandedSubagentPaneIDs
+                )
             )
         }
     }

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummary.swift
@@ -31,6 +31,7 @@ struct WorklaneSidebarPaneRow: Equatable {
     let isFocused: Bool
     let isWorking: Bool
     let taskProgress: PaneAgentTaskProgress?
+    let subagents: PaneAgentSubagentSummary?
     let serverPorts: [WorklaneSidebarServerPort]
     let isRemotePane: Bool
     let remotePaneLabel: String?
@@ -51,6 +52,7 @@ struct WorklaneSidebarPaneRow: Equatable {
         isFocused: Bool,
         isWorking: Bool,
         taskProgress: PaneAgentTaskProgress? = nil,
+        subagents: PaneAgentSubagentSummary? = nil,
         serverPorts: [WorklaneSidebarServerPort] = [],
         isRemotePane: Bool = false,
         remotePaneLabel: String? = nil
@@ -70,6 +72,7 @@ struct WorklaneSidebarPaneRow: Equatable {
         self.isFocused = isFocused
         self.isWorking = isWorking
         self.taskProgress = taskProgress
+        self.subagents = subagents
         self.serverPorts = serverPorts
         self.isRemotePane = isRemotePane
         self.remotePaneLabel = remotePaneLabel

--- a/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
+++ b/Zentty/UI/Sidebar/WorklaneSidebarSummaryBuilder.swift
@@ -286,6 +286,7 @@ enum WorklaneSidebarSummaryBuilder {
                 isFocused: isFocused,
                 isWorking: statusPresentation.isWorking,
                 taskProgress: statusPresentation.taskProgress,
+                subagents: paneContext.presentation.subagents,
                 serverPorts: serverPorts(for: paneContext.paneID, serverContext: serverContext),
                 isRemotePane: paneContext.presentation.isRemotePane,
                 remotePaneLabel: remotePaneLabel(for: paneContext.presentation)

--- a/ZenttyLogicTests/AgentEventBridgeTests.swift
+++ b/ZenttyLogicTests/AgentEventBridgeTests.swift
@@ -1890,7 +1890,9 @@ final class AgentEventBridgeTests: XCTestCase {
         let json = #"{"hook_event_name": "SubagentStop", "session_id": "cs1"}"#
         let payloads = try AgentEventBridge.claudeAdapter(data: json.data(using: .utf8)!, environment: claudeEnvironment())
 
-        XCTAssertEqual(payloads[0].state, .idle)
+        // A subagent finishing is not the parent's turn ending: the parent
+        // still has to consume the result, so the pane stays running.
+        XCTAssertEqual(payloads[0].state, .running)
         XCTAssertEqual(payloads[0].lifecycleEvent, .update)
     }
 

--- a/ZenttyLogicTests/AgentStatusSupportTests.swift
+++ b/ZenttyLogicTests/AgentStatusSupportTests.swift
@@ -2324,6 +2324,8 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertNotNil(hooks["PreCompact"])
         XCTAssertNotNil(hooks["PostCompact"])
         XCTAssertNotNil(hooks["TaskCompleted"])
+        XCTAssertNotNil(hooks["SubagentStart"])
+        XCTAssertNotNil(hooks["SubagentStop"])
         // PostToolUse / PostToolUseFailure are the only hooks Claude Code emits
         // between an approved tool and the next Bash/Write/Edit call; without
         // them an approval prompt stays "Needs input" while Claude works
@@ -2461,7 +2463,11 @@ final class AgentStatusSupportTests: XCTestCase {
         XCTAssertTrue(hookStateArgument.contains(#""/<session-flags>/config.toml:pre_compact:0:0""#))
         XCTAssertTrue(hookStateArgument.contains(#""/<session-flags>/config.toml:post_compact:0:0""#))
         XCTAssertTrue(hookStateArgument.contains(#""/<session-flags>/config.toml:stop:0:0""#))
-        XCTAssertEqual(hookStateArgument.components(separatedBy: "trusted_hash=\"sha256:").count - 1, 8)
+        XCTAssertTrue(hookConfigArguments.contains { $0.hasPrefix("hooks.SubagentStart=") && $0.contains("subagent-start") })
+        XCTAssertTrue(hookConfigArguments.contains { $0.hasPrefix("hooks.SubagentStop=") && $0.contains("subagent-stop") })
+        XCTAssertTrue(hookStateArgument.contains(#""/<session-flags>/config.toml:subagent_start:0:0""#))
+        XCTAssertTrue(hookStateArgument.contains(#""/<session-flags>/config.toml:subagent_stop:0:0""#))
+        XCTAssertEqual(hookStateArgument.components(separatedBy: "trusted_hash=\"sha256:").count - 1, 10)
         let sourceConfig = try String(contentsOf: sourceConfigURL, encoding: .utf8)
         XCTAssertFalse(sourceConfig.contains("hooks.state"))
         XCTAssertTrue(plan.arguments.contains("features.hooks=true"))

--- a/ZenttyLogicTests/AgentSubagentTrackingTests.swift
+++ b/ZenttyLogicTests/AgentSubagentTrackingTests.swift
@@ -296,8 +296,10 @@ final class AgentSubagentTrackingTests: XCTestCase {
         let subagentStore = try makeRegistryStore()
 
         _ = try codexPayloads(#"{"hook_event_name":"SessionStart","session_id":"root"}"#, subagentStore: subagentStore)
+        // Codex sends the thread id on start but the rollout path only on stop;
+        // both must resolve to the same registry entry.
         let started = try codexPayloads(
-            #"{"hook_event_name":"SubagentStart","session_id":"child-thread","agent_type":"worker","agent_transcript_path":"\#(rolloutPath)"}"#,
+            #"{"hook_event_name":"SubagentStart","session_id":"child-thread","agent_id":"01a07132-eb9a-7222-ad53-819ccda4db3c","agent_type":"worker","model":"gpt-5.6-sol"}"#,
             subagentStore: subagentStore
         )
         let payload = try XCTUnwrap(started.first)
@@ -305,9 +307,30 @@ final class AgentSubagentTrackingTests: XCTestCase {
         XCTAssertEqual(payload.state, .running)
         let entry = try XCTUnwrap(payload.subagents?.entries.first)
         XCTAssertEqual(entry.id, "01a07132-eb9a-7222-ad53-819ccda4db3c")
-        XCTAssertEqual(entry.model, "gpt-5.6-sol")
-        XCTAssertEqual(entry.nickname, "Noether")
-        XCTAssertEqual(entry.agentType, "worker")
+        XCTAssertEqual(entry.model, "gpt-5.6-sol", "payload model is used until the rollout exists")
+        XCTAssertNil(entry.nickname)
+
+        let toolHook = try codexPayloads(
+            #"{"hook_event_name":"PostToolUse","session_id":"root","agent_id":"01a07132-eb9a-7222-ad53-819ccda4db3c"}"#,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(toolHook.first?.subagents?.entries.first?.model, "gpt-5.6-sol")
+
+        let stoppedWithPath = try codexPayloads(
+            #"{"hook_event_name":"SubagentStop","session_id":"child-thread","agent_id":"01a07132-eb9a-7222-ad53-819ccda4db3c","agent_transcript_path":"\#(rolloutPath)"}"#,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(stoppedWithPath.first?.subagents, .empty)
+
+        let restarted = try codexPayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"child-thread","agent_type":"worker","agent_transcript_path":"\#(rolloutPath)"}"#,
+            subagentStore: subagentStore
+        )
+        let entryFromRollout = try XCTUnwrap(restarted.first?.subagents?.entries.first)
+        XCTAssertEqual(entryFromRollout.id, "01a07132-eb9a-7222-ad53-819ccda4db3c")
+        XCTAssertEqual(entryFromRollout.model, "gpt-5.6-sol")
+        XCTAssertEqual(entryFromRollout.nickname, "Noether")
+        XCTAssertEqual(entryFromRollout.agentType, "worker")
 
         let childStop = try codexPayloads(#"{"hook_event_name":"Stop","session_id":"child-thread"}"#, subagentStore: subagentStore)
         XCTAssertNil(childStop.first?.subagents, "a sub-thread Stop must not blank the parent's badge")

--- a/ZenttyLogicTests/AgentSubagentTrackingTests.swift
+++ b/ZenttyLogicTests/AgentSubagentTrackingTests.swift
@@ -229,22 +229,29 @@ final class AgentSubagentTrackingTests: XCTestCase {
     }
 
     func test_claude_hooks_inside_subagent_fill_in_model_from_transcript() throws {
+        // Live Claude 2.1.261 payloads: SubagentStart carries the session
+        // transcript_path and agent_id but no agent_transcript_path, so the
+        // subagent transcript is derived as <session>/subagents/agent-<id>.jsonl.
         let directory = try makeTemporaryDirectory()
-        let transcriptPath = directory.appendingPathComponent("agent-abc.jsonl").path
+        let sessionTranscriptPath = directory.appendingPathComponent("session-1.jsonl").path
+        let subagentsDirectory = directory.appendingPathComponent("session-1/subagents")
+        try FileManager.default.createDirectory(at: subagentsDirectory, withIntermediateDirectories: true)
+        let transcriptPath = subagentsDirectory.appendingPathComponent("agent-abc.jsonl").path
         let sessionStore = try makeClaudeSessionStore()
         let subagentStore = try makeRegistryStore()
 
         let started = try claudePayloads(
-            #"{"hook_event_name":"SubagentStart","session_id":"session-1","agent_id":"abc","agent_type":"Explore","agent_transcript_path":"\#(transcriptPath)"}"#,
+            #"{"hook_event_name":"SubagentStart","session_id":"session-1","transcript_path":"\#(sessionTranscriptPath)","agent_id":"abc","agent_type":"Explore"}"#,
             sessionStore: sessionStore,
             subagentStore: subagentStore
         )
         XCTAssertNil(started.first?.subagents?.entries.first?.model, "transcript does not exist yet at spawn")
+        XCTAssertEqual(started.first?.subagents?.entries.first?.transcriptPath, transcriptPath)
 
         try #"{"type":"assistant","message":{"model":"claude-sonnet-5","role":"assistant"}}"#
             .write(toFile: transcriptPath, atomically: true, encoding: .utf8)
         let toolUse = try claudePayloads(
-            #"{"hook_event_name":"PreToolUse","session_id":"session-1","tool_name":"Read","agent_id":"abc","agent_type":"Explore","agent_transcript_path":"\#(transcriptPath)"}"#,
+            #"{"hook_event_name":"PreToolUse","session_id":"session-1","tool_name":"Read","agent_id":"abc","agent_type":"Explore"}"#,
             sessionStore: sessionStore,
             subagentStore: subagentStore
         )

--- a/ZenttyLogicTests/AgentSubagentTrackingTests.swift
+++ b/ZenttyLogicTests/AgentSubagentTrackingTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import XCTest
+@testable import Zentty
+
+final class AgentSubagentTrackingTests: XCTestCase {
+    private let environment: [String: String] = [
+        "ZENTTY_WORKLANE_ID": "worklane-main",
+        "ZENTTY_PANE_ID": "worklane-main-shell",
+    ]
+
+    private let paneKey = AgentSubagentRegistryStore.Key(
+        tool: "claude",
+        worklaneID: WorklaneID("worklane-main"),
+        paneID: PaneID("worklane-main-shell")
+    )
+
+    // MARK: - Model labels
+
+    func test_model_label_shortens_known_families() {
+        XCTAssertEqual(AgentModelLabel.short(from: "claude-opus-5"), "opus")
+        XCTAssertEqual(AgentModelLabel.short(from: "claude-sonnet-5"), "sonnet")
+        XCTAssertEqual(AgentModelLabel.short(from: "claude-fable-5-1"), "fable")
+        XCTAssertEqual(AgentModelLabel.short(from: "claude-haiku-4-5-20251001"), "haiku")
+        XCTAssertEqual(AgentModelLabel.short(from: "opus"), "opus")
+        XCTAssertEqual(AgentModelLabel.short(from: "sonnet[1m]"), "sonnet")
+        XCTAssertEqual(AgentModelLabel.short(from: "us.anthropic.claude-opus-5-v1:0"), "opus")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-6-astra"), "astra")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.6-sol"), "sol")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.6-terra"), "terra")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.6-luna"), "luna")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.3-codex-spark"), "codex-spark")
+        XCTAssertEqual(AgentModelLabel.short(from: "codex-auto-review"), "auto-review")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.5"), "gpt-5.5")
+        XCTAssertEqual(AgentModelLabel.short(from: "gpt-5.4-mini"), "gpt-5.4-mini")
+        XCTAssertNil(AgentModelLabel.short(from: "   "))
+    }
+
+    // MARK: - Summary
+
+    func test_summary_groups_by_model_and_type_most_numerous_first() {
+        let summary = PaneAgentSubagentSummary(entries: [
+            PaneAgentSubagentEntry(id: "a", agentType: "general-purpose", model: "claude-opus-5"),
+            PaneAgentSubagentEntry(id: "b", agentType: "general-purpose", model: "claude-opus-5"),
+            PaneAgentSubagentEntry(id: "c", agentType: "codex-review", model: "claude-sonnet-5"),
+            PaneAgentSubagentEntry(id: "d", agentType: "worker", model: "gpt-6-astra", nickname: "Dirac"),
+        ])
+
+        XCTAssertEqual(summary.count, 4)
+        XCTAssertEqual(summary.badgeText, "4")
+        XCTAssertEqual(summary.tooltipText, "4 subagents\nClick for details")
+        let groups = summary.groups
+        XCTAssertEqual(groups.map(\.count), [2, 1, 1])
+        XCTAssertEqual(groups[0].modelText, "opus")
+        XCTAssertEqual(groups[0].trailingText, "general-purpose")
+        XCTAssertEqual(groups[1].modelText, "astra")
+        XCTAssertEqual(groups[1].trailingText, "worker · Dirac")
+        XCTAssertEqual(groups[2].modelText, "sonnet")
+        XCTAssertEqual(groups[2].leadingText, "1 ×")
+    }
+
+    func test_summary_without_model_shows_placeholder() {
+        let summary = PaneAgentSubagentSummary(entries: [PaneAgentSubagentEntry(id: "a", agentType: "Explore")])
+        XCTAssertEqual(summary.tooltipText, "1 subagent\nClick for details")
+        XCTAssertEqual(summary.groups.first?.modelText, "model?")
+    }
+
+    func test_payload_user_info_round_trips_subagents_including_explicit_empty() throws {
+        let summary = PaneAgentSubagentSummary(entries: [
+            PaneAgentSubagentEntry(id: "agent-1", agentType: "Explore", model: "claude-sonnet-5", transcriptPath: "/tmp/agent-1.jsonl"),
+        ])
+        let payload = AgentStatusPayload(
+            worklaneID: WorklaneID("worklane-main"),
+            paneID: PaneID("pane"),
+            state: .running,
+            toolName: "Claude Code",
+            text: nil,
+            subagents: summary,
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        )
+        let decoded = try AgentStatusPayload(userInfo: XCTUnwrap(payload.notificationUserInfo))
+        XCTAssertEqual(decoded.subagents, summary)
+
+        let cleared = payload.with(subagents: .empty)
+        let decodedCleared = try AgentStatusPayload(userInfo: XCTUnwrap(cleared.notificationUserInfo))
+        XCTAssertEqual(decodedCleared.subagents, .empty)
+
+        let untouched = payload.with(subagents: nil)
+        let decodedUntouched = try AgentStatusPayload(userInfo: XCTUnwrap(untouched.notificationUserInfo))
+        XCTAssertNil(decodedUntouched.subagents)
+    }
+
+    // MARK: - Registry store
+
+    func test_registry_tracks_start_stop_and_clear() throws {
+        let store = try makeRegistryStore()
+
+        let afterFirst = try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "a", agentType: "Explore"))
+        XCTAssertEqual(afterFirst.count, 1)
+        let afterSecond = try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "b", agentType: "Plan", model: "claude-opus-5"))
+        XCTAssertEqual(afterSecond.count, 2)
+
+        let afterStop = try store.stop(key: paneKey, subagentID: "a")
+        XCTAssertEqual(afterStop.entries.map(\.id), ["b"])
+
+        let afterUnknownStop = try store.stop(key: paneKey, subagentID: "zzz")
+        XCTAssertEqual(afterUnknownStop.count, 1, "stopping an unknown id must not retire a live subagent")
+
+        let afterAnonymousStop = try store.stop(key: paneKey, subagentID: nil)
+        XCTAssertEqual(afterAnonymousStop.count, 0, "a stop without id retires the oldest subagent")
+
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "c"))
+        XCTAssertEqual(try store.clear(key: paneKey), .empty)
+        XCTAssertEqual(try store.summary(key: paneKey), .empty)
+
+        try store.remove(key: paneKey)
+        XCTAssertNil(try store.summary(key: paneKey))
+    }
+
+    func test_registry_merges_repeated_start_and_refreshes_missing_models() throws {
+        let store = try makeRegistryStore()
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "a", agentType: "Explore", transcriptPath: "/tmp/a.jsonl"))
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "a", model: "claude-sonnet-5"))
+        let merged = try XCTUnwrap(try store.summary(key: paneKey)?.entries.first)
+        XCTAssertEqual(merged.agentType, "Explore")
+        XCTAssertEqual(merged.model, "claude-sonnet-5")
+        XCTAssertEqual(merged.transcriptPath, "/tmp/a.jsonl")
+
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "b", agentType: "Plan"))
+        var resolvedIDs: [String] = []
+        let refreshed = try store.refreshMissingModels(key: paneKey) { entry in
+            resolvedIDs.append(entry.id)
+            return entry.with(model: "claude-opus-5")
+        }
+        XCTAssertEqual(resolvedIDs, ["b"], "only entries without a model are resolved")
+        XCTAssertEqual(refreshed?.entries.first(where: { $0.id == "b" })?.model, "claude-opus-5")
+    }
+
+    func test_registry_prunes_stale_entries_and_remembers_root_session() throws {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let store = try makeRegistryStore(now: { now })
+        try store.recordRootSession(key: paneKey, sessionID: "root-1")
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "old"))
+        now = now.addingTimeInterval(AgentSubagentRegistryStore.staleEntryWindow + 1)
+        try store.start(key: paneKey, entry: PaneAgentSubagentEntry(id: "fresh"))
+
+        XCTAssertEqual(try store.summary(key: paneKey)?.entries.map(\.id), ["fresh"])
+        XCTAssertEqual(try store.rootSessionID(key: paneKey), "root-1")
+    }
+
+    // MARK: - Model resolver
+
+    func test_claude_model_resolver_prefers_meta_sidecar_then_transcript() throws {
+        let directory = try makeTemporaryDirectory()
+        let transcriptPath = directory.appendingPathComponent("agent-abc.jsonl").path
+        XCTAssertNil(AgentSubagentModelResolver.claudeModel(agentTranscriptPath: transcriptPath))
+
+        try """
+        {"parentUuid":null,"isSidechain":true,"agentId":"abc","type":"user","message":{"role":"user","content":"hi"}}
+        {"parentUuid":"x","isSidechain":true,"agentId":"abc","type":"assistant","message":{"model":"claude-opus-5","role":"assistant","content":[]}}
+        """.write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+        XCTAssertEqual(AgentSubagentModelResolver.claudeModel(agentTranscriptPath: transcriptPath), "claude-opus-5")
+
+        try """
+        {"agentType":"general-purpose","description":"x","toolUseId":"toolu_1","spawnDepth":1,"model":"sonnet"}
+        """.write(toFile: AgentSubagentModelResolver.claudeMetaPath(agentTranscriptPath: transcriptPath), atomically: true, encoding: .utf8)
+        XCTAssertEqual(AgentSubagentModelResolver.claudeModel(agentTranscriptPath: transcriptPath), "sonnet")
+    }
+
+    func test_claude_agent_transcript_path_derives_from_session_transcript() {
+        XCTAssertEqual(
+            AgentSubagentModelResolver.claudeAgentTranscriptPath(
+                sessionTranscriptPath: "/Users/x/.claude/projects/p/session-1.jsonl",
+                agentID: "a034fe"
+            ),
+            "/Users/x/.claude/projects/p/session-1/subagents/agent-a034fe.jsonl"
+        )
+        XCTAssertNil(AgentSubagentModelResolver.claudeAgentTranscriptPath(sessionTranscriptPath: nil, agentID: "a"))
+    }
+
+    func test_codex_thread_info_reads_nickname_role_and_model_from_rollout_head() {
+        let rollout = """
+        {"timestamp":"t","type":"session_meta","payload":{"id":"01a07132","parent_thread_id":"01a07119","source":{"subagent":{"thread_spawn":{"parent_thread_id":"01a07119","depth":1,"agent_path":"/root/unread_ui","agent_nickname":"Dirac","agent_role":"worker"}}},"thread_source":"subagent"}}
+        {"timestamp":"t","type":"response_item","payload":{"type":"message","role":"user","content":[]}}
+        {"timestamp":"t","type":"turn_context","payload":{"turn_id":"1","cwd":"/tmp","model":"gpt-6-astra","effort":"medium"}}
+        """
+        let info = AgentSubagentModelResolver.codexThreadInfo(rolloutText: rollout)
+        XCTAssertEqual(info, .init(model: "gpt-6-astra", nickname: "Dirac", role: "worker"))
+
+        let guardian = """
+        {"timestamp":"t","type":"session_meta","payload":{"id":"x","parent_thread_id":"y","source":{"subagent":{"other":"guardian"}},"thread_source":"guardian_review"}}
+        {"timestamp":"t","type":"turn_context","payload":{"model":"codex-auto-review"}}
+        """
+        XCTAssertEqual(AgentSubagentModelResolver.codexThreadInfo(rolloutText: guardian), .init(model: "codex-auto-review", nickname: nil, role: nil))
+        XCTAssertNil(AgentSubagentModelResolver.codexThreadInfo(rolloutText: "not json"))
+    }
+
+    // MARK: - Claude adapter
+
+    func test_claude_subagent_start_and_stop_update_payload_subagents() throws {
+        let directory = try makeTemporaryDirectory()
+        let transcriptPath = directory.appendingPathComponent("agent-abc.jsonl").path
+        try #"{"agentType":"general-purpose","model":"opus"}"#
+            .write(toFile: AgentSubagentModelResolver.claudeMetaPath(agentTranscriptPath: transcriptPath), atomically: true, encoding: .utf8)
+        let sessionStore = try makeClaudeSessionStore()
+        let subagentStore = try makeRegistryStore()
+
+        let started = try claudePayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"session-1","agent_id":"abc","agent_type":"general-purpose","agent_transcript_path":"\#(transcriptPath)"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        let startPayload = try XCTUnwrap(started.first)
+        XCTAssertEqual(startPayload.state, .running)
+        XCTAssertEqual(startPayload.sessionID, "session-1")
+        XCTAssertEqual(startPayload.subagents?.count, 1)
+        XCTAssertEqual(startPayload.subagents?.entries.first?.model, "opus")
+        XCTAssertEqual(startPayload.subagents?.entries.first?.agentType, "general-purpose")
+
+        let stopped = try claudePayloads(
+            #"{"hook_event_name":"SubagentStop","session_id":"session-1","agent_id":"abc","agent_type":"general-purpose"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        let stopPayload = try XCTUnwrap(stopped.first)
+        XCTAssertEqual(stopPayload.state, .running, "parent keeps working after a subagent finishes")
+        XCTAssertEqual(stopPayload.subagents, .empty)
+    }
+
+    func test_claude_hooks_inside_subagent_fill_in_model_from_transcript() throws {
+        let directory = try makeTemporaryDirectory()
+        let transcriptPath = directory.appendingPathComponent("agent-abc.jsonl").path
+        let sessionStore = try makeClaudeSessionStore()
+        let subagentStore = try makeRegistryStore()
+
+        let started = try claudePayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"session-1","agent_id":"abc","agent_type":"Explore","agent_transcript_path":"\#(transcriptPath)"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        XCTAssertNil(started.first?.subagents?.entries.first?.model, "transcript does not exist yet at spawn")
+
+        try #"{"type":"assistant","message":{"model":"claude-sonnet-5","role":"assistant"}}"#
+            .write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+        let toolUse = try claudePayloads(
+            #"{"hook_event_name":"PreToolUse","session_id":"session-1","tool_name":"Read","agent_id":"abc","agent_type":"Explore","agent_transcript_path":"\#(transcriptPath)"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        let payload = try XCTUnwrap(toolUse.first)
+        XCTAssertEqual(payload.state, .running)
+        XCTAssertEqual(payload.subagents?.entries.first?.model, "claude-sonnet-5")
+        XCTAssertEqual(payload.subagents?.entries.first?.modelLabel, "sonnet")
+    }
+
+    func test_claude_stop_clears_subagents_explicitly() throws {
+        let sessionStore = try makeClaudeSessionStore()
+        let subagentStore = try makeRegistryStore()
+        _ = try claudePayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"session-1","agent_id":"abc","agent_type":"Explore"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        let stopped = try claudePayloads(
+            #"{"hook_event_name":"Stop","session_id":"session-1"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        let payload = try XCTUnwrap(stopped.first)
+        XCTAssertEqual(payload.state, .idle)
+        XCTAssertEqual(payload.subagents, .empty)
+        XCTAssertEqual(try subagentStore.summary(key: paneKey), .empty)
+    }
+
+    func test_claude_unrelated_hook_leaves_subagents_untouched_when_none_recorded() throws {
+        let sessionStore = try makeClaudeSessionStore()
+        let subagentStore = try makeRegistryStore()
+        let payloads = try claudePayloads(
+            #"{"hook_event_name":"UserPromptSubmit","session_id":"session-1"}"#,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+        XCTAssertNil(payloads.first?.subagents)
+    }
+
+    // MARK: - Codex adapter
+
+    func test_codex_subagent_start_attributes_to_root_session_and_reads_rollout() throws {
+        let directory = try makeTemporaryDirectory()
+        let rolloutPath = directory.appendingPathComponent("rollout-2026-09-05T12-52-37-01a07132-eb9a-7222-ad53-819ccda4db3c.jsonl").path
+        try """
+        {"type":"session_meta","payload":{"id":"01a07132-eb9a-7222-ad53-819ccda4db3c","parent_thread_id":"root","source":{"subagent":{"thread_spawn":{"agent_nickname":"Noether","agent_role":"default"}}}}}
+        {"type":"turn_context","payload":{"model":"gpt-5.6-sol"}}
+        """.write(toFile: rolloutPath, atomically: true, encoding: .utf8)
+        let subagentStore = try makeRegistryStore()
+
+        _ = try codexPayloads(#"{"hook_event_name":"SessionStart","session_id":"root"}"#, subagentStore: subagentStore)
+        let started = try codexPayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"child-thread","agent_type":"worker","agent_transcript_path":"\#(rolloutPath)"}"#,
+            subagentStore: subagentStore
+        )
+        let payload = try XCTUnwrap(started.first)
+        XCTAssertEqual(payload.sessionID, "root")
+        XCTAssertEqual(payload.state, .running)
+        let entry = try XCTUnwrap(payload.subagents?.entries.first)
+        XCTAssertEqual(entry.id, "01a07132-eb9a-7222-ad53-819ccda4db3c")
+        XCTAssertEqual(entry.model, "gpt-5.6-sol")
+        XCTAssertEqual(entry.nickname, "Noether")
+        XCTAssertEqual(entry.agentType, "worker")
+
+        let childStop = try codexPayloads(#"{"hook_event_name":"Stop","session_id":"child-thread"}"#, subagentStore: subagentStore)
+        XCTAssertNil(childStop.first?.subagents, "a sub-thread Stop must not blank the parent's badge")
+
+        let stopped = try codexPayloads(
+            #"{"hook_event_name":"SubagentStop","session_id":"child-thread","agent_transcript_path":"\#(rolloutPath)"}"#,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(stopped.first?.subagents, .empty)
+
+        let rootStop = try codexPayloads(#"{"hook_event_name":"Stop","session_id":"root"}"#, subagentStore: subagentStore)
+        XCTAssertEqual(rootStop.first?.subagents, .empty)
+    }
+
+    func test_codex_positional_subagent_events_map_like_named_hooks() throws {
+        let subagentStore = try makeRegistryStore()
+        let payloads = try AgentEventBridge.codexAdapter(
+            data: Data(#"{"session_id":"root","agent_type":"worker"}"#.utf8),
+            defaultEventName: "subagent-start",
+            environment: environment,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(payloads.first?.subagents?.count, 1)
+    }
+
+    func test_codex_tool_hook_resolves_model_once_rollout_exists() throws {
+        let directory = try makeTemporaryDirectory()
+        let rolloutPath = directory.appendingPathComponent("rollout-x.jsonl").path
+        let subagentStore = try makeRegistryStore()
+        _ = try codexPayloads(
+            #"{"hook_event_name":"SubagentStart","session_id":"root","agent_transcript_path":"\#(rolloutPath)"}"#,
+            subagentStore: subagentStore
+        )
+        try #"{"type":"turn_context","payload":{"model":"gpt-6-astra"}}"#.write(toFile: rolloutPath, atomically: true, encoding: .utf8)
+        let payloads = try codexPayloads(#"{"hook_event_name":"PostToolUse","session_id":"root"}"#, subagentStore: subagentStore)
+        XCTAssertEqual(payloads.first?.subagents?.entries.first?.modelLabel, "astra")
+    }
+
+    // MARK: - Grok adapter
+
+    func test_grok_subagent_hooks_track_count() throws {
+        let subagentStore = try makeRegistryStore()
+        let started = try AgentEventBridge.grokAdapter(
+            data: Data(#"{"hook_event_name":"SubagentStart","session_id":"s","agent_id":"sub-1","agent_type":"explore"}"#.utf8),
+            environment: environment,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(started.first?.state, .running)
+        XCTAssertEqual(started.first?.subagents?.entries.first?.agentType, "explore")
+
+        let stopped = try AgentEventBridge.grokAdapter(
+            data: Data(#"{"hook_event_name":"SubagentStop","session_id":"s","agent_id":"sub-1"}"#.utf8),
+            environment: environment,
+            subagentStore: subagentStore
+        )
+        XCTAssertEqual(stopped.first?.subagents, .empty)
+    }
+
+    func test_grok_hooks_installer_registers_subagent_events_without_matcher() {
+        XCTAssertTrue(GrokHooksInstaller.defaultManagedEvents.contains("SubagentStart"))
+        XCTAssertTrue(GrokHooksInstaller.defaultManagedEvents.contains("SubagentStop"))
+    }
+
+    // MARK: - Reducer
+
+    func test_reducer_carries_subagents_until_explicitly_cleared() {
+        let startedAt = Date(timeIntervalSince1970: 100)
+        var reducerState = PaneAgentReducerState()
+        let summary = PaneAgentSubagentSummary(entries: [PaneAgentSubagentEntry(id: "a", model: "claude-opus-5")])
+
+        reducerState.apply(claudePayload(state: .running, subagents: summary), now: startedAt)
+        reducerState.apply(claudePayload(state: .running, subagents: nil), now: startedAt.addingTimeInterval(1))
+        XCTAssertEqual(reducerState.reducedStatus(now: startedAt.addingTimeInterval(1))?.subagents, summary)
+
+        reducerState.apply(claudePayload(state: .idle, subagents: .empty), now: startedAt.addingTimeInterval(2))
+        XCTAssertEqual(reducerState.reducedStatus(now: startedAt.addingTimeInterval(2))?.subagents, .empty)
+    }
+
+    // MARK: - Helpers
+
+    private func claudePayload(state: PaneAgentState, subagents: PaneAgentSubagentSummary?) -> AgentStatusPayload {
+        AgentStatusPayload(
+            worklaneID: WorklaneID("worklane-main"),
+            paneID: PaneID("pane-shell"),
+            state: state,
+            origin: .explicitHook,
+            toolName: "Claude Code",
+            text: nil,
+            confidence: .explicit,
+            sessionID: "session-1",
+            subagents: subagents,
+            artifactKind: nil,
+            artifactLabel: nil,
+            artifactURL: nil
+        )
+    }
+
+    private func claudePayloads(
+        _ json: String,
+        sessionStore: ClaudeHookSessionStore,
+        subagentStore: AgentSubagentRegistryStore
+    ) throws -> [AgentStatusPayload] {
+        try AgentEventBridge.claudeMakePayloads(
+            from: AgentEventBridge.claudeParseInput(Data(json.utf8)),
+            environment: environment,
+            sessionStore: sessionStore,
+            subagentStore: subagentStore
+        )
+    }
+
+    private func codexPayloads(_ json: String, subagentStore: AgentSubagentRegistryStore) throws -> [AgentStatusPayload] {
+        try AgentEventBridge.codexAdapter(
+            data: Data(json.utf8),
+            defaultEventName: nil,
+            environment: environment,
+            subagentStore: subagentStore
+        )
+    }
+
+    private func makeClaudeSessionStore() throws -> ClaudeHookSessionStore {
+        let store = ClaudeHookSessionStore(stateURL: try makeTemporaryDirectory().appendingPathComponent("claude-hook-sessions.json"))
+        try store.upsert(
+            sessionID: "session-1",
+            worklaneID: WorklaneID("worklane-main"),
+            paneID: PaneID("worklane-main-shell"),
+            cwd: nil,
+            pid: nil
+        )
+        return store
+    }
+
+    private func makeRegistryStore(now: @escaping () -> Date = Date.init) throws -> AgentSubagentRegistryStore {
+        AgentSubagentRegistryStore(
+            stateURL: try makeTemporaryDirectory().appendingPathComponent("agent-subagent-sessions.json"),
+            now: now
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("zentty-subagent-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}

--- a/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
+++ b/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
@@ -83,7 +83,7 @@ final class SidebarSubagentBadgeTests: AppKitTestCase {
         XCTAssertEqual(row.debugSnapshotForTesting.paneSubagentListTexts, [[]])
     }
 
-    func test_badge_uses_pane_primary_text_color_as_fill() throws {
+    func test_badge_uses_status_color_as_fill_like_the_status_icon() throws {
         let theme = ZenttyTheme.fallback(for: nil)
         let row = makeRow()
         row.configure(with: makeSummary(subagents: threeSubagents), theme: theme, animated: false)
@@ -92,8 +92,9 @@ final class SidebarSubagentBadgeTests: AppKitTestCase {
         let snapshot = row.debugSnapshotForTesting
         XCTAssertEqual(
             snapshot.firstPaneSubagentBadgeFillColor?.srgbClamped,
-            snapshot.firstPanePrimaryTextColor?.srgbClamped
+            snapshot.firstPaneStatusTextColor?.srgbClamped
         )
+        XCTAssertEqual(snapshot.firstPaneStatusTextColor?.srgbClamped, theme.statusRunning.srgbClamped)
     }
 
     // MARK: - Helpers

--- a/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
+++ b/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
@@ -1,0 +1,129 @@
+import AppKit
+import XCTest
+
+@testable import Zentty
+
+@MainActor
+final class SidebarSubagentBadgeTests: AppKitTestCase {
+    private var rowWidthConstraints: [ObjectIdentifier: NSLayoutConstraint] = [:]
+
+    private let paneID = PaneID("worklane-main-agent")
+
+    private var threeSubagents: PaneAgentSubagentSummary {
+        PaneAgentSubagentSummary(entries: [
+            PaneAgentSubagentEntry(id: "a", agentType: "general-purpose", model: "claude-opus-5"),
+            PaneAgentSubagentEntry(id: "b", agentType: "general-purpose", model: "claude-opus-5"),
+            PaneAgentSubagentEntry(id: "c", agentType: "codex-review", model: "claude-sonnet-5"),
+        ])
+    }
+
+    func test_badge_shows_count_with_native_tooltip_and_no_list_at_rest() throws {
+        let row = makeRow()
+        row.configure(with: makeSummary(subagents: threeSubagents), theme: ZenttyTheme.fallback(for: nil), animated: false)
+        row.layoutSubtreeIfNeeded()
+
+        let snapshot = row.debugSnapshotForTesting
+        XCTAssertEqual(snapshot.paneSubagentBadgeTexts, ["3"])
+        XCTAssertEqual(snapshot.firstPaneSubagentBadgeToolTip, "3 subagents\nClick for details")
+        XCTAssertEqual(snapshot.paneSubagentListTexts, [[]])
+
+        let layout = SidebarWorklaneRowLayout(summary: makeSummary(subagents: threeSubagents))
+        XCTAssertFalse(layout.visibleTextRows.contains(.paneSubagents(0)))
+    }
+
+    func test_badge_click_toggles_grouped_model_list_without_selecting_pane() throws {
+        let row = makeRow()
+        var selectedPaneIDs: [PaneID] = []
+        row.onPaneSelected = { selectedPaneIDs.append($0) }
+        row.configure(with: makeSummary(subagents: threeSubagents), theme: ZenttyTheme.fallback(for: nil), animated: false)
+        row.layoutSubtreeIfNeeded()
+        let collapsedHeight = row.intrinsicContentSize.height
+
+        row.performDebugInteractionForTesting(.firstPaneSubagentBadgeClick)
+        row.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(selectedPaneIDs, [])
+        XCTAssertEqual(row.expandedSubagentPaneIDsForTesting, [paneID])
+        XCTAssertEqual(
+            row.debugSnapshotForTesting.paneSubagentListTexts,
+            [["2 × opus general-purpose", "1 × sonnet codex-review"]]
+        )
+        XCTAssertEqual(
+            row.intrinsicContentSize.height,
+            collapsedHeight + 2 * ShellMetrics.sidebarDetailLineHeight + ShellMetrics.sidebarRowInterlineSpacing,
+            accuracy: 0.001
+        )
+
+        row.performDebugInteractionForTesting(.firstPaneSubagentBadgeClick)
+        row.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(row.expandedSubagentPaneIDsForTesting, [])
+        XCTAssertEqual(row.debugSnapshotForTesting.paneSubagentListTexts, [[]])
+        XCTAssertEqual(row.intrinsicContentSize.height, collapsedHeight, accuracy: 0.001)
+    }
+
+    func test_list_collapses_and_badge_hides_once_subagents_finish() throws {
+        let row = makeRow()
+        row.configure(with: makeSummary(subagents: threeSubagents), theme: ZenttyTheme.fallback(for: nil), animated: false)
+        row.layoutSubtreeIfNeeded()
+        row.performDebugInteractionForTesting(.firstPaneSubagentBadgeClick)
+        XCTAssertEqual(row.expandedSubagentPaneIDsForTesting, [paneID])
+
+        row.configure(with: makeSummary(subagents: .empty), theme: ZenttyTheme.fallback(for: nil), animated: false)
+        row.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(row.expandedSubagentPaneIDsForTesting, [])
+        XCTAssertEqual(row.debugSnapshotForTesting.paneSubagentBadgeTexts, [""])
+        XCTAssertEqual(row.debugSnapshotForTesting.paneSubagentListTexts, [[]])
+    }
+
+    func test_badge_uses_pane_primary_text_color_as_fill() throws {
+        let theme = ZenttyTheme.fallback(for: nil)
+        let row = makeRow()
+        row.configure(with: makeSummary(subagents: threeSubagents), theme: theme, animated: false)
+        row.layoutSubtreeIfNeeded()
+
+        let snapshot = row.debugSnapshotForTesting
+        XCTAssertEqual(
+            snapshot.firstPaneSubagentBadgeFillColor?.srgbClamped,
+            snapshot.firstPanePrimaryTextColor?.srgbClamped
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeRow(width: CGFloat = 220, height: CGFloat = 90) -> SidebarWorklaneRowButton {
+        let row = SidebarWorklaneRowButton(
+            worklaneID: WorklaneID("worklane-main"),
+            reducedMotionProvider: { true }
+        )
+        row.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        let widthConstraint = row.widthAnchor.constraint(equalToConstant: width)
+        widthConstraint.isActive = true
+        rowWidthConstraints[ObjectIdentifier(row)] = widthConstraint
+        return row
+    }
+
+    private func makeSummary(subagents: PaneAgentSubagentSummary?) -> WorklaneSidebarSummary {
+        WorklaneSidebarSummary(
+            worklaneID: WorklaneID("worklane-main"),
+            badgeText: "1",
+            primaryText: "agent",
+            paneRows: [
+                WorklaneSidebarPaneRow(
+                    paneID: paneID,
+                    primaryText: "1Password pane focus",
+                    trailingText: nil,
+                    detailText: "…/zentty",
+                    statusText: "Running",
+                    attentionState: .running,
+                    isFocused: true,
+                    isWorking: true,
+                    subagents: subagents
+                ),
+            ],
+            isWorking: true,
+            isActive: true
+        )
+    }
+}

--- a/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
+++ b/ZenttyLogicTests/SidebarSubagentBadgeTests.swift
@@ -48,6 +48,12 @@ final class SidebarSubagentBadgeTests: AppKitTestCase {
             row.debugSnapshotForTesting.paneSubagentListTexts,
             [["2 × opus general-purpose", "1 × sonnet codex-review"]]
         )
+        let listView = try XCTUnwrap(row.debugAccessForTesting.paneSubagentRows.first)
+        XCTAssertGreaterThan(listView.bounds.width, 120, "list row must stretch to the pane row width")
+        XCTAssertEqual(listView.bounds.height, 2 * ShellMetrics.sidebarDetailLineHeight, accuracy: 0.5)
+        let statusRow = try XCTUnwrap(row.debugAccessForTesting.paneStatusRows.first)
+        let badgeFrame = try XCTUnwrap(statusRow.subagentBadgeFrame(in: statusRow))
+        XCTAssertGreaterThanOrEqual(badgeFrame.width, SidebarSubagentBadgeMetrics.minimumWidth)
         XCTAssertEqual(
             row.intrinsicContentSize.height,
             collapsedHeight + 2 * ShellMetrics.sidebarDetailLineHeight + ShellMetrics.sidebarRowInterlineSpacing,

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -47,6 +47,8 @@ Register the same command for these Claude hook events:
 - `PreToolUse` with matcher `AskUserQuestion`
 - `TaskCreated`
 - `TaskCompleted`
+- `SubagentStart`
+- `SubagentStop`
 
 Example config snippet:
 
@@ -153,7 +155,8 @@ Example config snippet:
 - `SessionStart` -> session/PID attach only
 - `Notification`, `PermissionRequest`, `PreToolUse(AskUserQuestion)` -> `needs-input`
 - `UserPromptSubmit` -> `running`
-- `Stop` -> `idle`
+- `SubagentStart` / `SubagentStop` -> `running` plus the updated subagent set (see below)
+- `Stop` -> `idle` and clears the subagent set
 - `SessionEnd` -> clear session + PID mapping
 
 This keeps Zentty’s sidebar and alerts aligned with Claude’s own lifecycle instead of terminal heuristics.
@@ -165,6 +168,14 @@ Claude Code task hooks are used to maintain a per-session task registry. When a 
 Counts are intentionally scoped to the main session only. Subagent or nested task lists are ignored so the suffix stays stable.
 
 Claude hook execution is best effort. If the Claude adapter fails internally, Zentty returns success to Claude and suppresses stderr so users do not see hook error banners.
+
+### Subagents
+
+`SubagentStart` / `SubagentStop` maintain a per-pane registry of running subagents (`AgentSubagentRegistryStore`, shared with Codex and Grok). The sidebar shows the count as a badge next to the status icon; clicking it unfolds a list grouped by model and agent type.
+
+No hook payload carries the model, so Zentty resolves it from the files Claude writes next to the subagent transcript: `agent-<id>.meta.json` (present at spawn, holds `model` only when the parent chose one explicitly) or the first assistant line of `agent-<id>.jsonl`. `SubagentStart` arrives before either exists, so hooks fired from inside the subagent (`PreToolUse`, `PostToolUse`, …, recognizable by `agent_id`) retry the lookup and carry the refreshed set. The parent's `Stop` broadcasts an explicit empty set, and entries older than six hours are dropped in case a `SubagentStop` never arrived.
+
+The agent-bench `subagents` scenario is the regression check for this pipeline.
 
 ## Codex CLI
 
@@ -186,6 +197,8 @@ Zentty registers these Codex hook events:
 - `PreToolUse`
 - `PermissionRequest`
 - `PostToolUse`
+- `PreCompact` / `PostCompact`
+- `SubagentStart` / `SubagentStop`
 - `Stop`
 
 Each hook calls:
@@ -201,7 +214,10 @@ Each hook calls:
 - `PreToolUse` -> `running`
 - `PermissionRequest` -> `needs-input` with `approval`
 - `PostToolUse` -> `running`
-- `Stop` -> `idle`
+- `SubagentStart` / `SubagentStop` -> `running` plus the updated subagent set
+- `Stop` -> `idle`; clears the subagent set when it is the parent thread's stop
+
+Codex 0.153 fires subagent hooks with the parent `session_id` and the sub-thread id as `agent_id`; `agent_transcript_path` only arrives on `SubagentStop`. The model comes from the payload's `model` field at start and from the sub-thread rollout (`turn_context.model`, plus `agent_nickname` / `agent_role` from `session_meta`) once it exists.
 
 Codex 0.129's built-in AskUserQuestion UI does not emit a `PreToolUse` hook.
 When Codex switches the terminal title to `[ ! ] Action Required | ...`, Zentty
@@ -393,6 +409,7 @@ Zentty provides first-class support:
 - **Automatic on first run**: the first time `grok` (or `zentty launch grok`) runs inside a Zentty pane, Zentty drops the two files above. You get "Running (N/M)" for `TodoWrite` task lists and proper `needs-input` badges immediately.
 - **Manual**: `zentty install grok-hooks` / `zentty uninstall grok-hooks`.
 - `--adapter=grok` plus a Swift-side re-emitter produces canonical `task.progress`, `agent.needs-input`, and `session.start` events alongside the raw forward.
+- `SubagentStart` / `SubagentStop` (`subagentId`, `subagentType`) feed the sidebar subagent badge. Grok exposes no per-subagent transcript, so the list shows the agent type without a model.
 
 Disable with `ZENTTY_GROK_HOOKS_DISABLED=1`.
 

--- a/scripts/agent-bench/README.md
+++ b/scripts/agent-bench/README.md
@@ -79,3 +79,12 @@ finishing. The trace must show `PostToolUse` events between
 `PermissionRequest` and `Stop`; those are the only hooks Claude emits while it
 works through tools outside the PreToolUse matcher, and without them the pane
 stays on "Needs input" after an approval typed as `1`/`y`.
+
+`subagents` is the regression scenario for the sidebar subagent badge. It asks
+the agent to spawn one subagent (Claude `Agent`, Codex `spawn_agent`, Grok
+`spawn_subagent`) and requires a `SubagentStart` / `SubagentStop` pair. With
+`subagent_payload_required` the bench also checks, before redaction, that the
+hook payload names an agent type and that the transcript sidecar next to it
+yields a model (`agent-<id>.meta.json` or the first assistant line for Claude,
+the sub-thread rollout's `turn_context` for Codex), because those two facts are
+what the badge and its expanded list are built from.

--- a/scripts/agent-bench/agent_bench.py
+++ b/scripts/agent-bench/agent_bench.py
@@ -114,6 +114,13 @@ class ScenarioExpectation:
     synthetic: bool = False
     fixture: str | None = None
     post_stop_notification_required: bool = False
+    # The scenario must capture a SubagentStart/SubagentStop pair whose payload
+    # names the agent type and whose transcript sidecar yields the model —
+    # the two facts the sidebar badge and its expanded list are built from.
+    subagent_payload_required: bool = False
+    # Whether that payload check also demands a resolvable model. Grok exposes
+    # no per-subagent transcript, so its profile only proves count and type.
+    subagent_model_required: bool = True
     # A true end-to-end resume round-trip (modern kimi-code only): phase 1
     # creates a real session through the wrapper bootstrap against a bench-owned
     # home, phase 2 simulates a restart and resumes it by id, asserting the
@@ -189,6 +196,7 @@ class ScenarioResult:
     terminal_phase_sequence: list[str] = dataclasses.field(default_factory=list)
     terminal_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     task_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    subagent_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     session_identity_observations: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     timeline: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     rerun_command: str = ""
@@ -590,6 +598,17 @@ def classify_completed_result(
         result.detail = "required TodoWrite task progress was not captured"
         result.result_kind = "missing-task-progress"
         return result
+    if expectation.subagent_payload_required:
+        subagent_detail = missing_subagent_payload_detail(
+            subagent_observations_for_records(agent, scenario, records),
+            model_required=expectation.subagent_model_required,
+        )
+        if subagent_detail:
+            result.passed = False
+            result.status = "fail"
+            result.detail = subagent_detail
+            result.result_kind = "missing-subagent-payload"
+            return result
     if scenario_requires_terminal_needs_input(scenario) and not terminal_needs_input_observed(terminal_observations):
         result.passed = False
         result.status = "fail"
@@ -672,6 +691,17 @@ def classify_timeout_result(
             partial.status = "fail"
             partial.detail = "required TodoWrite task progress was not captured"
             partial.result_kind = "missing-task-progress"
+        elif expectation.subagent_payload_required and missing_subagent_payload_detail(
+            subagent_observations_for_records(agent, scenario, records),
+            model_required=expectation.subagent_model_required,
+        ):
+            partial.passed = False
+            partial.status = "fail"
+            partial.detail = missing_subagent_payload_detail(
+                subagent_observations_for_records(agent, scenario, records),
+                model_required=expectation.subagent_model_required,
+            ) or ""
+            partial.result_kind = "missing-subagent-payload"
         elif scenario_requires_terminal_needs_input(scenario) and not terminal_needs_input_observed(terminal_observations):
             partial.passed = False
             partial.status = "fail"
@@ -1057,6 +1087,116 @@ def task_observations_for_records(agent: str, scenario: str, records: list[Trace
                         }
                     )
     return observations
+
+
+SUBAGENT_START_EVENTS = {"subagentstart", "subagent_start", "subagent-start"}
+SUBAGENT_STOP_EVENTS = {"subagentstop", "subagent_stop", "subagent-stop", "subagentend", "subagent_end"}
+
+
+def subagent_trace_extra(agent: str | None, event_name: str | None, stdin_payload: str | None) -> dict[str, Any] | None:
+    """Capture, at record time, the facts Zentty's adapters derive from a
+    SubagentStart/SubagentStop hook: the agent type from the payload and the
+    model from the transcript sidecar next to it. Runs before redaction so the
+    real transcript path can still be read; only derived values are stored."""
+    lowered = (event_name or "").lower()
+    payload = parse_json_object(stdin_payload)
+    if lowered not in SUBAGENT_START_EVENTS | SUBAGENT_STOP_EVENTS:
+        payload_event = str(first_string(payload, ["hook_event_name", "hookEventName"]) or "").lower()
+        if payload_event not in SUBAGENT_START_EVENTS | SUBAGENT_STOP_EVENTS:
+            return None
+        lowered = payload_event
+    transcript_path = first_string(payload, ["agent_transcript_path", "agentTranscriptPath"])
+    resolved = resolve_subagent_model(agent, transcript_path, payload)
+    observation: dict[str, Any] = {
+        "event": "start" if lowered in SUBAGENT_START_EVENTS else "stop",
+        "agent_type": first_string(payload, ["agent_type", "agentType", "subagent_type", "subagentType", "agent_role", "agentRole"]),
+        "agent_id": first_string(payload, ["agent_id", "agentId", "turn_id", "turnId"]),
+        "transcript_path_present": bool(transcript_path),
+        "transcript_exists": bool(transcript_path) and pathlib.Path(transcript_path).exists(),
+        "model": resolved.get("model"),
+        "nickname": resolved.get("nickname"),
+    }
+    return {"subagent": observation}
+
+
+def resolve_subagent_model(agent: str | None, transcript_path: str | None, payload: dict[str, Any]) -> dict[str, Any]:
+    """Python mirror of AgentSubagentModelResolver so the bench proves the
+    sidecar files the app relies on actually carry a model."""
+    result: dict[str, Any] = {"model": first_string(payload, ["model", "model_id", "modelId"]), "nickname": None}
+    if not transcript_path:
+        return result
+    path = pathlib.Path(transcript_path)
+    if agent == "claude":
+        meta_path = path.with_name(path.name[: -len(".jsonl")] + ".meta.json") if path.name.endswith(".jsonl") else pathlib.Path(str(path) + ".meta.json")
+        meta = parse_json_object(_read_head(meta_path))
+        if isinstance(meta.get("model"), str) and meta["model"].strip():
+            result["model"] = meta["model"].strip()
+            return result
+        for line in (_read_head(path) or "").splitlines():
+            if '"model"' not in line:
+                continue
+            obj = parse_json_object(line)
+            message = obj.get("message")
+            model = message.get("model") if isinstance(message, dict) else obj.get("model")
+            if isinstance(model, str) and model.strip():
+                result["model"] = model.strip()
+                break
+        return result
+    if agent == "codex":
+        for line in (_read_head(path) or "").splitlines():
+            obj = parse_json_object(line)
+            record_type = obj.get("type")
+            record_payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else {}
+            if record_type == "session_meta":
+                spawn = (((record_payload.get("source") or {}).get("subagent") or {}).get("thread_spawn") or {})
+                if isinstance(spawn, dict) and isinstance(spawn.get("agent_nickname"), str):
+                    result["nickname"] = spawn["agent_nickname"]
+            elif record_type == "turn_context" and result.get("model") is None:
+                model = record_payload.get("model")
+                if isinstance(model, str) and model.strip():
+                    result["model"] = model.strip()
+            if result.get("model") and result.get("nickname"):
+                break
+        return result
+    return result
+
+
+def _read_head(path: pathlib.Path, max_bytes: int = 256 * 1024) -> str | None:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(max_bytes).decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def subagent_observations_for_records(agent: str, scenario: str, records: list[TraceRecord]) -> list[dict[str, Any]]:
+    observations: list[dict[str, Any]] = []
+    for record in records:
+        if record.agent != agent or record.scenario != scenario or record.kind != "hook":
+            continue
+        if isinstance(record.extra, dict) and isinstance(record.extra.get("subagent"), dict):
+            observations.append(dict(record.extra["subagent"]))
+    return observations
+
+
+def missing_subagent_payload_detail(observations: list[dict[str, Any]], model_required: bool = True) -> str | None:
+    """None when the captured subagent hooks carry everything the sidebar
+    needs; otherwise a one-line explanation of what was missing."""
+    starts = [item for item in observations if item.get("event") == "start"]
+    stops = [item for item in observations if item.get("event") == "stop"]
+    if not starts:
+        return "no SubagentStart hook payload was captured"
+    if not stops:
+        return "SubagentStart captured but no SubagentStop followed"
+    if not any(item.get("agent_type") for item in observations):
+        return "subagent hooks captured but none named an agent type"
+    if not model_required:
+        return None
+    if not any(item.get("model") for item in observations):
+        if any(item.get("transcript_exists") for item in observations):
+            return "subagent transcript exists but no model could be resolved from it"
+        return "subagent hooks captured but no transcript sidecar was available to resolve the model"
+    return None
 
 
 def todo_progress(tool_input: dict[str, Any] | None) -> tuple[int, int] | None:
@@ -1452,6 +1592,9 @@ class CaptureServer:
         if current_profile := self._current_profile_for_tool(agent):
             agent = current_profile.name
         extra = cursor_trace_extra(agent, stdin_payload if isinstance(stdin_payload, str) else None)
+        subagent_extra = subagent_trace_extra(agent, hook.event_name, stdin_payload if isinstance(stdin_payload, str) else None)
+        if subagent_extra:
+            extra = {**(extra or {}), **subagent_extra}
         self.recorder.append(
             TraceRecord(
                 kind="hook",
@@ -1598,6 +1741,8 @@ class LaunchPlanner:
             "PostCompact",
             "TaskCreated",
             "TaskCompleted",
+            "SubagentStart",
+            "SubagentStop",
         ):
             settings["hooks"][event] = [{"matcher": "", "hooks": [{"type": "command", "command": hook_command, "timeout": 10}]}]
         settings["hooks"]["SessionStart"] = [
@@ -1625,6 +1770,8 @@ class LaunchPlanner:
             ("UserPromptSubmit", "user_prompt_submit", "prompt-submit"),
             ("PreCompact", "pre_compact", "pre-compact"),
             ("PostCompact", "post_compact", "post-compact"),
+            ("SubagentStart", "subagent_start", "subagent-start"),
+            ("SubagentStop", "subagent_stop", "subagent-stop"),
             ("Stop", "stop", "stop"),
         ]
         hook_config_args = ["features.hooks=true"]
@@ -1914,7 +2061,7 @@ class LaunchPlanner:
         # the entry — that's exactly the bug this rewrite fixes.
         lifecycle_events = [
             "SessionStart", "SessionEnd", "UserPromptSubmit", "Stop", "Notification",
-            "BeforeAgent", "AfterAgent",
+            "SubagentStart", "SubagentStop", "BeforeAgent", "AfterAgent",
         ]
         tool_events = ["PreToolUse", "PostToolUse"]
         hooks_json: dict[str, Any] = {"hooks": {}}
@@ -2254,6 +2401,8 @@ def load_profiles(path: pathlib.Path) -> dict[str, AgentProfile]:
                 synthetic=bool(value.get("synthetic", False)),
                 fixture=value.get("fixture"),
                 post_stop_notification_required=bool(value.get("post_stop_notification_required", False)),
+                subagent_payload_required=bool(value.get("subagent_payload_required", False)),
+                subagent_model_required=bool(value.get("subagent_model_required", True)),
                 resume_roundtrip=bool(value.get("resume_roundtrip", False)),
             )
         profile = AgentProfile(
@@ -2740,6 +2889,7 @@ class BenchRunner:
         result.terminal_phase_sequence = terminal_phase_sequence(observations)
         result.terminal_observations = [dataclasses.asdict(observation) for observation in observations]
         result.task_observations = task_observations_for_records(result.agent, result.scenario, records)
+        result.subagent_observations = subagent_observations_for_records(result.agent, result.scenario, records)
         result.timeline = build_timeline(result.agent, result.scenario, records, observations)
         result.rerun_command = self._rerun_command(result.agent, result.scenario)
         if observations and not any(warning.startswith("terminal observations") for warning in result.warnings):
@@ -2750,6 +2900,12 @@ class BenchRunner:
             result.warnings.append("terminal post-scripted-input phase: needs-input")
         if result.task_observations and not any(warning.startswith("task observations") for warning in result.warnings):
             result.warnings.append(f"task observations captured: {len(result.task_observations)}")
+        if result.subagent_observations and not any(warning.startswith("subagent observations") for warning in result.warnings):
+            models = sorted({str(item.get("model")) for item in result.subagent_observations if item.get("model")})
+            result.warnings.append(
+                f"subagent observations captured: {len(result.subagent_observations)}"
+                + (f" (models: {', '.join(models)})" if models else "")
+            )
         return result
 
     def _rerun_command(self, agent: str, scenario: str) -> str:

--- a/scripts/agent-bench/profiles/claude.json
+++ b/scripts/agent-bench/profiles/claude.json
@@ -57,6 +57,18 @@
       "--max-budget-usd",
       "1.00",
       "For an integration hook regression test: 1) create a file named ZENTTY_AGENT_BENCH_APPROVAL_OK in the current directory using the Write tool with the text ZENTTY_AGENT_BENCH_APPROVAL_OK. 2) Then, without asking me anything, read README.md with the Read tool. 3) Then search for the word bench in this directory with the Grep tool. 4) Then reply with exactly DONE."
+    ],
+    "subagents": [
+      "--setting-sources",
+      "project,local",
+      "--print",
+      "--verbose",
+      "--output-format",
+      "stream-json",
+      "--include-hook-events",
+      "--max-budget-usd",
+      "2.00",
+      "For an integration hook regression test: use the Agent tool once, with subagent_type Explore, to list the files in the current directory. Wait for it to finish, then reply with exactly DONE."
     ]
   },
   "expectations": {
@@ -122,6 +134,16 @@
         "PostToolUse",
         "Stop"
       ]
+    },
+    "subagents": {
+      "required_events": [
+        "SessionStart",
+        "UserPromptSubmit",
+        "SubagentStart",
+        "SubagentStop",
+        "Stop"
+      ],
+      "subagent_payload_required": true
     }
   },
   "input_by_scenario": {

--- a/scripts/agent-bench/profiles/codex.json
+++ b/scripts/agent-bench/profiles/codex.json
@@ -52,6 +52,12 @@
     "restore_launch": [
       "resume",
       "session-codex"
+    ],
+    "subagents": [
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      "For an integration hook regression test: use the spawn_agent tool once to start a worker subagent whose task is to run this exact shell command and report its output: printf ZENTTY_AGENT_BENCH_SUBAGENT_OK. Wait for that subagent with wait_agent, then reply with exactly DONE."
     ]
   },
   "expectations": {
@@ -103,6 +109,10 @@
     "restore_launch": {
       "required_events": [],
       "required_bootstrap_arguments": [["resume", "session-codex"]]
+    },
+    "subagents": {
+      "required_events": ["session-start", "prompt-submit", "subagent-start", "subagent-stop", "stop"],
+      "subagent_payload_required": true
     }
   },
   "input_by_scenario": {

--- a/scripts/agent-bench/profiles/grok.json
+++ b/scripts/agent-bench/profiles/grok.json
@@ -15,6 +15,11 @@
     "approval": [
       "-p",
       "Use your ask_user_question tool to ask me one short question, then answer it yourself after I reply."
+    ],
+    "subagents": [
+      "--always-approve",
+      "-p",
+      "For an integration hook regression test: use your spawn_subagent tool once to start a subagent whose task is to list the files in the current directory and report back. Wait for it to finish, then reply with exactly DONE."
     ]
   },
   "expectations": {
@@ -34,6 +39,15 @@
     },
     "approval": {
       "required_events": ["session_start", "notification", "agent.needs-input", "stop"],
+      "session_identity": {
+        "session_id_pattern": "uuid",
+        "tracked_pid": false
+      }
+    },
+    "subagents": {
+      "required_events": ["session_start", "subagent_start", "subagent_stop", "stop"],
+      "subagent_payload_required": true,
+      "subagent_model_required": false,
       "session_identity": {
         "session_id_pattern": "uuid",
         "tracked_pid": false

--- a/scripts/agent-bench/tests/test_agent_bench.py
+++ b/scripts/agent-bench/tests/test_agent_bench.py
@@ -301,6 +301,91 @@ class SyntheticScenarioTests(unittest.TestCase):
                 [entry["matcher"] for entry in hooks["PreToolUse"]],
                 ["AskUserQuestion", "Bash|Write|Edit|MultiEdit|NotebookEdit"],
             )
+            # Mirror of AgentLaunchBootstrap.claudePlan: the sidebar subagent
+            # badge depends on these two hooks being registered per launch.
+            for event in ("SubagentStart", "SubagentStop"):
+                self.assertEqual([entry["matcher"] for entry in hooks[event]], [""], event)
+
+    def test_codex_plan_registers_and_trusts_subagent_hooks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            plan = agent_bench.LaunchPlanner(
+                profile=agent_bench.load_profiles(ROOT / "profiles")["codex"],
+                scenario="subagents",
+                run_dir=root,
+                resources_dir=None,
+            ).plan(
+                {
+                    "arguments": ["exec", "hello"],
+                    "environment": {"ZENTTY_REAL_BINARY": "/usr/local/bin/codex", "ZENTTY_CLI_BIN": "/tmp/zentty-bench"},
+                }
+            )
+            arguments = plan["arguments"]
+            self.assertTrue(any(arg.startswith("hooks.SubagentStart=") and "subagent-start" in arg for arg in arguments))
+            self.assertTrue(any(arg.startswith("hooks.SubagentStop=") and "subagent-stop" in arg for arg in arguments))
+            state = next(arg for arg in arguments if arg.startswith("hooks.state="))
+            self.assertIn("config.toml:subagent_start:0:0", state)
+            self.assertIn("config.toml:subagent_stop:0:0", state)
+
+    def test_subagent_profiles_require_start_stop_pair_and_payload(self):
+        profiles = agent_bench.load_profiles(ROOT / "profiles")
+        for name, start, stop in (("claude", "SubagentStart", "SubagentStop"), ("codex", "subagent-start", "subagent-stop"), ("grok", "subagent_start", "subagent_stop")):
+            expectation = profiles[name].expectations["subagents"]
+            self.assertIn(start, expectation.required_events, name)
+            self.assertIn(stop, expectation.required_events, name)
+            self.assertTrue(expectation.subagent_payload_required, name)
+            self.assertIn("subagents", profiles[name].launch_args_by_scenario, name)
+
+    def test_subagent_trace_extra_resolves_claude_model_from_meta_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = pathlib.Path(tmp) / "agent-abc.jsonl"
+            (pathlib.Path(tmp) / "agent-abc.meta.json").write_text(json.dumps({"agentType": "Explore", "model": "opus"}))
+            payload = json.dumps({"hook_event_name": "SubagentStart", "agent_id": "abc", "agent_type": "Explore", "agent_transcript_path": str(transcript)})
+            extra = agent_bench.subagent_trace_extra("claude", "SubagentStart", payload)
+            self.assertEqual(extra["subagent"]["event"], "start")
+            self.assertEqual(extra["subagent"]["agent_type"], "Explore")
+            self.assertEqual(extra["subagent"]["model"], "opus")
+
+            transcript.write_text('{"type":"assistant","message":{"model":"claude-sonnet-5"}}\n')
+            (pathlib.Path(tmp) / "agent-abc.meta.json").unlink()
+            extra = agent_bench.subagent_trace_extra("claude", None, json.dumps({"hook_event_name": "SubagentStop", "agent_id": "abc", "agent_transcript_path": str(transcript)}))
+            self.assertEqual(extra["subagent"]["event"], "stop")
+            self.assertEqual(extra["subagent"]["model"], "claude-sonnet-5")
+
+    def test_subagent_trace_extra_resolves_codex_model_and_nickname_from_rollout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rollout = pathlib.Path(tmp) / "rollout-x.jsonl"
+            rollout.write_text(
+                json.dumps({"type": "session_meta", "payload": {"source": {"subagent": {"thread_spawn": {"agent_nickname": "Dirac", "agent_role": "worker"}}}}})
+                + "\n"
+                + json.dumps({"type": "turn_context", "payload": {"model": "gpt-6-astra"}})
+                + "\n"
+            )
+            extra = agent_bench.subagent_trace_extra("codex", "subagent-start", json.dumps({"agent_type": "worker", "agent_transcript_path": str(rollout)}))
+            self.assertEqual(extra["subagent"]["model"], "gpt-6-astra")
+            self.assertEqual(extra["subagent"]["nickname"], "Dirac")
+            self.assertIsNone(agent_bench.subagent_trace_extra("codex", "pre-tool-use", "{}"))
+
+    def test_subagent_payload_validation_explains_what_is_missing(self):
+        self.assertEqual(agent_bench.missing_subagent_payload_detail([]), "no SubagentStart hook payload was captured")
+        self.assertEqual(
+            agent_bench.missing_subagent_payload_detail([{"event": "start", "agent_type": "Explore"}]),
+            "SubagentStart captured but no SubagentStop followed",
+        )
+        self.assertEqual(
+            agent_bench.missing_subagent_payload_detail([{"event": "start"}, {"event": "stop"}]),
+            "subagent hooks captured but none named an agent type",
+        )
+        self.assertIsNone(
+            agent_bench.missing_subagent_payload_detail(
+                [{"event": "start", "agent_type": "Explore"}, {"event": "stop", "model": "claude-opus-5"}]
+            )
+        )
+        # Grok names the subagent type but has no transcript sidecar for the model.
+        without_model = [{"event": "start", "agent_type": "general-purpose"}, {"event": "stop"}]
+        self.assertIsNotNone(agent_bench.missing_subagent_payload_detail(without_model))
+        self.assertIsNone(agent_bench.missing_subagent_payload_detail(without_model, model_required=False))
+        self.assertFalse(agent_bench.load_profiles(ROOT / "profiles")["grok"].expectations["subagents"].subagent_model_required)
 
     def test_stop_race_fixture_contains_late_notification_after_stop(self):
         fixture_path = ROOT / "fixtures" / "claude_stop_then_late_notification.jsonl"


### PR DESCRIPTION
## What

The sidebar now shows how many subagents a pane's agent is running, as a small count badge next to the status icon. Hovering gives a native tooltip, clicking unfolds a short list grouped by model and agent type, for example `2 × opus general-purpose` and `1 × sonnet codex-review`. The list folds away on its own once the last subagent finishes.

Works for Claude Code, Codex and Grok.

## How

- Claude, Codex and Grok launches now register `SubagentStart` / `SubagentStop` hooks. The three adapters share a small file-backed registry per pane (`AgentSubagentRegistryStore`), because each hook runs in a fresh process.
- No hook payload names the model, so it is read lazily from the files the CLIs leave next to the subagent transcript: `agent-<id>.meta.json` or the first assistant line for Claude, the sub-thread rollout's `turn_context` (plus nickname and role) for Codex. Grok exposes neither, so its list shows the agent type only.
- The snapshot travels on `AgentStatusPayload.subagents` through the reducer into `PanePresentationState` and the sidebar pane row. `nil` means unchanged, an empty set clears the badge; the parent's `Stop` sends that empty set.
- Badge and list live in `SidebarPaneSubagentViews.swift`. The badge takes the pane status color, the expanded state is per pane in the row button.

One behaviour change: Claude's `SubagentStop` now maps to running instead of idle, since the parent still has to consume the result.

## Proof

New agent-bench scenario `subagents` for `claude`, `codex` and `grok`, all passing live. It requires the start/stop pair and, before redaction, checks that the payload names an agent type and that the transcript sidecar yields a model (skipped for Grok). Live findings that shaped the code:

- Claude sends `agent_transcript_path` only on `SubagentStop`; the path is derived from the session transcript at start.
- Codex sends the parent `session_id` on subagent hooks, the thread id as `agent_id`, and the rollout path only on stop.
- Grok fires `subagent_start` / `subagent_stop` with `subagentId` / `subagentType`; `spawn_subagent` needs `--always-approve` in print mode.

Tests: 3908 ZenttyLogicTests green on the virtual display, 154 bench unit tests, new `AgentSubagentTrackingTests` and `SidebarSubagentBadgeTests`.

Not done: a look at the badge in the running app. The UI is covered by detached AppKit tests only.
